### PR TITLE
add stricter reroll limit

### DIFF
--- a/tests/dice_roller_test.py
+++ b/tests/dice_roller_test.py
@@ -49,7 +49,10 @@ def test_gt_lt_selectors():
 
 def test_infinite_loops():
     r = roll("1d1e1")
-    assert r.total == 1002  # 1 + 1000 rerolls + 1 extra
+    assert r.total == 1001  # 1 + 1000 rerolls
+
+    r = roll("1d1e1rr1e1rr1")
+    assert r.total == 0  # error
 
 
 def test_randomness():


### PR DESCRIPTION
### Summary
Limits rolls to a total of 1000 dice rerolls. It should be highly unlikely for any normal roll to hit this.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
