### PR TITLE
Use env var to auth with Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ You can join the Avrae Development Discord [here](https://discord.gg/pQbd4s6)!
 
 ## Contributing
 
-#### How to run Avrae locally
+### How to run Avrae locally
+#### Using Docker
+
+Check out docker/readme.md.
+
+#### Building Manually
 ###### OS Requirements
 Avrae runs best on Ubuntu 16.04.4, but should be fully compatible with any UNIX-based system.
 It is possible to run Avrae on Windows, but is not recommended.
@@ -29,24 +34,6 @@ You'll need to create a few files first.
 
 You'll also need to create a Google Drive Service Account. You can find instructions on how to do this [here](https://gspread.readthedocs.io/en/latest/oauth2.html#using-signed-credentials).
 Follow steps 1-3 in the **Signed Credentials** portion. Rename the JSON `avrae-google.json` and put it in the project root.
-
-###### Resources
-After creating the credential files, you'll have to create a few files so that Lookup doesn't break:
-- `res/backgrounds.json`*
-- `res/bestiary.json`*
-- `res/classes.json`*
-- `res/classfeats.json`*
-- `res/conditions.json`
-- `res/feats.json`
-- `res/itemprops.json` (should be `{}`)
-- `res/items.json`*
-- `res/names.json`*
-- `res/races.json`*
-- `res/rules.json`
-- `res/spells.json`*
-
-These files (except for itemprops) should just contain an empty JSON array (`[]`) for testing.
-Files marked with a * can be obtained by running the [data parsers](https://github.com/avrae/avrae-data).
 
 ###### Temp Folders
 You will need to create a folder named `temp`.

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -12,6 +12,7 @@ Created on May 8, 2017
 # v15: version fix
 import asyncio
 import logging
+import os
 import re
 
 import pygsheets
@@ -108,6 +109,8 @@ class GoogleSheet(SheetLoaderABC):
         GoogleSheet._client_initializing = True
 
         def _():
+            if "GOOGLE_SERVICE_ACCOUNT" in os.environ:
+                return pygsheets.authorize(service_account_env_var='GOOGLE_SERVICE_ACCOUNT', no_cache=True)
             return pygsheets.authorize(service_account_file='avrae-google.json', no_cache=True)
 
         GoogleSheet.g_client = await asyncio.get_event_loop().run_in_executor(None, _)

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -5,6 +5,9 @@
 - [Docker Compose](https://docs.docker.com/compose/install/).
 - [Dicecloud](https://www.dicecloud.com) account - do NOT register with Google, create a normal account.
 - [Discord](https://discordapp.com/) account.
+- [Google Drive Service Account](https://gspread.readthedocs.io/en/latest/oauth2.html#using-signed-credentials).
+    - Follow steps 1-3 in the **Signed Credentials** portion. The contents of this JSON file is your `GOOGLE_SERVICE_ACCOUNT` env var.
+
 
 ### Discord setup
 
@@ -34,3 +37,4 @@
     DICECLOUD_USER=b
     DICECLOUD_PASS=c
     DICECLOUD_TOKEN=d
+    GOOGLE_SERVICE_ACCOUNT=e


### PR DESCRIPTION
### Summary
Uses an env var to authenticate with Google Spreadsheets instead of a JSON file. Falls back to JSON if the env var is not found.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
