### PR TITLE
Monster automation framework

### DIFF
--- a/cogs5e/funcs/attackutils.py
+++ b/cogs5e/funcs/attackutils.py
@@ -1,0 +1,32 @@
+from cogs5e.models import embeds
+from utils.functions import a_or_an
+
+
+async def run_attack(ctx, embed, args, caster, attack, targets, combat):
+    """Runs an attack: adds title, handles -f and -thumb args, commits combat, runs automation, edits embed."""
+    if not args.last('h', type_=bool):
+        name = caster.get_title_name()
+    else:
+        name = "An unknown creature"
+
+    if not attack.proper:
+        attack_name = a_or_an(attack.name)
+    else:
+        attack_name = attack.name
+
+    verb = attack.verb or "attacks with"
+
+    if args.last('title') is not None:
+        embed.title = args.last('title') \
+            .replace('[name]', name) \
+            .replace('[aname]', attack_name)
+    else:
+        embed.title = f'{name} {verb} {attack_name}!'
+
+    await attack.automation.run(ctx, embed, caster, targets, args, combat=combat, title=embed.title)
+    if combat:
+        await combat.final()
+
+    embeds.add_fields_from_args(embed, args.get('f'))
+    if 'thumb' in args:
+        embed.set_thumbnail(url=args.last('thumb'))

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -8,7 +8,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands import NoPrivateMessage
 
-from cogs5e.funcs import scripting, targetutils
+from cogs5e.funcs import scripting, targetutils, attackutils
 from cogs5e.funcs.dice import roll
 from cogs5e.funcs.lookupFuncs import select_monster_full, select_spell_full
 from cogs5e.funcs.scripting import helpers
@@ -1005,7 +1005,6 @@ class InitTracker(commands.Cog):
             else:
                 caster = combatant.get_combatants()[0]
 
-
         # target handling
         if 't' not in args and target_name is not None:
             # old single-target
@@ -1027,29 +1026,15 @@ class InitTracker(commands.Cog):
 
         # embed setup
         embed = discord.Embed()
-        if args.last('title') is not None:
-            embed.title = args.last('title') \
-                .replace('[name]', combatant.name) \
-                .replace('[aname]', attack.name)
-        else:
-            embed.title = '{} attacks with {}!'.format(combatant.get_title_name(), a_or_an(attack.name))
-
         if is_player:
             embed.colour = combatant.character.get_color()
         else:
             embed.colour = random.randint(0, 0xffffff)
 
         # run
-        await attack.automation.run(ctx, embed, caster, targets, args, title=embed.title)
-
-        # post-run
-        _fields = args.get('f')
-        embeds.add_fields_from_args(embed, _fields)
-        if 'thumb' in args:
-            embed.set_thumbnail(url=args.last('thumb'))
+        await attackutils.run_attack(ctx, embed, args, caster, attack, targets, combat)
 
         await ctx.send(embed=embed)
-        await combat.final()
 
     @init.command()
     async def cast(self, ctx, spell_name, *, args=''):

--- a/cogs5e/models/monster.py
+++ b/cogs5e/models/monster.py
@@ -344,6 +344,23 @@ class Monster(StatBlock):
         else:
             return self.image_url or ''
 
+    # ---- setter overrides ----
+    @property
+    def hp(self):
+        return self._hp
+
+    @hp.setter
+    def hp(self, value):
+        pass
+
+    @property
+    def temp_hp(self):
+        return self._temp_hp
+
+    @temp_hp.setter
+    def temp_hp(self, value):
+        pass
+
 
 def parse_type(_type):
     if isinstance(_type, dict):

--- a/cogs5e/models/monster.py
+++ b/cogs5e/models/monster.py
@@ -153,7 +153,7 @@ class Monster(StatBlock):
         scores.prof_bonus = _calc_prof(scores, saves, skills)
 
         source = data['source']
