### PR TITLE
Limit multiline to defined number of commands

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -73,6 +73,8 @@ class Customization:
         !monster Rat"
         """
         cmds = cmds.splitlines()
+        hardLimit = 100
+        ct = 1
         for c in cmds:
             ctx.message.content = c
             if not hasattr(self.bot, 'global_prefixes'):  # bot's still starting up!
@@ -87,6 +89,10 @@ class Customization:
                 return
             await self.bot.process_commands(ctx.message)
             await asyncio.sleep(1)
+            if (ct == hardLimit):
+                break
+            else:
+                ct = ct + 1
 
     async def handle_aliases(self, message):
         if message.content.startswith(self.bot.prefix):

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -73,9 +73,7 @@ class Customization:
         !monster Rat"
         """
         cmds = cmds.splitlines()
-        hardLimit = 100
-        ct = 1
-        for c in cmds:
+        for c in cmds[:30]:
             ctx.message.content = c
             if not hasattr(self.bot, 'global_prefixes'):  # bot's still starting up!
                 return
@@ -89,10 +87,6 @@ class Customization:
                 return
             await self.bot.process_commands(ctx.message)
             await asyncio.sleep(1)
-            if (ct == hardLimit):
-                break
-            else:
-                ct = ct + 1
 
     async def handle_aliases(self, message):
         if message.content.startswith(self.bot.prefix):


### PR DESCRIPTION
Using loops you can get multiline to run for a very long time.
Limiting it to 100 helps fix potential spam abuse.

Maybe lower the number to about 40-60 instead. (Meaning avrae will only run commands for a full minute or so and will stop after that)