### PR TITLE
Fixes: 2019w28

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -462,6 +462,7 @@ class GameTrack(commands.Cog):
         __Valid Arguments:__
         -i - Ignores Spellbook restrictions, for demonstrations or rituals.
         -l [level] - Specifies the level to cast the spell at.
+        noconc - Ignores concentration requirements.
         **__Save Spells__**
         -dc [Save DC] - Default: Pulls a cvar called `dc`.
         -save [Save type] - Default: The spell's default save.

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -1057,6 +1057,7 @@ class InitTracker(commands.Cog):
         -t <target> - Specifies one or more combatant's to target, chainable (e.g., "-t or1 -t or2").
         -i - Ignores Spellbook restrictions, for demonstrations or rituals. Doesn't use a spell slot.
         -l <level> - Specifies the level to cast the spell at.
+        noconc - Ignores concentration requirements.
         **__Save Spells__**
         -dc <save dc> - Changes the DC of the save.
         -save [str|dex|con|int|wis|cha] - Changes the save that the spell rolls. Default: The spell's default save type.
@@ -1078,6 +1079,7 @@ class InitTracker(commands.Cog):
         -t <target> - Specifies one or more combatant's to target, chainable (e.g., "-t or1 -t or2").
         -i - Ignores Spellbook restrictions, for demonstrations or rituals. Doesn't use a spell slot.
         -l <level> - Specifies the level to cast the spell at.
