### PR TITLE
Fix `-custom` attacks w/ automation

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -17,6 +17,7 @@ from cogs5e.models.character import Character
 from cogs5e.models.embeds import EmbedWithAuthor, EmbedWithCharacter
 from cogs5e.models.errors import InvalidArgument, SelectionException
 from cogs5e.models.initiative import Combat, Combatant, CombatantGroup, Effect, MonsterCombatant, PlayerCombatant
+from cogs5e.models.sheet.attack import Attack, old_to_automation
 from cogs5e.models.sheet.base import Resistances, Skill
 from cogsmisc.stats import Stats
 from utils.argparser import argparse, argsplit
@@ -964,7 +965,7 @@ class InitTracker(commands.Cog):
         # attack selection
         attacks = combatant.attacks
         if 'custom' in args:
-            attack = {'attackBonus': '0', 'damage': '0', 'name': atk_name}
+            attack = Attack(atk_name, old_to_automation(bonus=0, damage=0))
         else:
             try:
                 attack = await search_and_select(ctx, attacks, atk_name, lambda a: a.name,

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -17,7 +17,7 @@ from cogs5e.models.character import Character
 from cogs5e.models.embeds import EmbedWithAuthor, EmbedWithCharacter
 from cogs5e.models.errors import InvalidArgument, SelectionException
 from cogs5e.models.initiative import Combat, Combatant, CombatantGroup, Effect, MonsterCombatant, PlayerCombatant
-from cogs5e.models.sheet.attack import Attack, old_to_automation
+from cogs5e.models.sheet.attack import Attack
 from cogs5e.models.sheet.base import Resistances, Skill
 from cogsmisc.stats import Stats
 from utils.argparser import argparse, argsplit

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -965,7 +965,7 @@ class InitTracker(commands.Cog):
         # attack selection
         attacks = combatant.attacks
         if 'custom' in args:
-            attack = Attack(atk_name, old_to_automation(bonus=0, damage='0'))
+            attack = Attack.new(name=atk_name, bonus_calc='', damage_calc='0')
         else:
             try:
                 attack = await search_and_select(ctx, attacks, atk_name, lambda a: a.name,

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -965,7 +965,7 @@ class InitTracker(commands.Cog):
         # attack selection
         attacks = combatant.attacks
         if 'custom' in args:
-            attack = Attack.new(name=atk_name, bonus_calc='', damage_calc='0')
+            attack = Attack.new(name=atk_name, bonus_calc='0', damage_calc='0')
         else:
             try:
                 attack = await search_and_select(ctx, attacks, atk_name, lambda a: a.name,

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -965,7 +965,7 @@ class InitTracker(commands.Cog):
         # attack selection
         attacks = combatant.attacks
         if 'custom' in args:
-            attack = Attack(atk_name, old_to_automation(bonus=0, damage=0))
+            attack = Attack(atk_name, old_to_automation(bonus=0, damage='0'))
         else:
             try:
                 attack = await search_and_select(ctx, attacks, atk_name, lambda a: a.name,


### PR DESCRIPTION
### Summary
Fixes `-custom` attacks in initiative by creating an automation object. 
The old implementation was returning:

```py
Error: Command raised an exception: AttributeError: 'dict' object has no attribute 'name'
```

### Checklist
#### PR Type
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
