### PR TITLE
Update stated Python requirement to '>= 3.8.0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will need to run a Redis instance to serve as a high-performance cache. Down
 ###### MongoDB
 You will also need to run a MongoDB instance to serve as Avrae's database.
 ###### Avrae
-To actually run Avrae, you need Python version >= 3.6.0 < 3.7.
+To actually run Avrae, you need Python version >= 3.8.0.
 First, install the dependencies with `pip install -r requirements.txt`.
 
 - If running Avrae in unsharded mode (**recommended for testing**), run `python dbot.py test`.


### PR DESCRIPTION
### Summary
The Python requirement stated in the readme for hosting a local copy of Avrae did not match with the actual requirement (namely, >= 3.8.0 as opposed to >= 3.6.0 < 3.7)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
