### PR TITLE
Allow resist args for `!i opt` be case insensitive

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -570,6 +570,7 @@ class InitTracker:
         if 'resist' in args:
             for resist in args.get('resist'):
                 resist = resist.lower()
+                combatant.resists['resist'] = list(set(i.lower() for i in combatant.resists['resist']))
                 if resist in combatant.resists['resist']:
                     combatant.resists['resist'].remove(resist)
                     out += "\u2705 {} removed from combatant resistances.\n".format(resist)
@@ -579,6 +580,7 @@ class InitTracker:
         if 'immune' in args:
             for immune in args.get('immune'):
                 immune = immune.lower()
+                combatant.resists['immune'] = list(set(i.lower() for i in combatant.resists['immune']))
                 if immune in combatant.resists['immune']:
                     combatant.resists['immune'].remove(immune)
                     out += "\u2705 {} removed from combatant immunities.\n".format(immune)
@@ -588,6 +590,7 @@ class InitTracker:
         if 'vuln' in args:
             for vuln in args.get('vuln'):
                 vuln = vuln.lower()
+                combatant.resists['vuln'] = list(set(i.lower() for i in combatant.resists['vuln']))
                 if vuln in combatant.resists['vuln']:
                     combatant.resists['vuln'].remove(vuln)
                     out += "\u2705 {} removed from combatant vulnerabilities.\n".format(vuln)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -569,6 +569,7 @@ class InitTracker:
                 out += "\u274c You must pass in a name with the -name tag.\n"
         if 'resist' in args:
             for resist in args.get('resist'):
+                resist = resist.lower()
                 if resist in combatant.resists['resist']:
                     combatant.resists['resist'].remove(resist)
                     out += "\u2705 {} removed from combatant resistances.\n".format(resist)
@@ -577,6 +578,7 @@ class InitTracker:
                     out += "\u2705 {} added to combatant resistances.\n".format(resist)
         if 'immune' in args:
             for immune in args.get('immune'):
+                immune = immune.lower()
                 if immune in combatant.resists['immune']:
                     combatant.resists['immune'].remove(immune)
                     out += "\u2705 {} removed from combatant immunities.\n".format(immune)
@@ -585,6 +587,7 @@ class InitTracker:
                     out += "\u2705 {} added to combatant immunities.\n".format(immune)
         if 'vuln' in args:
             for vuln in args.get('vuln'):
+                vuln = vuln.lower()
                 if vuln in combatant.resists['vuln']:
                     combatant.resists['vuln'].remove(vuln)
                     out += "\u2705 {} removed from combatant vulnerabilities.\n".format(vuln)


### PR DESCRIPTION
Simply .lower() the input of args for `-resist` `-immune` and `-vuln`
So that 
Bludgeoning == bludgeoning == BluDgeoNing
Biggest issue I see is any potential resists that exist before this that have capitals can't be removed? I wasn't sure how to fix that, other than something like

combatant.resists['resist'] = list(set(i.lower() for i in combatant.resists['resist']))

But I figured you wouldn't want that running every time opt? I dunno