### PR TITLE
2020w14 - lock improvement

### DIFF
--- a/dbot.py
+++ b/dbot.py
@@ -83,11 +83,12 @@ class Avrae(commands.AutoShardedBot):
 
     async def launch_shards(self):
         # set up my shard_ids
-        await clustering.coordinate_shards(self)
-        if self.shard_ids is not None:
-            log.info(f"Launching {len(self.shard_ids)} shards! ({set(self.shard_ids)})")
-        await super(Avrae, self).launch_shards()
-        log.info(f"Launched {len(self.shards)} shards!")
+        async with clustering.coordination_lock(self.rdb):
+            await clustering.coordinate_shards(self)
+            if self.shard_ids is not None:
+                log.info(f"Launching {len(self.shard_ids)} shards! ({set(self.shard_ids)})")
+            await super(Avrae, self).launch_shards()
+            log.info(f"Launched {len(self.shards)} shards!")
 
         if self.is_cluster_0:
             await self.rdb.incr('build_num')


### PR DESCRIPTION
### Summary
Strengthens the lock during initial bot startup to avoid hitting the 1 IDENTIFY/5s ratelimit from Discord multiple times when restarting multiple clusters.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
