### PR TITLE
AVR-359 Fix import error of houserules w/o values

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -280,8 +280,11 @@ class BeyondSheetParser(SheetLoaderABC):
                     skills[skill_name] = Skill(charval['value'])
                     ignored_ids.add(charval['valueId'])  # this must be the final value so we stop looking
                 elif charval['typeId'] in {24, 25}:  # PROBABLY skill magic/misc bonus
-                    skills[skill_name].value += charval['value']
-                    skills[skill_name].bonus += charval['value']
+                    try:
+                        skills[skill_name].value += charval['value']
+                        skills[skill_name].bonus += charval['value']
+                    except TypeError:
+                        pass  # listed due to note but probably doesn't have a value, ignore it
                 elif charval['typeId'] == 26:  # proficiency stuff
                     relevantprof = profs.get(skill_name, 0)
                     skills[skill_name].value -= relevantprof * profBonus
@@ -359,9 +362,15 @@ class BeyondSheetParser(SheetLoaderABC):
             if val['typeId'] == 1:  # AC override
                 return val['value']
             elif val['typeId'] == 2:  # AC magic bonus
-                miscBonus += val['value']
+                try:
+                    miscBonus += val['value']
+                except TypeError:
+                    pass  # listed due to note but probably doesn't have a value, ignore it
             elif val['typeId'] == 3:  # AC misc bonus
-                miscBonus += val['value']
+                try:
+                    miscBonus += val['value']
+                except TypeError:
+                    pass  # listed due to note but probably doesn't have a value, ignore it
             elif val['typeId'] == 4:  # AC+DEX override
                 baseArmor = val['value']
 

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -276,15 +276,13 @@ class BeyondSheetParser(SheetLoaderABC):
         for charval in self.character_data['characterValues']:
             if charval['valueId'] in HOUSERULE_SKILL_MAP and charval['valueId'] not in ignored_ids:
                 skill_name = HOUSERULE_SKILL_MAP[charval['valueId']]
+                if charval['value'] is None: continue
                 if charval['typeId'] == 23:  # override
                     skills[skill_name] = Skill(charval['value'])
                     ignored_ids.add(charval['valueId'])  # this must be the final value so we stop looking
                 elif charval['typeId'] in {24, 25}:  # PROBABLY skill magic/misc bonus
-                    try:
-                        skills[skill_name].value += charval['value']
-                        skills[skill_name].bonus += charval['value']
-                    except TypeError:
-                        pass  # listed due to note but probably doesn't have a value, ignore it
+                    skills[skill_name].value += charval['value']
+                    skills[skill_name].bonus += charval['value']
                 elif charval['typeId'] == 26:  # proficiency stuff
                     relevantprof = profs.get(skill_name, 0)
                     skills[skill_name].value -= relevantprof * profBonus
@@ -359,18 +357,13 @@ class BeyondSheetParser(SheetLoaderABC):
         armored = armortype is not None
 
         for val in self.character_data['characterValues']:
+            if val['value'] is None: continue
             if val['typeId'] == 1:  # AC override
                 return val['value']
             elif val['typeId'] == 2:  # AC magic bonus
-                try:
-                    miscBonus += val['value']
-                except TypeError:
-                    pass  # listed due to note but probably doesn't have a value, ignore it
+                miscBonus += val['value']
             elif val['typeId'] == 3:  # AC misc bonus
-                try:
-                    miscBonus += val['value']
-                except TypeError:
-                    pass  # listed due to note but probably doesn't have a value, ignore it
+                miscBonus += val['value']
             elif val['typeId'] == 4:  # AC+DEX override
                 baseArmor = val['value']
 


### PR DESCRIPTION
### Summary
Fixes AVR-359 (#706) where sheets error on import due to houserules not having a value

This has generally occurred when they have a note but without a value, which led to them being in the list of values to apply with a NoneType as their value, causing an error on import
(Note: As far as I could tell this does not occur when houseruling proficiency type, only bonuses.)

This PR fixes the issue by adding Try/Except blocks to the relevant sections where it can error.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
