### PR TITLE
Bump tensorflow to 1.14, use main pygsheets fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-absl-py==0.6.1
+absl-py==0.7.1
 aiohttp==3.4.4
 astor==0.7.1
 async-timeout==3.0.1
@@ -16,6 +16,7 @@ google-api-python-client==1.7.9
 google-auth==1.6.3
 google-auth-httplib2==0.0.3
 google-auth-oauthlib==0.3.0
+google-pasta==0.1.7
 graphviz==0.8.4
 grpcio==1.17.1
 h5py==2.8.0
@@ -46,8 +47,7 @@ pyasn1==0.4.2
 pyasn1-modules==0.2.1
 pycryptodome==3.4.7
 pyee==5.0.0
-# pygsheets==2.0.1  # using personal fork to fix gsheet bug until fix is reviewed
-git+https://github.com/mommothazaz123/pygsheets.git@a5194aeb12fdffbc75b971c025899da79b5633f5
+pygsheets==2.0.2
 pymongo==3.7.1
 pyparsing==2.4.0
 pytest==4.6.3
@@ -63,14 +63,16 @@ rsa==3.4.2
 sentry-sdk==0.10.2
 simpleeval==0.9.6
 six==1.11.0
-tensorboard==1.12.1
-tensorflow==1.12.0
+tensorboard==1.14.0
+tensorflow==1.14.0
+tensorflow-estimator==1.14.0
 termcolor==1.1.0
 uritemplate==3.0.0
 urllib3==1.25.3
 wcwidth==0.1.7
 websockets==6.0
 Werkzeug==0.14.1
+wrapt==1.11.2
 ws4py==0.4.2
 yarl==1.3.0
 zipp==0.5.1


### PR DESCRIPTION
### Summary
Bumps tensorflow to 1.14 and changes pygsheets to use the main fork now that it's fixed.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
