### PR TITLE
Add larger(x,y) to dicecloud integration

### DIFF
--- a/cogs5e/sheets/dicecloud.py
+++ b/cogs5e/sheets/dicecloud.py
@@ -463,9 +463,12 @@ class DicecloudParser(SheetLoaderABC):
 def func_if(condition, t, f):
     return t if condition else f
 
+def larger(x, y):
+    return 1 if x > y else 0
+
 
 class DicecloudEvaluator(SimpleEval):
-    DEFAULT_FUNCTIONS = {'ceil': ceil, 'floor': floor, 'max': max, 'min': min, 'round': round, 'func_if': func_if}
+    DEFAULT_FUNCTIONS = {'ceil': ceil, 'floor': floor, 'max': max, 'min': min, 'round': round, 'func_if': func_if, 'larger': larger}
 
     def __init__(self, operators=None, functions=None, names=None):
         if not functions:


### PR DESCRIPTION
Resolves #989 

### Summary
Adding the dicecloud function "larger(x, y)" to the dicecloud parser. 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.


I have not tested the code, as I wrote the PR on the train and I'm close to where I exit. If anyone that has the testing environment setup, code can be tested by running:
!dicecloud https://dicecloud.com/character/mWSQosLimL37cmiCK/AvraeTestChar

Thanks!