### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Severity**
+Trivial (typos, etc) / Low (formatting issues, things that don't impact operation) / Medium (minor functional impact) / High (a broken feature, major functional impact) / Critical (bot crash, extremely major functional impact)
+
+**Context**
+The command run that the bug occured in and any choice trees.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: featurereq
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Who would use it?**
+The use case for this feature
+
+**What part of the bot?**
+i.e. Initiative, SheetManager, general functionality, Aliasing
+
+**How would it work?**
+[This is where you put the avrae syntax/command]
+
+**Why should this be added?**
+Justify why you think it'd help others
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/internal-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/internal-enhancement.md
@@ -1,0 +1,10 @@
+---
+name: Internal enhancement
+about: Improvements to the infrastructure we use
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
These templates should automatically label new issues with the right labels for Taine. If accepted, will also add these templates to avrae/avrae.io, avrae/avrae-service, and avrae/taine.