### PR TITLE
Modify snippet/alias display

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -188,7 +188,8 @@ class Customization(commands.Cog):
 
         await self.bot.mdb.aliases.update_one({"owner": str(ctx.author.id), "name": alias_name},
                                               {"$set": {"commands": cmds.lstrip('!')}}, True)
-        await ctx.send(f'Alias `{ctx.prefix}{alias_name}` added for command:\n`{ctx.prefix}{cmds.lstrip("!")}`')
+        await ctx.send(f'Alias `{ctx.prefix}{alias_name}` added for command:'
+                       f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```')
 
     @alias.command(name='list')
     async def alias_list(self, ctx):
@@ -247,7 +248,8 @@ class Customization(commands.Cog):
 
         await self.bot.mdb.servaliases.update_one({"server": str(ctx.guild.id), "name": alias_name},
                                                   {"$set": {"commands": cmds.lstrip('!')}}, True)
-        await ctx.send(f'Server alias `{ctx.prefix}{alias_name}` added for command:\n`{ctx.prefix}{cmds.lstrip("!")}`')
+        await ctx.send(f'Server alias `{ctx.prefix}{alias_name}` added for command:'
+                       f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```')
 
     @servalias.command(name='list')
     @commands.guild_only()
@@ -289,15 +291,14 @@ class Customization(commands.Cog):
         user_snippets = await helpers.get_snippets(ctx)
 
         if snippet is None:
-            return await ctx.send(f'**{snipname}**:\n'
-                                  f'(Copy-pastable)```md\n'
+            return await ctx.send(f'**{snipname}**:```py\n'
                                   f'{ctx.prefix}snippet {snipname} {user_snippets.get(snipname, "Not defined.")}'
                                   f'\n```')
 
         if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
         await self.bot.mdb.snippets.update_one({"owner": str(ctx.author.id), "name": snipname},
                                                {"$set": {"snippet": snippet}}, True)
-        await ctx.send('Shortcut {} added for arguments:\n`{}`'.format(snipname, snippet))
+        await ctx.send(f'Snippet {snipname} added for arguments:```py\n{ctx.prefix}snippet {snippet}\n```')
 
     @snippet.command(name='list')
     async def snippet_list(self, ctx):
@@ -339,16 +340,15 @@ class Customization(commands.Cog):
         server_snippets = await helpers.get_servsnippets(ctx)
 
         if snippet is None:
-            return await ctx.send(f'**{snipname}**:\n'
-                                  f'(Copy-pastable)```md\n'
-                                  f'{ctx.prefix}snippet {snipname} {server_snippets.get(snipname, "Not defined.")}\n'
-                                  f'```')
+            return await ctx.send(f'**{snipname}**:```py\n'
+                                  f'{ctx.prefix}snippet {snipname} {server_snippets.get(snipname, "Not defined.")}'
+                                  f'\n```')
 
         if self.can_edit_servaliases(ctx):
             if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
             await self.bot.mdb.servsnippets.update_one({"server": server_id, "name": snipname},
                                                        {"$set": {"snippet": snippet}}, True)
-            await ctx.send('Server snippet {} added for arguments:\n`{}`'.format(snipname, snippet))
+            await ctx.send(f'Server snippet {snipname} added for arguments:```py\n{ctx.prefix}snippet {snippet}\n```')
         else:
             return await ctx.send("You do not have permission to edit server snippets. Either __Administrator__ "
                                   "Discord permissions or a role named \"Server Aliaser\" or \"Dragonspeaker\" "

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -187,7 +187,7 @@ class Customization(commands.Cog):
             out = f'**{alias_name}**: ```py\n{alias}\n```'
             out = out if len(out) <= 2000 else f'**{alias_name}**:\nCommand output too long to display.\n' \
                                                f'You can view your personal aliases (and more) on the dashboard.\n' \
-                                               f'https://avrae.io/dashboard/aliases'
+                                               f'<https://avrae.io/dashboard/aliases>'
             return await ctx.send(out)
 
         await self.bot.mdb.aliases.update_one({"owner": str(ctx.author.id), "name": alias_name},
@@ -199,7 +199,7 @@ class Customization(commands.Cog):
         out = out if len(out) <= 2000 else f'Alias `{ctx.prefix}{alias_name}` added.\n' \
                                            f'Command output too long to display.\n' \
                                            f'You can view your personal aliases (and more) on the dashboard.\n' \
-                                           f'https://avrae.io/dashboard/aliases'
+                                           f'<https://avrae.io/dashboard/aliases>'
         await ctx.send(out)
 
     @alias.command(name='list')
@@ -315,7 +315,7 @@ class Customization(commands.Cog):
             out = out if len(out) <= 2000 else f'**{snipname}**:\n' \
                                                f'Command output too long to display.\n' \
                                                f'You can view your personal snippets (and more) on the dashboard.\n' \
-                                               f'https://avrae.io/dashboard/aliases'
+                                               f'<https://avrae.io/dashboard/aliases>'
             return await ctx.send(out)
 
         if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
@@ -326,7 +326,7 @@ class Customization(commands.Cog):
         out = out if len(out) <= 2000 else f'Snippet {snipname} added.\n' \
                                            f'Command output too long to display.\n' \
                                            f'You can view your personal snippets (and more) on the dashboard.\n' \
-                                           f'https://avrae.io/dashboard/aliases'
+                                           f'<https://avrae.io/dashboard/aliases>'
         await ctx.send(out)
 
     @snippet.command(name='list')

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -183,13 +183,23 @@ class Customization(commands.Cog):
             if alias is None:
                 alias = 'Not defined.'
             else:
-                alias = f'{ctx.prefix}alias {alias_name} {alias}'
-            return await ctx.send(f'**{alias_name}**: ```py\n{alias}\n```')
+                alias = f'{ctx.prefix}alias {alias_name} {alias}'            out = f'**{alias_name}**: ```py\n{alias}\n```'
+            out = out if len(out) <= 2000 else f'**{alias_name}**:\nCommand output too long to display.\n' \
+                                               f'You can view your personal aliases (and more) on the dashboard.\n' \
+                                               f'https://avrae.io/dashboard/aliases'
+            return await ctx.send(out)
 
         await self.bot.mdb.aliases.update_one({"owner": str(ctx.author.id), "name": alias_name},
                                               {"$set": {"commands": cmds.lstrip('!')}}, True)
-        await ctx.send(f'Alias `{ctx.prefix}{alias_name}` added for command:'
-                       f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```')
+
+        out = f'Alias `{ctx.prefix}{alias_name}` added for command:' \
+              f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```'
+
+        out = out if len(out) <= 2000 else f'Alias `{ctx.prefix}{alias_name}` added.\n' \
+                                           f'Command output too long to display.\n' \
+                                           f'You can view your personal aliases (and more) on the dashboard.\n' \
+                                           f'https://avrae.io/dashboard/aliases'
+        await ctx.send(out)
 
     @alias.command(name='list')
     async def alias_list(self, ctx):
@@ -239,7 +249,10 @@ class Customization(commands.Cog):
                 alias = 'Not defined.'
             else:
                 alias = f'{ctx.prefix}alias {alias_name} {alias}'
-            return await ctx.send(f'**{alias_name}**: ```py\n{alias}\n```')
+            out = f'**{alias_name}**: ```py\n{alias}\n```'
+            out = out if len(out) <= 2000 else f'Servalias `{ctx.prefix}{alias_name}` added.\n' \
+                                               f'Command output too long to display.'
+            return await ctx.send(out)
 
         if not self.can_edit_servaliases(ctx):
             return await ctx.send("You do not have permission to edit server aliases. Either __Administrator__ "
@@ -248,8 +261,12 @@ class Customization(commands.Cog):
 
         await self.bot.mdb.servaliases.update_one({"server": str(ctx.guild.id), "name": alias_name},
                                                   {"$set": {"commands": cmds.lstrip('!')}}, True)
-        await ctx.send(f'Server alias `{ctx.prefix}{alias_name}` added for command:'
-                       f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```')
+
+        out = f'Server alias `{ctx.prefix}{alias_name}` added for command:' \
+              f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```'
+        out = out if len(out) <= 2000 else f'Servalias `{ctx.prefix}{alias_name}` added.\n' \
+                                           f'Command output too long to display.'
+        await ctx.send(out)
 
     @servalias.command(name='list')
     @commands.guild_only()
@@ -291,14 +308,25 @@ class Customization(commands.Cog):
         user_snippets = await helpers.get_snippets(ctx)
 
         if snippet is None:
-            return await ctx.send(f'**{snipname}**:```py\n'
-                                  f'{ctx.prefix}snippet {snipname} {user_snippets.get(snipname, "Not defined.")}'
-                                  f'\n```')
+            out = f'**{snipname}**:```py\n' \
+                  f'{ctx.prefix}snippet {snipname} {user_snippets.get(snipname, "Not defined.")}'\
+                  f'\n```'
+            out = out if len(out) <= 2000 else f'**{snipname}**:\n' \
+                                               f'Command output too long to display.\n' \
+                                               f'You can view your personal snippets (and more) on the dashboard.\n' \
+                                               f'https://avrae.io/dashboard/aliases'
+            return await ctx.send(out)
 
         if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
         await self.bot.mdb.snippets.update_one({"owner": str(ctx.author.id), "name": snipname},
                                                {"$set": {"snippet": snippet}}, True)
-        await ctx.send(f'Snippet {snipname} added for arguments:```py\n{ctx.prefix}snippet {snippet}\n```')
+        out = f'Snippet {snipname} added for arguments:```py\n' \
+              f'{ctx.prefix}snippet {snippet}\n```'
+        out = out if len(out) <= 2000 else f'Snippet {snipname} added.\n' \
+                                           f'Command output too long to display.\n' \
+                                           f'You can view your personal snippets (and more) on the dashboard.\n' \
+                                           f'https://avrae.io/dashboard/aliases'
+        await ctx.send(out)
 
     @snippet.command(name='list')
     async def snippet_list(self, ctx):
@@ -340,15 +368,23 @@ class Customization(commands.Cog):
         server_snippets = await helpers.get_servsnippets(ctx)
 
         if snippet is None:
-            return await ctx.send(f'**{snipname}**:```py\n'
-                                  f'{ctx.prefix}snippet {snipname} {server_snippets.get(snipname, "Not defined.")}'
-                                  f'\n```')
+            out = f'**{snipname}**:```py\n' \
+                  f'{ctx.prefix}snippet {snipname} {server_snippets.get(snipname, "Not defined.")}' \
+                  f'\n```'
+            out = out if len(out) <= 2000 else f'**{snipname}**:\n' \
+                                               f'Command output too long to display.'
+            return await ctx.send(out)
 
         if self.can_edit_servaliases(ctx):
             if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
             await self.bot.mdb.servsnippets.update_one({"server": server_id, "name": snipname},
                                                        {"$set": {"snippet": snippet}}, True)
-            await ctx.send(f'Server snippet {snipname} added for arguments:```py\n{ctx.prefix}snippet {snippet}\n```')
+            out = f'Server snippet {snipname} added for arguments:```py\n' \
+                           f'{ctx.prefix}snippet {snippet}' \
+                           f'\n```'
+            out = out if len(out) <= 2000 else f'Server snippet {snipname} added.\n' \
+                                               f'Command output too long to display.'
+            await ctx.send(out)
         else:
             return await ctx.send("You do not have permission to edit server snippets. Either __Administrator__ "
                                   "Discord permissions or a role named \"Server Aliaser\" or \"Dragonspeaker\" "

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -183,7 +183,8 @@ class Customization(commands.Cog):
             if alias is None:
                 alias = 'Not defined.'
             else:
-                alias = f'{ctx.prefix}alias {alias_name} {alias}'            out = f'**{alias_name}**: ```py\n{alias}\n```'
+                alias = f'{ctx.prefix}alias {alias_name} {alias}'
+            out = f'**{alias_name}**: ```py\n{alias}\n```'
             out = out if len(out) <= 2000 else f'**{alias_name}**:\nCommand output too long to display.\n' \
                                                f'You can view your personal aliases (and more) on the dashboard.\n' \
                                                f'https://avrae.io/dashboard/aliases'

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -193,8 +193,8 @@ class Customization(commands.Cog):
         await self.bot.mdb.aliases.update_one({"owner": str(ctx.author.id), "name": alias_name},
                                               {"$set": {"commands": cmds.lstrip('!')}}, True)
 
-        out = f'Alias `{ctx.prefix}{alias_name}` added for command:' \
-              f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```'
+        out = f'Alias `{ctx.prefix}{alias_name}` added.' \
+              f'```py\n{ctx.prefix}alias {alias_name} {cmds.lstrip("!")}\n```'
 
         out = out if len(out) <= 2000 else f'Alias `{ctx.prefix}{alias_name}` added.\n' \
                                            f'Command output too long to display.\n' \
@@ -251,7 +251,7 @@ class Customization(commands.Cog):
             else:
                 alias = f'{ctx.prefix}alias {alias_name} {alias}'
             out = f'**{alias_name}**: ```py\n{alias}\n```'
-            out = out if len(out) <= 2000 else f'Servalias `{ctx.prefix}{alias_name}` added.\n' \
+            out = out if len(out) <= 2000 else f'Servalias `{ctx.prefix}{alias_name}`.\n' \
                                                f'Command output too long to display.'
             return await ctx.send(out)
 
@@ -263,8 +263,8 @@ class Customization(commands.Cog):
         await self.bot.mdb.servaliases.update_one({"server": str(ctx.guild.id), "name": alias_name},
                                                   {"$set": {"commands": cmds.lstrip('!')}}, True)
 
-        out = f'Server alias `{ctx.prefix}{alias_name}` added for command:' \
-              f'```py\n{ctx.prefix}{alias_name} {cmds.lstrip("!")}\n```'
+        out = f'Server alias `{ctx.prefix}{alias_name}` added.' \
+              f'```py\n{ctx.prefix}alias {alias_name} {cmds.lstrip("!")}\n```'
         out = out if len(out) <= 2000 else f'Servalias `{ctx.prefix}{alias_name}` added.\n' \
                                            f'Command output too long to display.'
         await ctx.send(out)
@@ -321,8 +321,9 @@ class Customization(commands.Cog):
         if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
         await self.bot.mdb.snippets.update_one({"owner": str(ctx.author.id), "name": snipname},
                                                {"$set": {"snippet": snippet}}, True)
-        out = f'Snippet {snipname} added for arguments:```py\n' \
-              f'{ctx.prefix}snippet {snippet}\n```'
+
+        out = f'Snippet {snipname} added.```py\n' \
+              f'{ctx.prefix}snippet {snipname} {snippet}\n```'
         out = out if len(out) <= 2000 else f'Snippet {snipname} added.\n' \
                                            f'Command output too long to display.\n' \
                                            f'You can view your personal snippets (and more) on the dashboard.\n' \
@@ -380,8 +381,8 @@ class Customization(commands.Cog):
             if len(snipname) < 2: return await ctx.send("Snippets must be at least 2 characters long!")
             await self.bot.mdb.servsnippets.update_one({"server": server_id, "name": snipname},
                                                        {"$set": {"snippet": snippet}}, True)
-            out = f'Server snippet {snipname} added for arguments:```py\n' \
-                           f'{ctx.prefix}snippet {snippet}' \
+            out = f'Server snippet {snipname} added.```py\n' \
+                           f'{ctx.prefix}snippet {snipname} {snippet}' \
                            f'\n```'
             out = out if len(out) <= 2000 else f'Server snippet {snipname} added.\n' \
                                                f'Command output too long to display.'

--- a/tests/mixed/aliasing_mixed_test.py
+++ b/tests/mixed/aliasing_mixed_test.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.asyncio
 class TestSimpleAliases:
     async def test_echo_alias(self, avrae, dhttp):
         avrae.message("!alias foobar echo foobar")
-        await dhttp.receive_message("Alias `!foobar` added for command:```py\n!foobar echo foobar\n```")
+        await dhttp.receive_message("Alias `!foobar` added.```py\n!alias foobar echo foobar\n```")
         avrae.message("!foobar")
         await dhttp.receive_delete()
         await dhttp.receive_message(".+: foobar")

--- a/tests/mixed/aliasing_mixed_test.py
+++ b/tests/mixed/aliasing_mixed_test.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.asyncio
 class TestSimpleAliases:
     async def test_echo_alias(self, avrae, dhttp):
         avrae.message("!alias foobar echo foobar")
-        await dhttp.receive_message("Alias `!foobar` added for command:\n`!echo foobar`")
+        await dhttp.receive_message("Alias `!foobar` added for command:```py\n!foobar echo foobar\n```")
         avrae.message("!foobar")
         await dhttp.receive_delete()
         await dhttp.receive_message(".+: foobar")


### PR DESCRIPTION
### Summary
Modifies the output of the `!snippet`, `!servsnippet`, `!alias`, and `!servalias` commands when displaying snippets/aliases, both on creation and during look up. This keeps everything consistent, and within proper code blocks, hopefully reducing the amount of miss-copied aliases/snippets.

#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.

![Image](https://media.discordapp.net/attachments/558409101051297799/649415616326795304/Screenshot_20191127-180536_Discord.jpg?width=258&height=677)