-        proper = bool(data.get('isNamedCreature') or data.get('isNPC'))
+        proper = bool(data.get('proper'))
 
         attacks = AttackList.from_dict(data.get('attacks', []))
         spellcasting = data.get('spellcasting', {})

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -3,9 +3,11 @@ class Attack:
     Actually an automation script.
     """
 
-    def __init__(self, name, automation):
+    def __init__(self, name, automation, verb=None, proper=False):
         self.name = name
         self.automation = automation
+        self.verb = verb
+        self.proper = proper
 
     @classmethod
     def from_dict(cls, d):
@@ -15,7 +17,8 @@ class Attack:
             return cls.from_v1(d)
 
         from cogs5e.models import automation
-        return cls(name=d['name'], automation=automation.Automation.from_data(d['automation']))
+        return cls(name=d['name'], automation=automation.Automation.from_data(d['automation']),
+                   verb=d.get('verb'), proper=d.get('proper'))
 
     @classmethod
     def from_old(cls, d):
@@ -34,7 +37,8 @@ class Attack:
         return cls(d['name'], old_to_automation(bonus, damage, d['details']))
 
     def to_dict(self):
-        return {"name": self.name, "automation": self.automation.to_dict(), "_v": 2}
+        return {"name": self.name, "automation": self.automation.to_dict(), "verb": self.verb, "proper": self.proper,
+                "_v": 2}
 
     # ---------- main funcs ----------
     @classmethod

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -12,7 +12,7 @@ import discord
 from discord.ext import commands
 from discord.ext.commands.cooldowns import BucketType
 
-from cogs5e.funcs import checkutils, targetutils
+from cogs5e.funcs import checkutils, targetutils, attackutils
 from cogs5e.funcs.scripting import helpers
 from cogs5e.models import embeds
 from cogs5e.models.character import Character
@@ -91,7 +91,7 @@ class SheetManager(commands.Cog):
         *crit* (automatically crit)
         *max* (deals max damage)
 
-        -h (hides rolled values)
+        -h (hides name and rolled values)
         -phrase [flavor text]
         -title [title] *note: [name] and [aname] will be replaced automatically*
         -thumb [url]
@@ -109,21 +109,7 @@ class SheetManager(commands.Cog):
         attack = await search_and_select(ctx, caster.attacks, atk_name, lambda a: a.name)
 
         embed = EmbedWithCharacter(char, name=False)
-        if args.last('title') is not None:
-            embed.title = args.last('title') \
-                .replace('[name]', char.name) \
-                .replace('[aname]', attack.name)
-        else:
-            embed.title = '{} attacks with {}!'.format(char.name, a_or_an(attack.name))
-
-        await attack.automation.run(ctx, embed, caster, targets, args, combat=combat, title=embed.title)
-        if combat:
-            await combat.final()
-
-        _fields = args.get('f')
-        embeds.add_fields_from_args(embed, _fields)
-        if 'thumb' in args:
-            embed.set_thumbnail(url=args.last('thumb'))
+        await attackutils.run_attack(ctx, embed, args, caster, attack, targets, combat)
 
         await ctx.send(embed=embed)
         try:

--- a/migrators/combine_monster_automation.py
+++ b/migrators/combine_monster_automation.py
@@ -1,0 +1,21 @@
+import json
+
+with open('srd-bestiary.json') as f:
+    mons = json.load(f)
+
+with open('monsters.json') as f:
+    automation = json.load(f)
+
+for monster in mons:
+    try:
+        monauto = next(m for m in automation if m['name'] == monster['name'])
+    except StopIteration:
+        print(f"Could not find automation for {monster['name']}")
+        continue
+
+    monster['attacks'] = monauto['attacks']
+
+with open('srd-bestiary-out.json', 'w') as f:
+    json.dump(mons, f, indent=2)
+
+print("Done!")


### PR DESCRIPTION
### Summary
This PR adds the framework for the full automation of monster actions. Most notably, it adds `proper` and `verb` attributes to Attacks and changes `SheetManager.attack`, `Dice.monster_attack`, and `Initiative._attack` to all use `attackutils.run_attack()`.

This change should not be breaking to any of the changed models (there are no proper nouns in the SRD monsters, either).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
