### PR TITLE
[WEB-026] Update monster media URL

### DIFF
--- a/cogs5e/models/monster.py
+++ b/cogs5e/models/monster.py
@@ -345,7 +345,7 @@ class Monster:
     def get_image_url(self):
         """Returns a monster's image URL."""
         if not self.source == 'homebrew':
-            return f"https://avrae.io/img/{parse.quote(self.source)}/{parse.quote(self.name)}.png"
+            return f"https://media.avrae.io/{parse.quote(self.source)}/{parse.quote(self.name)}.png"
         else:
             return self.image_url or ''
 


### PR DESCRIPTION
Resolves #625

Moved location of monster images to `media.avrae.io/:src/:monster`.