### PR TITLE
[GH-676] Better Bestiary Storage

### DIFF
--- a/cogs5e/funcs/lookupFuncs.py
+++ b/cogs5e/funcs/lookupFuncs.py
@@ -92,7 +92,7 @@ async def select_monster_full(ctx, name, cutoff=5, return_key=False, pm=False, m
     choices = list(itertools.chain(c.monster_mash, custom_monsters))
     if ctx.guild:
         async for servbestiary in Bestiary.server_bestiaries(ctx):
-            if servbestiary['_id'] == bestiary_id:
+            if servbestiary.id == bestiary_id:
                 continue
             await servbestiary.load_monsters(ctx)
             choices.extend(servbestiary.monsters)

--- a/cogs5e/funcs/lookupFuncs.py
+++ b/cogs5e/funcs/lookupFuncs.py
@@ -83,6 +83,7 @@ async def select_monster_full(ctx, name, cutoff=5, return_key=False, pm=False, m
     """
     try:
         bestiary = await Bestiary.from_ctx(ctx)
+        await bestiary.load_monsters(ctx)
         custom_monsters = bestiary.monsters
         bestiary_id = bestiary.id
     except NoActiveBrew:
@@ -90,9 +91,11 @@ async def select_monster_full(ctx, name, cutoff=5, return_key=False, pm=False, m
         bestiary_id = None
     choices = list(itertools.chain(c.monster_mash, custom_monsters))
     if ctx.guild:
-        async for servbestiary in ctx.bot.mdb.bestiaries.find({"server_active": str(ctx.guild.id)}, ['monsters']):
-            choices.extend(
-                Monster.from_bestiary(m) for m in servbestiary['monsters'] if servbestiary['_id'] != bestiary_id)
+        async for servbestiary in Bestiary.server_bestiaries(ctx):
+            if servbestiary['_id'] == bestiary_id:
+                continue
+            await servbestiary.load_monsters(ctx)
+            choices.extend(servbestiary.monsters)
 
     def get_homebrew_formatted_name(monster):
         if monster.source == 'homebrew':

--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -6,7 +6,7 @@ from discord.ext import commands
 
 from cogs5e.models.embeds import HomebrewEmbedWithAuthor
 from cogs5e.models.errors import NoActiveBrew, NoSelectionElements
-from cogs5e.models.homebrew.bestiary import Bestiary, bestiary_from_critterdb, select_bestiary
+from cogs5e.models.homebrew.bestiary import Bestiary, select_bestiary
 from cogs5e.models.homebrew.pack import Pack, select_pack
 from cogs5e.models.homebrew.tome import Tome, select_tome
 from utils import checks
@@ -126,7 +126,7 @@ class Homebrew(commands.Cog):
                 f"You don't have a bestiary active. Add one with `{ctx.prefix}bestiary import` first!")
         loading = await ctx.send("Updating bestiary (this may take a while for large bestiaries)...")
 
-        await active_bestiary.unsubscribe(ctx)
+        await active_bestiary.unsubscribe(ctx)  # TODO - when updating, copy old server subs to new version - will require servers to know who shared
         bestiary = await Bestiary.from_critterdb(ctx, active_bestiary.upstream)
 
         await bestiary.set_active(ctx)

--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -64,9 +64,7 @@ class Homebrew(commands.Cog):
     @bestiary.command(name='list')
     async def bestiary_list(self, ctx):
         """Lists your available bestiaries."""
-        out = []
-        async for best in Bestiary.user_bestiaries(ctx):
-            out.append(best.name)
+        out = [b.name async for b in Bestiary.user_bestiaries(ctx)]
         await ctx.send(f"Your bestiaries: {', '.join(out)}")
 
     @bestiary.command(name='delete')

--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -34,7 +34,7 @@ class Homebrew(commands.Cog):
         """Commands to manage homebrew monsters.
         When called without an argument, lists the current bestiary and the monsters in it.
         When called with a name, switches to a different bestiary."""
-        user_bestiaries = await self.bot.mdb.bestiaries.count_documents({"owner": str(ctx.author.id)})
+        user_bestiaries = await Bestiary.num_user(ctx)
 
         if not user_bestiaries:
             return await ctx.send(f"You have no bestiaries. Use `{ctx.prefix}bestiary import` to import one!")
@@ -53,6 +53,7 @@ class Homebrew(commands.Cog):
         embed.title = bestiary.name
         if bestiary.desc:
             embed.description = bestiary.desc
+        await bestiary.load_monsters(ctx)
         monnames = '\n'.join(m.name for m in bestiary.monsters)
         if len(monnames) < 1020:
             embed.add_field(name="Creatures", value=monnames)
@@ -63,8 +64,10 @@ class Homebrew(commands.Cog):
     @bestiary.command(name='list')
     async def bestiary_list(self, ctx):
         """Lists your available bestiaries."""
-        user_bestiaries = await self.bot.mdb.bestiaries.find({"owner": str(ctx.author.id)}, ['name']).to_list(None)
-        await ctx.send(f"Your bestiaries: {', '.join(b['name'] for b in user_bestiaries)}")
+        out = []
+        async for best in Bestiary.user_bestiaries(ctx):
+            out.append(best.name)
+        await ctx.send(f"Your bestiaries: {', '.join(out)}")
 
     @bestiary.command(name='delete')
     async def bestiary_delete(self, ctx, *, name):
@@ -79,7 +82,7 @@ class Homebrew(commands.Cog):
         resp = await confirm(ctx, 'Are you sure you want to delete {}? (Reply with yes/no)'.format(bestiary.name))
 
         if resp:
-            await self.bot.mdb.bestiaries.delete_one({"critterdb_id": bestiary.id})
+            await bestiary.unsubscribe(ctx)
             return await ctx.send('{} has been deleted.'.format(bestiary.name))
         else:
             return await ctx.send("OK, cancelling.")
@@ -99,10 +102,10 @@ class Homebrew(commands.Cog):
         loading = await ctx.send("Importing bestiary (this may take a while for large bestiaries)...")
         bestiary_id = url.split('/view')[1].strip('/ \n')
 
-        bestiary = await bestiary_from_critterdb(bestiary_id)
+        bestiary = await Bestiary.from_critterdb(ctx, bestiary_id)
 
-        await bestiary.commit(ctx)
         await bestiary.set_active(ctx)
+        await bestiary.load_monsters(ctx)
         await loading.edit(content=f"Imported {bestiary.name}!")
         embed = HomebrewEmbedWithAuthor(ctx)
         embed.title = bestiary.name
@@ -116,16 +119,18 @@ class Homebrew(commands.Cog):
     @bestiary.command(name='update')
     async def bestiary_update(self, ctx):
         """Updates the active bestiary from CritterDB."""
-        active_bestiary = await self.bot.mdb.bestiaries.find_one({"owner": str(ctx.author.id), "active": True})
-
-        if active_bestiary is None:
+        try:
+            active_bestiary = await Bestiary.from_ctx(ctx)
+        except NoActiveBrew:
             return await ctx.send(
                 f"You don't have a bestiary active. Add one with `{ctx.prefix}bestiary import` first!")
-        loading = await ctx.send("Importing bestiary (this may take a while for large bestiaries)...")
+        loading = await ctx.send("Updating bestiary (this may take a while for large bestiaries)...")
 
-        bestiary = await bestiary_from_critterdb(active_bestiary["critterdb_id"])
+        await active_bestiary.unsubscribe(ctx)
+        bestiary = await Bestiary.from_critterdb(ctx, active_bestiary.upstream)
 
-        await bestiary.commit(ctx)
+        await bestiary.set_active(ctx)
+        await bestiary.load_monsters(ctx)
         await loading.edit(content=f"Imported and updated {bestiary.name}!")
         embed = HomebrewEmbedWithAuthor(ctx)
         embed.title = bestiary.name
@@ -152,8 +157,8 @@ class Homebrew(commands.Cog):
     async def bestiary_server_list(self, ctx):
         """Shows what bestiaries are currently active on the server."""
         desc = ""
-        async for doc in self.bot.mdb.bestiaries.find({"server_active": str(ctx.guild.id)}, ['name', 'owner']):
-            desc += f"{doc['name']} (<@{doc['owner']}>)\n"
+        async for best in Bestiary.server_bestiaries(ctx):
+            desc += f"{best.name}\n"
         await ctx.send(embed=discord.Embed(title="Active Server Bestiaries", description=desc))
 
     @commands.group(invoke_without_command=True)

--- a/cogs5e/models/errors.py
+++ b/cogs5e/models/errors.py
@@ -31,6 +31,11 @@ class InvalidArgument(AvraeException):
     pass
 
 
+class NotAllowed(AvraeException):
+    """Raised when a user tries to do something they are not allowed to do by role or dependency."""
+    pass
+
+
 class EvaluationError(AvraeException):
     """Raised when a cvar evaluation causes an error."""
 

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -1,56 +1,122 @@
+import hashlib
 import logging
 
 import aiohttp
 
-from cogs5e.models.errors import ExternalImportError, NoActiveBrew, NoSelectionElements, SelectionCancelled
+from cogs5e.models.errors import ExternalImportError, NoActiveBrew
 from cogs5e.models.monster import Monster
-from utils.functions import get_selection
+from utils.functions import search_and_select
 
 log = logging.getLogger(__name__)
 
 
 class Bestiary:
-    def __init__(self, _id: str, name: str, monsters: list, desc: str = None):
+    def __init__(self, _id, sha256: str, upstream: str, subscribers: list, active: list, server_active: list,
+                 name: str, monsters: list = None, desc: str = None):
+        # metadata - should never change
         self.id = _id
+        self.sha256 = sha256
+        self.upstream = upstream
+
+        # subscription data - only atomic writes
+        self.subscribers = subscribers
+        self.active = active
+        self.server_active = server_active
+
+        # content
         self.name = name
-        self.monsters = monsters
         self.desc = desc
+        self._monsters = monsters  # only loaded if needed
 
     @classmethod
-    def from_raw(cls, _id, raw):
-        monsters = [Monster.from_bestiary(m) for m in raw['monsters']]
-        return cls(_id, raw['name'], monsters, raw.get('desc'))
+    def from_dict(cls, d):
+        return cls(**d)
+
+    @classmethod
+    async def from_critterdb(cls, ctx, url):
+        log.info(f"Getting bestiary ID {url}...")
+        index = 1
+        creatures = []
+        sha256_hash = hashlib.sha256()
+        async with aiohttp.ClientSession() as session:
+            for _ in range(100):  # 100 pages max
+                log.info(f"Getting page {index} of {url}...")
+                async with session.get(
+                        f"http://critterdb.com/api/publishedbestiaries/{url}/creatures/{index}") as resp:
+                    if not 199 < resp.status < 300:
+                        raise ExternalImportError("Error importing bestiary. Are you sure the link is right?")
+                    try:
+                        raw_creatures = await resp.json()
+                        sha256_hash.update(await resp.read())
+                    except ValueError:
+                        raise ExternalImportError("Error importing bestiary. Are you sure the link is right?")
+                    if not raw_creatures:
+                        break
+                    creatures.extend(raw_creatures)
+                    index += 1
+            async with session.get(f"http://critterdb.com/api/publishedbestiaries/{url}") as resp:
+                try:
+                    raw = await resp.json()
+                except ValueError:
+                    raise ExternalImportError("Error importing bestiary metadata. Are you sure the link is right?")
+                name = raw['name']
+                desc = raw['description']
+                sha256_hash.update(name.encode() + desc.encode())
+
+        # try and find a bestiary by looking up upstream|hash
+        # if it exists, return it
+        # otherwise commit a new one to the db and return that
+        existing_bestiary = await ctx.bot.mdb.bestiaries.find_one({"upstream": url, "sha256": sha256_hash.hexdigest()})
+        if existing_bestiary:
+            await existing_bestiary.subscribe(ctx)
+            return existing_bestiary
+
+        parsed_creatures = [Monster.from_critterdb(c) for c in creatures]
+        b = cls(None, sha256_hash.hexdigest(), url, [], [], [], name, parsed_creatures, desc)
+        await b.write_to_db(ctx)
+        return b
 
     @classmethod
     async def from_ctx(cls, ctx):
-        active_bestiary = await ctx.bot.mdb.bestiaries.find_one({"owner": str(ctx.author.id), "active": True})
+        active_bestiary = await ctx.bot.mdb.bestiaries.find_one({"active": str(ctx.author.id)},
+                                                                projection={"monsters": False})
         if active_bestiary is None:
             raise NoActiveBrew()
-        return cls.from_raw(active_bestiary['critterdb_id'], active_bestiary)
+        return cls.from_dict(active_bestiary)
 
-    def to_dict(self):
-        return {'monsters': [m.to_dict() for m in self.monsters], 'name': self.name, 'critterdb_id': self.id,
-                'desc': self.desc}
+    async def load_monsters(self, ctx):
+        if not self._monsters:
+            monsters = await ctx.bot.mdb.bestiaries.find_one({"_id": self.id}, projection=['monsters'])
+            self._monsters = [Monster.from_bestiary(m) for m in monsters]
+        return self._monsters
 
-    async def commit(self, ctx):
-        """Writes a bestiary object to the database, under the contextual author. Returns self."""
-        data = {"$set": self.to_dict(), "$setOnInsert": {"owner": str(ctx.author.id), "server_active": []}}
+    @property
+    def monsters(self):
+        if not self._monsters:
+            raise AttributeError("load_monsters() must be called before accessing bestiary monsters.")
+        return self._monsters
 
-        await ctx.bot.mdb.bestiaries.update_one(
-            {"owner": str(ctx.author.id), "critterdb_id": self.id},
-            data,
-            True
-        )
+    async def write_to_db(self, ctx):
+        """Writes a bestiary object to the database. Returns self."""
+        assert self._monsters is not None
+        data = {
+            "sha256": self.sha256, "upstream": self.upstream, "subscribers": [str(ctx.author.id)], "active": [],
+            "server_active": [], "name": self.name, "desc": self.desc, "monsters": [m.to_dict() for m in self._monsters]
+        }
+
+        result = await ctx.bot.mdb.bestiaries.insert_one(data)
+        self.id = result.inserted_id
         return self
 
     async def set_active(self, ctx):
+        """Sets the bestiary as active for the contextual author."""
         await ctx.bot.mdb.bestiaries.update_many(
-            {"owner": str(ctx.author.id), "active": True},
-            {"$set": {"active": False}}
+            {"active": str(ctx.author.id)},
+            {"$pull": {"active": str(ctx.author.id)}}
         )
         await ctx.bot.mdb.bestiaries.update_one(
-            {"owner": str(ctx.author.id), "critterdb_id": self.id},
-            {"$set": {"active": True}}
+            {"_id": self.id},
+            {"$push": {"active": str(ctx.author.id)}}
         )
         return self
 
@@ -60,75 +126,71 @@ class Bestiary:
         :param ctx: Context
         :return: Whether the bestiary is now active on the server.
         """
-        data = await ctx.bot.mdb.bestiaries.find_one({"owner": str(ctx.author.id), "critterdb_id": self.id},
-                                                     ["server_active"])
-        server_active = data.get('server_active', [])
-        if str(ctx.guild.id) in server_active:
-            server_active.remove(str(ctx.guild.id))
+        guild_id = str(ctx.guild.id)
+        if guild_id in self.server_active:
+            await ctx.bot.mdb.bestiaries.update_one(
+                {"_id": self.id},
+                {"$pull": {"active": guild_id}}
+            )
+            self.server_active.remove(guild_id)
         else:
-            server_active.append(str(ctx.guild.id))
+            await ctx.bot.mdb.bestiaries.update_one(
+                {"_id": self.id},
+                {"$push": {"active": guild_id}}
+            )
+            self.server_active.append(guild_id)
+
+        return guild_id in self.server_active
+
+    async def subscribe(self, ctx):
         await ctx.bot.mdb.bestiaries.update_one(
-            {"owner": str(ctx.author.id), "critterdb_id": self.id},
-            {"$set": {"server_active": server_active}}
+            {"_id": self.id},
+            {"$addToSet": {"subscribers": str(ctx.author.id)}}
         )
-        return str(ctx.guild.id) in server_active
+        self.subscribers.append(str(ctx.author.id))
+
+    async def unsubscribe(self, ctx):
+        await ctx.bot.mdb.bestiaries.update_one(
+            {"_id": self.id},
+            {"$pull": {"subscribers": str(ctx.author.id)}}
+        )
+        if str(ctx.author.id) in self.subscribers:
+            self.subscribers.remove(str(ctx.author.id))
+
+        # if no one is subscribed to this bestiary anymore, delete it.
+        if not self.subscribers:
+            await self.delete(ctx)
+
+    async def delete(self, ctx):
+        await ctx.bot.mdb.bestiaries.delete_one({"_id": self.id})
+
+    @staticmethod
+    async def num_user(ctx):
+        """Returns the number of bestiaries a user has imported."""
+        return await ctx.bot.mdb.bestiaries.count_documents({"subscribers": str(ctx.author.id)})
+
+    @staticmethod
+    async def user_bestiaries(ctx):
+        """Returns an async iterator of partial Bestiary objects that the user has imported."""
+        async for b in ctx.bot.mdb.bestiaries.find({"subscribers": str(ctx.author.id)},
+                                                   projection={"monsters": False}):
+            yield Bestiary.from_dict(b)
+
+    @staticmethod
+    async def server_bestiaries(ctx):
+        """Returns an async iterator of partial Bestiary objects that are active on the server."""
+        async for b in ctx.bot.mdb.bestiaries.find({"server_active": str(ctx.guild.id)},
+                                                   projection={"monsters": False}):
+            yield Bestiary.from_dict(b)
 
 
 async def select_bestiary(ctx, name):
-    user_bestiaries = await ctx.bot.mdb.bestiaries.find({"owner": str(ctx.author.id)}).to_list(None)
-
+    user_bestiaries = []
+    async for b in Bestiary.user_bestiaries(ctx):
+        user_bestiaries.append(b)
     if not user_bestiaries:
         raise NoActiveBrew()
-    choices = []
-    for bestiary in user_bestiaries:
-        url = bestiary['critterdb_id']
-        if bestiary['name'].lower() == name.lower():
-            choices.append((bestiary, url))
-        elif name.lower() in bestiary['name'].lower():
-            choices.append((bestiary, url))
 
-    if len(choices) > 1:
-        choiceList = [(f"{c[0]['name']} (`{c[1]})`", c) for c in choices]
-
-        result = await get_selection(ctx, choiceList, delete=True)
-        if result is None:
-            raise SelectionCancelled()
-
-        bestiary = result[0]
-        bestiary_url = result[1]
-    elif len(choices) == 0:
-        raise NoSelectionElements()
-    else:
-        bestiary = choices[0][0]
-        bestiary_url = choices[0][1]
-    return Bestiary.from_raw(bestiary_url, bestiary)
-
-
-async def bestiary_from_critterdb(url):
-    log.info(f"Getting bestiary ID {url}...")
-    index = 1
-    creatures = []
-    async with aiohttp.ClientSession() as session:
-        for _ in range(100):  # 100 pages max
-            log.info(f"Getting page {index} of {url}...")
-            async with session.get(
-                    f"http://critterdb.com/api/publishedbestiaries/{url}/creatures/{index}") as resp:
-                if not 199 < resp.status < 300:
-                    raise ExternalImportError("Error importing bestiary. Are you sure the link is right?")
-                try:
-                    raw = await resp.json()
-                except ValueError:
-                    raise ExternalImportError("Error importing bestiary. Are you sure the link is right?")
-                if not raw:
-                    break
-                creatures.extend(raw)
-                index += 1
-        async with session.get(f"http://critterdb.com/api/publishedbestiaries/{url}") as resp:
-            try:
-                raw = await resp.json()
-            except ValueError:
-                raise ExternalImportError("Error importing bestiary metadata. Are you sure the link is right?")
-            name = raw['name']
-            desc = raw['description']
-    parsed_creatures = [Monster.from_critterdb(c) for c in creatures]
-    return Bestiary(url, name, parsed_creatures, desc)
+    bestiary = await search_and_select(ctx, user_bestiaries, name, key=lambda b: b['name'],
+                                       selectkey=lambda b: f"{b['name']} (`{b['upstream']})`")
+    return Bestiary.from_dict(bestiary)

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -104,16 +104,18 @@ class Bestiary:
         return self._monsters
 
     async def write_to_db(self, ctx):
-        """Writes a bestiary object to the database. Returns self."""
+        """Writes a new bestiary object to the database."""
         assert self._monsters is not None
+        subscribers = [str(ctx.author.id)]
+        monsters = [m.to_dict() for m in self._monsters]
+
         data = {
-            "sha256": self.sha256, "upstream": self.upstream, "subscribers": [str(ctx.author.id)], "active": [],
-            "server_active": [], "name": self.name, "desc": self.desc, "monsters": [m.to_dict() for m in self._monsters]
+            "sha256": self.sha256, "upstream": self.upstream, "subscribers": subscribers, "active": [],
+            "server_active": [], "name": self.name, "desc": self.desc, "monsters": monsters
         }
 
         result = await ctx.bot.mdb.bestiaries.insert_one(data)
         self.id = result.inserted_id
-        return self
 
     async def set_active(self, ctx):
         """Sets the bestiary as active for the contextual author."""

--- a/migrators/bestiary_hasher.py
+++ b/migrators/bestiary_hasher.py
@@ -25,10 +25,11 @@ def migrate(bestiary):
 
 
 def to_dict(bestiary):
+    monsters = [m.to_dict() for m in bestiary._monsters]
     return {
         "sha256": bestiary.sha256, "upstream": bestiary.upstream, "subscribers": bestiary.subscribers,
         "active": bestiary.active, "server_active": bestiary.server_active, "name": bestiary.name,
-        "desc": bestiary.desc, "monsters": [m.to_dict() for m in bestiary._monsters]
+        "desc": bestiary.desc, "monsters": monsters
     }
 
 

--- a/migrators/bestiary_hasher.py
+++ b/migrators/bestiary_hasher.py
@@ -1,0 +1,134 @@
+import hashlib
+import json
+import sys
+import time
+
+from cogs5e.models.homebrew.bestiary import Bestiary
+from cogs5e.models.monster import Monster
+
+
+def migrate(bestiary):
+    sha256 = hashlib.sha256()
+    hash_str = json.dumps(bestiary['monsters']).encode() \
+               + bestiary['name'].encode() \
+               + str(bestiary.get('desc')).encode()
+    sha256.update(hash_str)
+
+    active = [bestiary['owner']] if bestiary.get('active') else []
+    monsters = [Monster.from_bestiary(m) for m in bestiary['monsters']]
+    new_bestiary = Bestiary(None, sha256.hexdigest(), bestiary['critterdb_id'], [bestiary['owner']], active,
+                            bestiary.get('server_active', []), bestiary['name'], monsters, bestiary.get('desc'))
+    return new_bestiary
+
+
+def to_dict(bestiary):
+    return {
+        "sha256": bestiary.sha256, "upstream": bestiary.upstream, "subscribers": bestiary.subscribers,
+        "active": bestiary.active, "server_active": bestiary.server_active, "name": bestiary.name,
+        "desc": bestiary.desc, "monsters": [m.to_dict() for m in bestiary._monsters]
+    }
+
+
+def local_test(fp):
+    with open(fp) as f:
+        bestiaries = json.load(f)
+    num_monsters = sum(len(b['monsters']) for b in bestiaries)
+    print(f"Migrating {len(bestiaries)} bestiaries ({num_monsters} monsters)...")
+
+    new_bestiaries = {}
+    for b in bestiaries:
+        print(f"\nmigrating {b['name']}")
+        new_bestiary = migrate(b)
+        key = f"{new_bestiary.upstream} {new_bestiary.sha256}"
+        if key in new_bestiaries:
+            print("exists - merging...")
+            # merge
+            existing = new_bestiaries[key]
+            existing.subscribers.extend(new_bestiary.subscribers)
+            existing.active.extend(new_bestiary.active)
+            existing.server_active.extend(new_bestiary.server_active)
+        else:
+            new_bestiaries[key] = new_bestiary
+
+    new_bestiaries = [to_dict(b) for b in new_bestiaries.values()]
+    out = fp.split('/')[-1]
+    with open(f"temp/new-{out}", 'w') as f:
+        json.dump(new_bestiaries, f, indent=2)
+    print(f"Done migrating {len(new_bestiaries)} bestiaries (down from {len(bestiaries)}).")
+
+
+async def from_db(mdb):
+    import pymongo
+
+    coll_names = await mdb.list_collection_names()
+    if "old_bestiaries" not in coll_names:
+        print("Renaming bestiaries to old_bestiaries...")
+        await mdb.bestiaries.rename("old_bestiaries")
+    else:
+        print("Dropping bestiaries_bak and making backup...")
+        if "bestiaries_bak" in coll_names:
+            await mdb.bestiaries_bak.drop()
+        await mdb.bestiaries.rename("bestiaries_bak")
+
+    num_old_bestiaries = await mdb.old_bestiaries.count_documents({})
+    print(f"Migrating {num_old_bestiaries} bestiaries...")
+
+    # db.bestiaries.createIndex({"upstream": 1, "sha256": 1}, {"unique": true});
+    print("Creating compound index on upstream|sha256...")
+    await mdb.bestiaries.create_index([("upstream", pymongo.ASCENDING),
+                                       ("sha256", pymongo.ASCENDING)], unique=True)
+
+    # db.bestiaries.createIndex({"subscribers": 1});
+    print("Creating index on subscribers...")
+    await mdb.bestiaries.create_index("subscribers")
+
+    # db.bestiaries.createIndex({"active": 1});
+    print("Creating index on active...")
+    await mdb.bestiaries.create_index("active")
+
+    # db.bestiaries.createIndex({"server_active": 1});
+    print("Creating index on server_active...")
+    await mdb.bestiaries.create_index("server_active")
+
+    new_bestiaries = {}
+    async for old_bestiary in mdb.old_bestiaries.find({}):
+        print(f"\nmigrating {old_bestiary['name']}")
+        new_bestiary = migrate(old_bestiary)
+        key = f"{new_bestiary.upstream} {new_bestiary.sha256}"
+        if key in new_bestiaries:
+            print("exists - merging...")
+            # merge
+            existing = new_bestiaries[key]
+            existing.subscribers.extend(new_bestiary.subscribers)
+            existing.active.extend(new_bestiary.active)
+            existing.server_active.extend(new_bestiary.server_active)
+        else:
+            new_bestiaries[key] = new_bestiary
+
+    for new_b in new_bestiaries.values():
+        await mdb.bestiaries.insert_one(to_dict(new_b))
+
+    num_bestiaries = await mdb.bestiaries.count_documents({})
+    print(f"Done migrating! Collapsed {num_old_bestiaries} into {num_bestiaries} bestiaries.")
+    print("It's probably safe to drop the collections old_bestiaries and bestiaries_bak now.")
+
+
+if __name__ == '__main__':
+    import asyncio
+    import motor.motor_asyncio
+    import credentials
+
+    start = time.time()
+
+    if 'mdb' not in sys.argv:
+        local_test("temp/bestiaries.json")
+    else:
+        input("Running full MDB migration. Press enter to continue.")
+        mdb = motor.motor_asyncio.AsyncIOMotorClient(credentials.test_mongo_url
+                                                     if 'test' in sys.argv else
+                                                     "mongodb://localhost:27017").avrae
+
+        asyncio.get_event_loop().run_until_complete(from_db(mdb))
+
+    end = time.time()
+    print(f"Done! Took {end - start} seconds.")

--- a/migrators/bestiary_hasher.py
+++ b/migrators/bestiary_hasher.py
@@ -18,6 +18,13 @@ def migrate(bestiary):
     server_active = []
     for serv_sub in bestiary.get('server_active', []):
         server_active.append({"subscriber_id": bestiary['owner'], "guild_id": serv_sub})
+
+    for monster in bestiary['monsters']:
+        for key in ('traits', 'actions', 'reactions', 'legactions'):
+            for trait in monster[key]:
+                if 'attacks' in trait:
+                    del trait['attacks']  # why did we store this in the first place?
+
     monsters = [Monster.from_bestiary(m) for m in bestiary['monsters']]
     new_bestiary = Bestiary(None, sha256.hexdigest(), bestiary['critterdb_id'], [bestiary['owner']], active,
                             server_active, bestiary['name'], monsters, bestiary.get('desc'))
@@ -61,7 +68,7 @@ def local_test(fp):
     new_bestiaries = [to_dict(b) for b in new_bestiaries.values()]
     out = fp.split('/')[-1]
     with open(f"temp/new-{out}", 'w') as f:
-        json.dump(new_bestiaries, f, indent=2)
+        json.dump(new_bestiaries, f)
     print(f"Done migrating {len(new_bestiaries)} bestiaries (down from {num_bestiaries}).")
 
 

--- a/notes/dbIndices.txt
+++ b/notes/dbIndices.txt
@@ -9,7 +9,7 @@ bestiaries:
 db.bestiaries.createIndex({"upstream": 1, "sha256": 1}, {"unique": true});
 db.bestiaries.createIndex({"subscribers": 1});
 db.bestiaries.createIndex({"active": 1});
-db.bestiaries.createIndex({"server_active": 1});
+db.bestiaries.createIndex({"server_active.guild_id": 1});
 
 tomes:
 db.tomes.createIndex({"owner.id": 1});

--- a/notes/dbIndices.txt
+++ b/notes/dbIndices.txt
@@ -6,6 +6,9 @@ db.packs.createIndex({"active": 1});
 db.packs.createIndex({"server_active": 1});
 
 bestiaries:
+db.bestiaries.createIndex({"upstream": 1, "sha256": 1}, {"unique": true});
+db.bestiaries.createIndex({"subscribers": 1});
+db.bestiaries.createIndex({"active": 1});
 db.bestiaries.createIndex({"server_active": 1});
 
 tomes:


### PR DESCRIPTION
### Summary
Resolves #676 

The largest source of duplicate data in bestiaries is multiple users who have imported the same bestiary - the old system would store a copy for each user, leading to a lot of identical data. Since bestiaries are read-only, this change implements a hashing system to track identical bestiaries. If two users import an identical bestiary, it will now mark two "subscribers" on the same hashed bestiary, removing duplicate entries.

Running a test on a local copy of the database, this reduces the space needed to store bestiaries by 79.7% (as of 44ab986).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed) (**A migrator script is included and will require downtime to run**)
- [x] If code changes were made then they have been tested.
- N/A I have updated the documentation to reflect the changes.
