### PR TITLE
Embed Formatting Changes

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -359,7 +359,7 @@ class GameTrack(commands.Cog):
         for level, spells in sorted(list(spells_known.items()), key=lambda k: k[0]):
             if spells:
                 spells.sort()
-                embed.add_field(name=level_name.get(level, "Unknown"), value=', '.join(spells))
+                embed.add_field(name=level_name.get(level, "Unknown"), value=', '.join(spells), inline=False)
 
         # dynamic help
         footer_out = []

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -66,7 +66,8 @@ class Lookup(commands.Cog):
                             f"a certain type.\nCategories: {categories}"
 
         for actiontype in compendium.rule_references:
-            embed.add_field(name=actiontype['fullName'], value=', '.join(a['name'] for a in actiontype['items']))
+            embed.add_field(name=actiontype['fullName'], value=', '.join(a['name'] for a in actiontype['items']),
+                            inline=False)
 
         await destination.send(embed=embed)
 
@@ -124,10 +125,10 @@ class Lookup(commands.Cog):
         embed = EmbedWithAuthor(ctx)
         embed.title = result['name']
         if result['prerequisite']:
-            embed.add_field(name="Prerequisite", value=result['prerequisite'])
+            embed.add_field(name="Prerequisite", value=result['prerequisite'], inline=False)
         if result['ability']:
             embed.add_field(name="Ability Improvement",
-                            value=f"Increase your {result['ability']} score by 1, up to a maximum of 20.")
+                            value=f"Increase your {result['ability']} score by 1, up to a maximum of 20.", inline=False)
 
         add_fields_from_long_text(embed, "Description", result['desc'])
         embed.set_footer(text=f"Feat | {result['source']} {result['page']}")
@@ -169,11 +170,7 @@ class Lookup(commands.Cog):
         if result.ability:
             embed.add_field(name="Ability Bonuses", value=result.get_asi_str())
         for t in result.get_traits():
-            f_text = t['text']
-            f_text = [f_text[i:i + 1024] for i in range(0, len(f_text), 1024)]
-            embed.add_field(name=t['name'], value=f_text[0])
-            for piece in f_text[1:]:
-                embed.add_field(name="** **", value=piece)
+            add_fields_from_long_text(embed, t['name'], t['text'])
 
         await destination.send(embed=embed)
 
@@ -236,8 +233,8 @@ class Lookup(commands.Cog):
                     level_str.append(feature.get('name'))
                 levels.append(', '.join(level_str))
 
-            embed.add_field(name="Starting Proficiencies", value=starting_profs)
-            embed.add_field(name="Starting Equipment", value=starting_items)
+            embed.add_field(name="Starting Proficiencies", value=starting_profs, inline=False)
+            embed.add_field(name="Starting Equipment", value=starting_items, inline=False)
 
             level_features_str = ""
             for i, l in enumerate(levels):
@@ -262,7 +259,7 @@ class Lookup(commands.Cog):
 
             for f in level_features:
                 text = parse_data_entry(f['entries'])
-                embed.add_field(name=f['name'], value=(text[:1019] + "...") if len(text) > 1023 else text)
+                embed.add_field(name=f['name'], value=(text[:1019] + "...") if len(text) > 1023 else text, inline=False)
 
             embed.set_footer(text=f"Use {ctx.prefix}classfeat to look up a feature if it is cut off.")
 
@@ -289,7 +286,8 @@ class Lookup(commands.Cog):
                     if not isinstance(entry, dict): continue
                     if not entry.get('type') == 'entries': continue
                     text = parse_data_entry(entry['entries'])
-                    embed.add_field(name=entry['name'], value=(text[:1019] + "...") if len(text) > 1023 else text)
+                    embed.add_field(name=entry['name'], value=(text[:1019] + "...") if len(text) > 1023 else text,
+                                    inline=False)
 
         embed.set_footer(text=f"Use {ctx.prefix}classfeat to look up a feature if it is cut off.")
 
@@ -315,7 +313,7 @@ class Lookup(commands.Cog):
             if trait['name'].lower() in ignored_fields: continue
             text = trait['text']
             text = textwrap.shorten(text, width=1020, placeholder="...")
-            embed.add_field(name=trait['name'], value=text)
+            embed.add_field(name=trait['name'], value=text, inline=False)
 
         # do stuff here
         if pm:
@@ -436,7 +434,7 @@ class Lookup(commands.Cog):
 
         def safe_append(title, desc):
             if len(desc) < 1024:
-                embed_queue[-1].add_field(name=title, value=desc)
+                embed_queue[-1].add_field(name=title, value=desc, inline=False)
             elif len(desc) < 2048:
                 # noinspection PyTypeChecker
                 # I'm adding an Embed to a list of Embeds, shut up.
