### PR TITLE
Added default commands to cvar, gvar, uvar

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -929,6 +929,9 @@ class SheetManager:
         Arguments surrounded with `{{}}` will be evaluated as a custom script.
         See http://avrae.io/cheatsheets/aliasing for more help.
         Dicecloud `statMod` and `stat` variables are also available."""
+        if name is None:
+            return await ctx.invoke(self.bot.get_command("cvar list"))
+
         character = Character.from_ctx(ctx)
 
         if value is None:  # display value

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -564,7 +564,7 @@ class Customization:
         Global variables must be accessed through scripting, with `get_gvar(gvar_id)`.
         See http://avrae.io/cheatsheets/aliasing for more help."""
         if name is None:
-            return await ctx.invoke(self.bot.get_command("uvar list"))
+            return await ctx.invoke(self.bot.get_command("globalvar list"))
 
         glob_vars = self.bot.db.jget("global_vars", {})
 

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -499,6 +499,9 @@ class Customization:
         User variables can be called in the `-phrase` tag by surrounding the variable name with `{}` (calculates) or `<>` (prints).
         Arguments surrounded with `{{}}` will be evaluated as a custom script.
         See http://avrae.io/cheatsheets/aliasing for more help."""
+        if name is None:
+            return await ctx.invoke(self.bot.get_command("uservar list"))
+
         user_vars = self.bot.db.jhget("user_vars", ctx.message.author.id, {})
 
         if value is None:  # display value
@@ -560,6 +563,9 @@ class Customization:
         Global variables are readable by all users, but only editable by the creator.
         Global variables must be accessed through scripting, with `get_gvar(gvar_id)`.
         See http://avrae.io/cheatsheets/aliasing for more help."""
+        if name is None:
+            return await ctx.invoke(self.bot.get_command("uvar list"))
+
         glob_vars = self.bot.db.jget("global_vars", {})
 
         gvar = glob_vars.get(name)


### PR DESCRIPTION
Commands should default to list. I think I saw a feature request or something somewhere. Just used the same format as alias and snippet.

Also using GitHub to make changes is the worst. Can't figure out how to squash them locally. RIP