+        noconc - Ignores concentration requirements.
         **__Save Spells__**
         -dc <save dc> - Changes the DC of the save. Default: Pulls a cvar called `dc`.
         -save [str|dex|con|int|wis|cha] - Changes the save that the spell rolls. Default: The spell's default save type.

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -756,7 +756,7 @@ class InitTracker(commands.Cog):
     @init.command()
     async def effect(self, ctx, target_name: str, effect_name: str, *args):
         """Attaches a status effect to a combatant.
-        ]args] is a set of args that affects a combatant in combat.
+        [args] is a set of args that affects a combatant in combat.
         See `!help init re` to remove effects.
         __**Valid Arguments**__
         -dur <duration> - Sets the duration of the effect, in rounds.

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -114,11 +114,11 @@ async def bestiary_from_critterdb(url):
             async with session.get(
                     f"http://critterdb.com/api/publishedbestiaries/{url}/creatures/{index}") as resp:
                 if not 199 < resp.status < 300:
-                    raise ExternalImportError("Error importing bestiary. Are you sure the link is right?")
+                    raise ExternalImportError("Error importing bestiary: HTTP error. Are you sure the link is right?")
                 try:
                     raw = await resp.json()
-                except ValueError:
-                    raise ExternalImportError("Error importing bestiary. Are you sure the link is right?")
+                except (ValueError, aiohttp.ContentTypeError):
+                    raise ExternalImportError("Error importing bestiary: bad response. Are you sure the link is right?")
                 if not raw:
                     break
                 creatures.extend(raw)
@@ -126,7 +126,7 @@ async def bestiary_from_critterdb(url):
         async with session.get(f"http://critterdb.com/api/publishedbestiaries/{url}") as resp:
             try:
                 raw = await resp.json()
-            except ValueError:
+            except (ValueError, aiohttp.ContentTypeError):
                 raise ExternalImportError("Error importing bestiary metadata. Are you sure the link is right?")
             name = raw['name']
             desc = raw['description']

--- a/cogs5e/models/spell.py
+++ b/cogs5e/models/spell.py
@@ -915,9 +915,11 @@ class Spell:
         if phrase:
             embed.description = f"*{phrase}*"
 
+        # concentration
+        noconc = args.last("noconc", type_=bool)
         conc_conflict = None
         conc_effect = None
-        if self.concentration and isinstance(caster, Combatant) and combat:
+        if all((self.concentration, isinstance(caster, Combatant), combat, not noconc)):
             duration = args.last('dur', self.get_combat_duration(), int)
             conc_effect = initiative.Effect.new(combat, caster, self.name, duration, "", True)
             effect_result = caster.add_effect(conc_effect)

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -29,7 +29,7 @@ API_BASE = "https://www.dndbeyond.com/character/"
 DAMAGE_TYPES = {1: "bludgeoning", 2: "piercing", 3: "slashing", 4: "necrotic", 5: "acid", 6: "cold", 7: "fire",
                 8: "lightning", 9: "thunder", 10: "poison", 11: "psychic", 12: "radiant", 13: "force"}
 CASTER_TYPES = {"Barbarian": 0, "Bard": 1, "Cleric": 1, "Druid": 1, "Fighter": 0.334, "Monk": 0, "Paladin": 0.5,
-                "Ranger": 0.5, "Rogue": 0.334, "Sorcerer": 1, "Warlock": 0, "Wizard": 1}
+                "Ranger": 0.5, "Rogue": 0.334, "Sorcerer": 1, "Warlock": 0, "Wizard": 1, "Artificer": 0.5}
 SLOTS_PER_LEVEL = {
     1: lambda l: min(l + 1, 4) if l else 0,
     2: lambda l: 0 if l < 3 else min(l - 1, 3),
@@ -375,6 +375,7 @@ class BeyondSheetParser(SheetLoaderABC):
         spellMod = 0
         pactSlots = 0
         pactLevel = 1
+        hasSpells = False
         for _class in self.character_data['classes']:
             castingAbility = _class['definition']['spellCastingAbilityId'] or \
                              (_class['subclassDefinition'] or {}).get('spellCastingAbilityId')
@@ -383,6 +384,7 @@ class BeyondSheetParser(SheetLoaderABC):
                 casterMult = CASTER_TYPES.get(_class['definition']['name'], 1)
                 spellcasterLevel += _class['level'] * casterMult
                 spellMod = max(spellMod, self.stat_from_id(castingAbility))
+                hasSpells = 'Spellcasting' in [cf['name'] for cf in _class['definition']['classFeatures']] or hasSpells
             if _class['definition']['name'] == 'Warlock':
                 pactSlots = pact_slots_by_level(_class['level'])
                 pactLevel = pact_level_by_level(_class['level'])
@@ -390,7 +392,7 @@ class BeyondSheetParser(SheetLoaderABC):
         if castingClasses > 1:
             spellcasterLevel = floor(spellcasterLevel)
         else:
-            if spellcasterLevel >= 1:
+            if hasSpells:
                 spellcasterLevel = ceil(spellcasterLevel)
             else:
                 spellcasterLevel = 0

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -480,16 +480,16 @@ class BeyondSheetParser(SheetLoaderABC):
         def monk_scale():
             monk_level = self.get_levels().get('Monk')
             if not monk_level:
-                dice_size = 0
+                monk_dice_size = 0
             elif monk_level < 5:
-                dice_size = 4
+                monk_dice_size = 4
             elif monk_level < 11:
-                dice_size = 6
+                monk_dice_size = 6
             elif monk_level < 17:
-                dice_size = 8
+                monk_dice_size = 8
             else:
-                dice_size = 10
-            return dice_size
+                monk_dice_size = 10
+            return monk_dice_size
 
         if atkType == 'action':
             if atkIn['dice'] is None:

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -380,11 +380,12 @@ class BeyondSheetParser(SheetLoaderABC):
             castingAbility = _class['definition']['spellCastingAbilityId'] or \
                              (_class['subclassDefinition'] or {}).get('spellCastingAbilityId')
             if castingAbility:
-                castingClasses += 1
                 casterMult = CASTER_TYPES.get(_class['definition']['name'], 1)
                 spellcasterLevel += _class['level'] * casterMult
+                castingClasses += 1 if casterMult else 0  # warlock multiclass fix
                 spellMod = max(spellMod, self.stat_from_id(castingAbility))
                 hasSpells = 'Spellcasting' in [cf['name'] for cf in _class['definition']['classFeatures']] or hasSpells
+
             if _class['definition']['name'] == 'Warlock':
                 pactSlots = pact_slots_by_level(_class['level'])
                 pactLevel = pact_level_by_level(_class['level'])

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -599,28 +599,41 @@ class BeyondSheetParser(SheetLoaderABC):
     def calculate_stats(self):
         ignored = set()
         has_stat_bonuses = []  # [{type, stat, subtype}]
-        for modtype in self.character_data['modifiers'].values():  # {race: [], class: [], ...}
-            for mod in modtype:  # [{}, ...]
-                mod_type = mod['subType']  # e.g. 'strength-score'
-                if mod_type in ignored:
-                    continue
-                if mod['statId']:
-                    has_stat_bonuses.append({'subtype': mod_type, 'type': mod['type'], 'stat': mod['statId']})
 
-                if mod['type'] == 'bonus':
-                    if mod_type in self.set_calculated_stats:
-                        continue
-                    self.calculated_stats[mod_type] += (mod['value'] or 0)
-                elif mod['type'] == 'damage':
-                    self.calculated_stats[f"{mod_type}-damage"] += (mod['value'] or 0)
-                elif mod['type'] == 'set':
-                    if mod_type in self.set_calculated_stats and self.calculated_stats[mod_type] > (mod['value'] or 0):
-                        continue
-                    self.calculated_stats[mod_type] = (mod['value'] or 0)
-                    self.set_calculated_stats.add(mod_type)
-                elif mod['type'] == 'ignore':
-                    self.calculated_stats[mod_type] = 0
-                    ignored.add(mod_type)
+        def handle_mod(mod):
+            mod_type = mod['subType']  # e.g. 'strength-score'
+            if mod_type in ignored:
+                return
+            if mod['statId']:
+                has_stat_bonuses.append({'subtype': mod_type, 'type': mod['type'], 'stat': mod['statId']})
+
+            if mod['type'] == 'bonus':
+                if mod_type in self.set_calculated_stats:
+                    return
+                self.calculated_stats[mod_type] += (mod['value'] or 0)
+            elif mod['type'] == 'damage':
+                self.calculated_stats[f"{mod_type}-damage"] += (mod['value'] or 0)
+            elif mod['type'] == 'set':
+                if mod_type in self.set_calculated_stats and self.calculated_stats[mod_type] > (mod['value'] or 0):
+                    return
+                self.calculated_stats[mod_type] = (mod['value'] or 0)
+                self.set_calculated_stats.add(mod_type)
+            elif mod['type'] == 'ignore':
+                self.calculated_stats[mod_type] = 0
+                ignored.add(mod_type)
+
+        for provider, modtype in self.character_data['modifiers'].items():  # {race: [], class: [], ...}
+            if provider == 'item':  # we handle this by iterating over inventory to handle unequipped items
+                continue
+            for modifier in modtype:  # [{}, ...]
+                handle_mod(modifier)
+
+        for item in self.character_data['inventory']:
+            if not item['equipped']:
+                continue
+            for modifier in item['definition']['grantedModifiers']:
+                handle_mod(modifier)
+
         for mod in has_stat_bonuses:
             mod_type = mod['subtype']
             if mod_type in ignored:

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -428,8 +428,9 @@ class BeyondSheetParser(SheetLoaderABC):
         slots[str(pactLevel)] += pactSlots
 
         prof = self.get_stats().prof_bonus
-        attack_bonus_bonus = self.get_stat("spell-attacks")
-        dc = 8 + spellMod + prof
+        save_dc_bonus = max(self.get_stat("spell-save-dc"), self.get_stat("warlock-spell-save-dc"))
+        attack_bonus_bonus = max(self.get_stat("spell-attacks"), self.get_stat("warlock-spell-attacks"))
+        dc = 8 + spellMod + prof + save_dc_bonus
         sab = spellMod + prof + attack_bonus_bonus
 
         spellnames = []

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -122,7 +122,7 @@ class GoogleSheet(SheetLoaderABC):
         doc = GoogleSheet.g_client.open_by_key(self.url)
         self.character_data = TempCharacter(doc.sheet1, "A1:AR180")
         vcell = doc.sheet1.cell("AQ4").value
-        if "1.3" not in vcell:
+        if ("1.3" not in vcell) and vcell:
             self.additional = TempCharacter(doc.worksheet('index', 1), "A1:AP81")
             self.version = 2 if "2" in vcell else 1
 


### PR DESCRIPTION


### Summary
Resolves #592 
Resolves #655 - If a caster attempts to cast a spell whose default level is a level they have no max slots for, automatically upscale to the next lowest level they have slots for, below level 5 (for warlocks)
Resolves #669 

**Old DDB Import Bugs**
Resolves #585 
Resolves #664 
Resolves #670 
Resolves #628 
Resolves #679 
Resolves #671 
Resolves #683 
Resolves #642 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
