### PR TITLE
Fix missing ` in help

### DIFF
--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -81,7 +81,7 @@ class Homebrew(commands.Cog):
     async def bestiary_import(self, ctx, url):
         """Imports a published bestiary from [CritterDB](https://critterdb.com/).
         If your attacks don't seem to be importing properly, you can add a hidden line to the description to set it:
-        `<avrae hidden>NAME|TOHITBONUS|DAMAGE</avrae>"""
+        `<avrae hidden>NAME|TOHITBONUS|DAMAGE</avrae>`"""
         # ex: https://critterdb.com//#/publishedbestiary/view/5acb0aa187653a455731b890
         # https://critterdb.com/#/publishedbestiary/view/57552905f9865548206b50b0
         if not 'critterdb.com' in url:


### PR DESCRIPTION
### Summary
`!help bestiary import` has been missing a ` for some time now. This puts it back in.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
