### PR TITLE
Add `.skills`, `.cr` and `.monster_name` to `SimpleCombatant`

### DIFF
--- a/cogs5e/funcs/scripting/combat.py
+++ b/cogs5e/funcs/scripting/combat.py
@@ -1,7 +1,7 @@
 from cogs5e.funcs.dice import roll
 from cogs5e.funcs.scripting.functions import SimpleRollResult
 from cogs5e.models.errors import CombatNotFound, InvalidSaveType
-from cogs5e.models.initiative import Combat, Combatant, CombatantGroup, Effect
+from cogs5e.models.initiative import Combat, Combatant, CombatantGroup, Effect, MonsterCombatant
 from cogs5e.models.sheet.statblock import StatBlock
 from utils.argparser import ParsedArguments
 
@@ -96,13 +96,22 @@ class SimpleCombatant:
         self.init = self._combatant.init
         self.name = self._combatant.name
         self.note = self._combatant.notes
+        self.skills = self._combatant.skills
         self.effects = [SimpleEffect(e) for e in self._combatant.get_effects()]
+        self.level = self._combatant.spellbook.caster_level
+        if isinstance(combatant, MonsterCombatant):
+            self.monster_name = self._combatant.monster_name
+            self.cr = self._combatant.cr
+        else:
+            self.monster_name = self.name
+            self.cr = self.level
         # deprecated
         if self._combatant.hp is not None and self._combatant.max_hp:
             self.ratio = self._combatant.hp / self._combatant.max_hp
         else:
             self.ratio = 0
-        self.level = self._combatant.spellbook.caster_level
+
+
 
     def set_hp(self, newhp: int):
         """

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -828,15 +828,17 @@ class MonsterCombatant(Combatant):
                  spellbook: Spellbook = None,
                  ac: int = None, max_hp: int = None, hp: int = None, temp_hp: int = 0,
                  # monster specific
-                 monster_name=None):
+                 monster_name: str = None, cr: int = None):
         super(MonsterCombatant, self).__init__(
             ctx, combat, name, controller_id, private, init, index, notes, effects, group,
             stats, levels, attacks, skills, saves, resistances, spellbook, ac, max_hp, hp, temp_hp)
         self._monster_name = monster_name
+        self._cr = cr
 
     @classmethod
     def from_monster(cls, monster, ctx, combat, name, controller_id, init, private, hp=None, ac=None):
         monster_name = monster.name
+        cr = monster.cr
         hp = int(monster.hp) if not hp else int(hp)
         ac = int(monster.ac) if not ac else int(ac)
 
@@ -846,21 +848,32 @@ class MonsterCombatant(Combatant):
                    skills=monster.skills, saves=monster.saves, resistances=monster.resistances,
                    spellbook=monster.spellbook, ac=ac, max_hp=hp,
                    # monster specific
-                   monster_name=monster_name)
+                   monster_name=monster_name, cr=cr)
 
     @classmethod
     def from_dict(cls, raw, ctx, combat):
         inst = super(MonsterCombatant, cls).from_dict(raw, ctx, combat)
         inst._monster_name = raw['monster_name']
+        inst._cr = raw['cr']
         return inst
 
     @property
     def monster_name(self):
         return self._monster_name
 
+    @property
+    def cr(self):
+        verbose = ['1/8', '1/4', '1/2']
+        if self._cr in verbose:
+            int_cr = [.125, .25, .5][verbose.index(self._cr)]
+        else:
+            int_cr = int(self._cr) or float(self._cr)
+        return int_cr
+
     def to_dict(self):
         raw = super(MonsterCombatant, self).to_dict()
         raw['monster_name'] = self.monster_name
+        raw['cr'] = self.cr
         raw['type'] = 'monster'
         return raw
 


### PR DESCRIPTION
### Summary
Allows access to skills, cr, and actual monster name from within scripting.

#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
