### PR TITLE
subscriptable SimpleCombatant

### DIFF
--- a/cogs5e/funcs/scripting/combat.py
+++ b/cogs5e/funcs/scripting/combat.py
@@ -203,6 +203,12 @@ class SimpleCombatant:
     def __str__(self):
         return str(self._combatant)
 
+    def __getitem__(self, item):
+        attr = getattr(self, item)
+        if callable(attr) or item.startswith("_"):
+            raise AttributeError
+        return attr
+
 
 class SimpleGroup:
     def __init__(self, group: CombatantGroup):


### PR DESCRIPTION
Only let's you subscript attributes.
Will throw attribute error on funcs and "class" variables

I got bored and tried to mess with the !browse alias

Didn't know if you would consider it all right to access funcs and hidden stuff with combatant[string] but i figured having at least stuff like combatant["hp"] work would be fine.

Only tested it via manually creating a simple combatant cause i don't feel like trying to get the whole thing to start

[test.txt](https://github.com/avrae/avrae/files/3194750/test.txt)
(Renamed it cause i guess they don't let you attach python files to these...)