### PR TITLE
Add a `-reset_to` arg to counter creation

### DIFF
--- a/cogs5e/funcs/scripting/evaluators.py
+++ b/cogs5e/funcs/scripting/evaluators.py
@@ -154,10 +154,10 @@ class ScriptingEvaluator(EvalWithCompoundTypes):
             self.character_changed = True
 
         def create_cc_nx(name: str, minVal: str = None, maxVal: str = None, reset: str = None,
-                         dispType: str = None):
+                         dispType: str = None, reset_to: str = None):
             if not cc_exists(name):
                 from cogs5e.models.sheet.player import CustomCounter
-                new_consumable = CustomCounter.new(character, name, minVal, maxVal, reset, dispType)
+                new_consumable = CustomCounter.new(character, name, minVal, maxVal, reset, dispType, reset_to=reset_to)
                 character.consumables.append(new_consumable)
                 self.character_changed = True
 

--- a/cogs5e/funcs/scripting/legacy.py
+++ b/cogs5e/funcs/scripting/legacy.py
@@ -61,7 +61,7 @@ class LegacyRawCharacter:
         for counter in self.character.consumables:
             out[counter.name] = {
                 'value': counter.value, 'max': counter.max, 'min': counter.min, 'reset': counter.reset_on,
-                'type': counter.display_type
+                'type': counter.display_type, 'reset_to': counter.reset_to
             }
         return {"custom": out}
 

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -116,7 +116,7 @@ class GameTrack(commands.Cog):
             raise ValueError(f"Invalid rest type: {rest_type}")
 
         if '-h' in args:
-            values = ', '.join(set(ctr.name for ctr, _ in reset) | {"Hit Points", "Death Saves", "Spell Slots"})
+            values = ', '.join(set(ctr.name for ctr, _, _ in reset) | {"Hit Points", "Death Saves", "Spell Slots"})
             embed.add_field(name="Reset Values", value=values)
         else:
             # hp

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -349,19 +349,20 @@ class Character(StatBlock):
             self.death_saves.reset()
         return reset
 
-    def short_rest(self):
+    def short_rest(self, counter: bool = True):
         """
         Returns a list of all the reset counters and their deltas in [(counter, delta)].
         Resets but does not return Spell Slots or Death Saves.
         """
         reset = []
         reset.extend(self.on_hp())
-        reset.extend(self._reset_custom('short'))
+        if counter:
+            reset.extend(self._reset_custom('short'))
         if self.get_setting('srslots', False):
             self.reset_spellslots()
         return reset
 
-    def long_rest(self):
+    def long_rest(self, counter: bool = False):
         """
         Resets all applicable consumables.
         Returns a list of all the reset counters and their deltas in [(counter, delta)].
@@ -369,7 +370,7 @@ class Character(StatBlock):
         """
         reset = []
         reset.extend(self.on_hp())
-        reset.extend(self.short_rest())
+        reset.extend(self.short_rest(counter=not counter))
         reset.extend(self._reset_custom('long'))
         self.reset_hp()
         if not self.get_setting('srslots', False):
@@ -383,8 +384,8 @@ class Character(StatBlock):
         """
         reset = []
         reset.extend(self.on_hp())
-        reset.extend(self.short_rest())
-        reset.extend(self.long_rest())
+        reset.extend(self.short_rest(counter=False))
+        reset.extend(self.long_rest(counter=False))
         reset.extend(self._reset_custom(None))
         return reset
 

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -167,14 +167,14 @@ class CustomCounter:
         return self._max
 
     def get_reset(self):
-    if self._reset_to is None:
-        if self.reset_to is None:
-            return self.get_max(), True
-        else:
-            self._reset_to = self.evaluator.parse(self.reset_to)
-            _reset = roll(self._reset_to)
-            self._reset_type = all(isinstance(i, Constant) for i in _reset.raw_dice.parts)
-    return self._reset_to, self._reset_type
+        if self._reset_to is None:
+            if self.reset_to is None:
+                return self.get_max(), True
+            else:
+                self._reset_to = self.evaluator.parse(self.reset_to)
+                _reset = roll(self._reset_to)
+                self._reset_type = all(isinstance(i, Constant) for i in _reset.raw_dice.parts)
+        return self._reset_to, self._reset_type
 
     @property
     def value(self):

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -193,7 +193,7 @@ class CustomCounter:
         if self.live_id:
             self._character.sync_consumable(self)
 
-        def reset(self):
+    def reset(self):
         if self.reset_on == 'none' or self.max is None:
             raise NoReset()
         if self.reset_to is None:


### PR DESCRIPTION
### Summary
This adds a `-reset_to` argument to counter creation, allowing users to have reset counters to something other than max, or change it by a relative amount, such as a dice roll.

Fulfills AFR-265- #450  

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
