### PR TITLE
Multiline Change for Alternate Prefix Servers

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -87,8 +87,6 @@ class Customization:
                 guild_prefix = self.bot.prefix
             if ctx.message.content.startswith(guild_prefix):
                 ctx.message.content = ctx.message.content.replace(guild_prefix, self.bot.prefix, 1)
-            elif ctx.message.content.startswith(self.bot.prefix):
-                return
             await self.bot.process_commands(ctx.message)
             await asyncio.sleep(1)
 


### PR DESCRIPTION
I dunno if this change breaks any intended fail safes.
Since multiline is processed in bulk on the backend, allowing the commands in multiline to use ! as opposed to
the guild prefix shouldn't cause any issues with other bots.

Trying to think of what the intent was behind killing the multiline command if it used the default prefix?