@@ -566,7 +564,7 @@ class Lookup(commands.Cog):
             time = spell.time
         embed.add_field(name="Casting Time", value=time)
         embed.add_field(name="Range", value=spell.range)
-        embed.add_field(name="Components", value=spell.components)
+        embed.add_field(name="Components", value=spell.components, inline=False)
         embed.add_field(name="Duration", value=spell.duration)
 
         text = spell.description
@@ -577,7 +575,7 @@ class Lookup(commands.Cog):
         else:
             pieces = [text]
 
-        embed.add_field(name="Description", value=pieces[0])
+        embed.add_field(name="Description", value=pieces[0], inline=False)
 
         embed_queue = [embed]
         if len(pieces) > 1:
@@ -588,7 +586,7 @@ class Lookup(commands.Cog):
                 embed_queue.append(temp_embed)
 
         if higher_levels:
-            embed_queue[-1].add_field(name="At Higher Levels", value=higher_levels)
+            embed_queue[-1].add_field(name="At Higher Levels", value=higher_levels, inline=False)
 
         if spell.source == 'homebrew':
             embed_queue[-1].set_footer(text="Homebrew content.", icon_url=HOMEBREW_ICON)
@@ -707,7 +705,7 @@ class Lookup(commands.Cog):
                 if item['reqAttune'] is True:  # can be truthy, but not true
                     embed.add_field(name="Attunement", value=f"Requires Attunement")
                 else:
-                    embed.add_field(name="Attunement", value=f"Requires Attunement {item['reqAttune']}")
+                    embed.add_field(name="Attunement", value=f"Requires Attunement {item['reqAttune']}", inline=False)
 
             embed.set_footer(text=f"Item | {item.get('source', 'Unknown')} {item.get('page', 'Unknown')}")
         else:
@@ -725,10 +723,7 @@ class Lookup(commands.Cog):
         if len(text) > 5500:
             text = text[:5500] + "..."
 
-        field_name = "Description"
-        for piece in [text[i:i + 1024] for i in range(0, len(text), 1024)]:
-            embed.add_field(name=field_name, value=piece)
-            field_name = "** **"
+        add_fields_from_long_text(embed, "Description", text)
 
         if pm:
             await ctx.author.send(embed=embed)

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -564,7 +564,7 @@ class Lookup(commands.Cog):
             time = spell.time
         embed.add_field(name="Casting Time", value=time)
         embed.add_field(name="Range", value=spell.range)
-        embed.add_field(name="Components", value=spell.components, inline=False)
+        embed.add_field(name="Components", value=spell.components)
         embed.add_field(name="Duration", value=spell.duration)
 
         text = spell.description

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -137,7 +137,7 @@ class AutomationContext:
         for field in self._field_queue:
             self.embed.add_field(**field)
         for effect in self._effect_queue:
-            self.embed.add_field(name="Effect", value=effect)
+            self.embed.add_field(name="Effect", value=effect, inline=False)
         self.embed.set_footer(text='\n'.join(self._footer_queue))
 
     def add_pm(self, user, message):

