### PR TITLE
Adds a `fullname` arg to `!init madd`

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -178,6 +178,7 @@ class InitTracker(commands.Cog):
         -n <number> - Adds more than one of that monster.
         -p <value> - Places combatant at the given value, instead of rolling.
         -name <name> - Sets the combatant's name. Use "#" for auto-numbering, e.g. "Orc#"
+        fullname - Uses the full name of the monster with number appended, e.g. "Goblin 1"
         -h - Hides HP, AC, Resists, etc. Default: True.
         -group <group> - Adds the combatant to a group.
         -rollhp - Rolls the monsters HP, instead of using the default value.
@@ -197,7 +198,10 @@ class InitTracker(commands.Cog):
         hp = args.last('hp', type_=int)
         ac = args.last('ac', type_=int)
         n = args.last('n', 1, int)
-        name_template = args.last('name', monster.name[:2].upper() + '#')
+        if args.last('fullname', type_=bool):
+            name_template = f"{monster.name} #"
+        else:
+            name_template = args.last('name', monster.name[:2].upper() + '#')
         init_skill = monster.skills.initiative
 
         combat = await Combat.from_ctx(ctx)


### PR DESCRIPTION
### Summary
Adds a `fullname` arg to `!init madd`, which adds the creatures using its full name instead of just the first two characters, e.g. `Goblin #`, or `Giant Goat #`


### Checklist
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
