### PR TITLE
Fix docstring for `!update` to include `-nocc`

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -388,7 +388,7 @@ class SheetManager(commands.Cog):
         """Updates the current character sheet, preserving all settings.
         __Valid Arguments__
         `-v` - Shows character sheet after update is complete.
-        `-cc` - Updates custom counters from Dicecloud."""
+        `-nocc` - Do not automatically create or update custom counters for class resources and features."""
         old_character: Character = await Character.from_ctx(ctx)
         url = old_character.upstream
         args = argparse(args)


### PR DESCRIPTION
### Summary
`!update` made reference to the removed argument `-cc` and did not mention the new `-nocc` present in `!beyond` and `!dicecloud`'s documentation. This fixes that.

Fixes #1143 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