--- a/cogs5e/models/embeds.py
+++ b/cogs5e/models/embeds.py
@@ -42,9 +42,13 @@ def add_fields_from_args(embed, _fields):
     """
     if type(_fields) == list:
         for f in _fields:
+            inline = False
             title = f.split('|')[0] if '|' in f else '\u200b'
             value = f.split('|', 1)[1] if '|' in f else f
-            embed.add_field(name=title, value=value)
+            if value.endswith('|inline'):
+                inline = True
+                value = value[:-7]
+            embed.add_field(name=title, value=value, inline=inline)
     return embed
 
 

--- a/cogs5e/models/embeds.py
+++ b/cogs5e/models/embeds.py
@@ -43,7 +43,7 @@ def add_fields_from_args(embed, _fields):
     if type(_fields) == list:
         for f in _fields:
             title = f.split('|')[0] if '|' in f else '\u200b'
-            value = "|".join(f.split('|')[1:]) if '|' in f else f
+            value = f.split('|', 1)[1] if '|' in f else f
             embed.add_field(name=title, value=value)
     return embed
 
@@ -64,7 +64,7 @@ def set_maybe_long_desc(embed, desc):
     desc = [desc[i:i + 1024] for i in range(0, len(desc), 1024)]
     embed.description = ''.join(desc[:2])
     for piece in desc[2:]:
-        embed.add_field(name="** **", value=piece)
+        embed.add_field(name="** **", value=piece, inline=False)
 
 
 def add_fields_from_long_text(embed, field_name, text):
@@ -77,6 +77,6 @@ def add_fields_from_long_text(embed, field_name, text):
     text = [text[i:i + 1024] for i in range(0, len(text), 1024)]
     if not text:
         return
-    embed.add_field(name=field_name, value=text[0])
+    embed.add_field(name=field_name, value=text[0], inline=False)
     for piece in text[1:]:
-        embed.add_field(name="** **", value=piece)
+        embed.add_field(name="** **", value=piece, inline=False)

--- a/cogs5e/models/spell.py
+++ b/cogs5e/models/spell.py
@@ -240,9 +240,9 @@ class Spell:
             text = self.description
             if len(text) > 1020:
                 text = f"{text[:1020]}..."
-            embed.add_field(name="Description", value=text)
+            embed.add_field(name="Description", value=text, inline=False)
             if l != self.level and self.higherlevels:
-                embed.add_field(name="At Higher Levels", value=self.higherlevels)
+                embed.add_field(name="At Higher Levels", value=self.higherlevels, inline=False)
             embed.set_footer(text="No spell automation found.")
 
         if l > 0 and not i:

--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -8,6 +8,7 @@ from math import sqrt
 import discord
 from discord.ext import commands
 
+from cogs5e.models import embeds
 from utils.argparser import argparse
 from utils.functions import clean_content
 
@@ -56,8 +57,7 @@ class PBPUtils(commands.Cog):
         except:
             pass
 
-        embed = discord.Embed()
-        embed.set_author(name=ctx.author.display_name, icon_url=ctx.author.avatar_url)
+        embed = embeds.EmbedWithAuthor(ctx)
         args = argparse(args)
         embed.title = args.last('title')
         embed.description = args.last('desc')
@@ -68,11 +68,8 @@ class PBPUtils(commands.Cog):
             embed.colour = int(args.last('color', "0").strip('#'), base=16)
         except:
             pass
-        for f in args.get('f'):
-            if f:
-                title = f.split('|')[0] if '|' in f else '\u200b'
-                value = "|".join(f.split('|')[1:]) if '|' in f else f
-                embed.add_field(name=title, value=value)
+
+        embeds.add_fields_from_args(embed, args.get('f'))
 
         timeout = 0
         if 't' in args:

--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -43,14 +43,16 @@ class PBPUtils(commands.Cog):
     @commands.command()
     async def embed(self, ctx, *, args):
         """Creates and prints an Embed.
-        Arguments: -title [title]
-        -desc [description text]
-        -thumb [image url]
-        -image [image url]
-        -footer [footer text]
-        -f ["Field Title|Field Text"]
-        -color [hex color]
-        -t [timeout (0..600)]
+        __Valid Arguments__
+        -title <title>
+        -desc <description text>
+        -thumb <image url>
+        -image <image url>
+        -footer <footer text>
+        -f "<Field Title>|<Field Text>[|inline]"
+            (e.g. "Donuts|I have 15 donuts|inline" for an inline field, or "Donuts|I have 15 donuts" for one with its own line.)
+        -color <hex color>
+        -t <timeout (0..600)>
         """
         try:
             await ctx.message.delete()

--- a/tests/cogs5e/dice_test.py
+++ b/tests/cogs5e/dice_test.py
@@ -34,7 +34,7 @@ async def test_ma(avrae, dhttp):
     await dhttp.receive_delete()
     atk_embed = discord.Embed(title=r"(\w+ ?){2,3} attacks with a Dagger!")
     atk_embed.add_field(name="Meta", inline=False, value=ATTACK_PATTERN)
-    atk_embed.add_field(name="Effect", value=r"Melee Weapon Attack:.+")
+    atk_embed.add_field(name="Effect", inline=False, value=r"Melee Weapon Attack:.+")
     await dhttp.receive_message(embed=atk_embed)
 
     avrae.message("!ma kobold dagger -h")

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -310,7 +310,7 @@ async def get_selection(ctx, choices, delete=True, pm=False, message=None, force
         embed.description = selectStr
         embed.colour = random.randint(0, 0xffffff)
         if message:
-            embed.add_field(name="Note", value=message)
+            embed.add_field(name="Note", value=message, inline=False)
         if selectMsg:
             try:
                 await selectMsg.delete()
@@ -321,7 +321,7 @@ async def get_selection(ctx, choices, delete=True, pm=False, message=None, force
         else:
             embed.add_field(name="Instructions",
                             value="Type your response in the channel you called the command. This message was PMed to "
-                                  "you to hide the monster name.")
+                                  "you to hide the monster name.", inline=False)
             selectMsg = await ctx.author.send(embed=embed)
 
         try:


### PR DESCRIPTION
### Summary
In the latest Discord update, the layout of inline fields in embeds was changed to force inline fields into a column instead of allowing them to dynamically choose a size. This PR explicitly sets some fields to be non-inline.

Additionally, this adds the ability for `!embed` to add inline fields, with `-f title|desc|inline`.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
