### PR TITLE
fix warforged ac value

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -393,10 +393,6 @@ class BeyondSheetParser(SheetLoaderABC):
         # Dual Wielder feat
         miscBonus += self.get_stat('dual-wield-armor-class')
 
-        # Warforged: Integrated Protection
-        if "Integrated Protection" in self._all_features:
-            miscBonus += self.get_stats().prof_bonus
-
         if armortype == 'Medium Armor':
             maxDexBonus = 2
         elif armortype == 'Heavy Armor' or self.get_race() == 'Tortle':  # HACK - tortle natural armor


### PR DESCRIPTION
### Summary
This PR fixes the warforged AC calculation. I did not see an open issue for this but if necessary I can make one.

This is the official Warforged description for AC calculation
<img width="926" alt="Screen Shot 2019-12-20 at 12 52 21 PM" src="https://user-images.githubusercontent.com/22303619/71291463-980e6b80-2327-11ea-8b75-5021195af0a2.png">

This is the generated character sheet from dndbeyond:
<img width="1341" alt="Screen Shot 2019-12-20 at 12 50 13 PM" src="https://user-images.githubusercontent.com/22303619/71291419-7319f880-2327-11ea-9750-535d15db1c4c.png">

Here is the character that is imported into avrae showing the extra proficiency bonus (+2) being erroneously added to the character's AC
<img width="670" alt="Screen Shot 2019-12-20 at 12 50 54 PM" src="https://user-images.githubusercontent.com/22303619/71291420-7319f880-2327-11ea-9d09-1415d78f3d2a.png">


### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
