### PR TITLE
2020w29

### DIFF
--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -1107,7 +1107,7 @@ def _max_mapper(node):
 def _crit_mapper(node):
     """A function that doubles the number of dice for each Dice AST node."""
     if isinstance(node, d20.ast.Dice):
-        node.num *= 2
+        return d20.ast.Dice(node.num * 2, node.size)
     return node
 
 

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -727,7 +727,7 @@ class Damage(Effect):
         args = autoctx.args
         damage = self.damage
         resistances = Resistances()
-        d_arg = args.join('d', '+', ephem=True)
+        d_args = args.get('d', [], ephem=True)
         c_arg = args.join('c', '+', ephem=True)
         crit_arg = args.last('crit', None, bool, ephem=True)
         max_arg = args.last('max', None, bool, ephem=True)
@@ -752,16 +752,11 @@ class Damage(Effect):
 
         # add on combatant damage effects (#224)
         if autoctx.combatant:
-            effect_d = '+'.join(autoctx.combatant.active_effects('d'))
-            if effect_d:
-                if d_arg:
-                    d_arg = f"{d_arg}+{effect_d}"
-                else:
-                    d_arg = effect_d
+            d_args.extend(autoctx.combatant.active_effects('d'))
 
         # check if we actually need to care about the -d tag
         if self.is_meta(autoctx):
-            d_arg = None  # d was likely applied in the Roll effect already
+            d_args = []  # d was likely applied in the Roll effect already
 
         # set up damage AST
         damage = autoctx.parse_annostr(damage)
@@ -773,7 +768,7 @@ class Damage(Effect):
             dice_ast = d20.utils.tree_map(_mi_mapper(mi_arg), dice_ast)
 
         # -d #
-        if d_arg:
+        for d_arg in d_args:
             d_ast = d20.parse(d_arg)
             dice_ast.roll = d20.ast.BinOp(dice_ast.roll, '+', d_ast.roll)
 

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -728,7 +728,7 @@ class Damage(Effect):
         damage = self.damage
         resistances = Resistances()
         d_args = args.get('d', [], ephem=True)
-        c_arg = args.join('c', '+', ephem=True)
+        c_args = args.get('c', [], ephem=True)
         crit_arg = args.last('crit', None, bool, ephem=True)
         max_arg = args.last('max', None, bool, ephem=True)
         magic_arg = args.last('magical', None, bool, ephem=True)
@@ -784,9 +784,10 @@ class Damage(Effect):
                     left.num += int(critdice)
 
         # -c #
-        if c_arg and in_crit:
-            c_ast = d20.parse(c_arg)
-            dice_ast.roll = d20.ast.BinOp(dice_ast.roll, '+', c_ast.roll)
+        if in_crit:
+            for c_arg in c_args:
+                c_ast = d20.parse(c_arg)
+                dice_ast.roll = d20.ast.BinOp(dice_ast.roll, '+', c_ast.roll)
 
         # max
         if max_arg:

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -422,7 +422,10 @@ def parse_critterdb_spellcasting(traits, base_stats):
             extracted = []
             spell_names = text.split(', ')
             for name in spell_names:
-                s = name.strip('* _')
+                # remove any (parenthetical stuff) except (UA)
+                name = re.sub(r'\((?!ua\)).+\)', '', name.lower())
+
+                s = name.strip('* _').replace('.', '').replace('$', '')
 
                 try:
                     real_name = next(sp for sp in compendium.spells if sp.name.lower() == s).name

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -42,7 +42,6 @@ class Customization(commands.Cog):
 
     @commands.command()
     @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
     async def prefix(self, ctx, prefix: str = None):
         """Sets the bot's prefix for this server.
 
@@ -54,6 +53,10 @@ class Customization(commands.Cog):
         if prefix is None:
             current_prefix = await self.bot.get_server_prefix(ctx.message)
             return await ctx.send(f"My current prefix is: `{current_prefix}`")
+
+        if not checks._role_or_permissions(ctx, lambda r: r.name.lower() == 'bot admin', manage_guild=True):
+            return await ctx.send("You do not have permissions to change the guild prefix.")
+
         # insert into cache
         self.bot.prefixes[guild_id] = prefix
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ cachetools==4.0.0
 certifi==2019.6.16
 chardet==3.0.4
 coverage==4.5.4
-discord.py==1.3.3
+discord.py==1.3.4
 dnspython==1.16.0
 docutils==0.15.2
 fuzzywuzzy==0.18.0


### PR DESCRIPTION
### Summary
- Resolves #1156 (snippets damage type inheritance now prioritizes weapon damage type if another damage type is not found in the same snippet)
- Resolves #1160 
- Resolves #1159 
- Fixes an issue where rolling multiple crits in the same attack would double the damage dice each time
- Bump discord.py 


### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
