### PR TITLE
Add support for Battle Master Artificer's Battle Ready feature

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -594,9 +594,9 @@ class BeyondSheetParser(SheetLoaderABC):
         
             mod_bonus = self.get_relevant_atkmod(itemdef, item_properties)
             if character_item_bonuses['isHex']:
-                mod_bonus = self.stat_from_id(6)
+                mod_bonus = max(mod_bonus, self.stat_from_id(6))
             if itemdef['magic'] and self.get_levels().get('Artificer') and "Battle Ready" in self._all_features:
-                mod_bonus = self.stat_from_id(4)
+                mod_bonus = max(mod_bonus, self.stat_from_id(4))
         
             magic_bonus = item_specific_bonuses['magicBonus']
             item_dmg_bonus = self.get_stat(f"{itemdef['type'].lower()}-damage")

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -591,8 +591,13 @@ class BeyondSheetParser(SheetLoaderABC):
                                                        item_specific_bonuses['extraProperties']]
 
             isProf = self.get_prof(itemdef['type']) or character_item_bonuses['isPact']
-            mod_bonus = self.get_relevant_atkmod(itemdef, item_properties) if not character_item_bonuses[
-                'isHex'] else self.stat_from_id(6)
+        
+            mod_bonus = self.get_relevant_atkmod(itemdef, item_properties)
+            if character_item_bonuses['isHex']:
+                mod_bonus = self.stat_from_id(6)
+            if itemdef['magic'] and self.get_levels().get('Artificer') and "Battle Ready" in self._all_features:
+                mod_bonus = self.stat_from_id(4)
+        
             magic_bonus = item_specific_bonuses['magicBonus']
             item_dmg_bonus = self.get_stat(f"{itemdef['type'].lower()}-damage")
 


### PR DESCRIPTION
### Summary
Checks if the player is an Artificer with the Battle Ready feature, and if so, uses int for their magic weapons mod bonus

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
