### PR TITLE
Added Death Saves to game status as well as append test for it

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -45,7 +45,8 @@ class GameTrack(commands.Cog):
         embed = EmbedWithCharacter(character)
         embed.add_field(name="Hit Points", value=character.hp_str())
         embed.add_field(name="Spell Slots", value=character.spellbook.slots_str())
-        embed.add_field(name="Death Saves", value=str(character.death_saves))
+        if character.death_saves.successes != 0 or character.death_saves.fails != 0:
+            embed.add_field(name="Death Saves", value=str(character.death_saves))
         for counter in character.consumables:
             embed.add_field(name=counter.name, value=counter.full_str())
         await ctx.send(embed=embed)

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -45,6 +45,7 @@ class GameTrack(commands.Cog):
         embed = EmbedWithCharacter(character)
         embed.add_field(name="Hit Points", value=character.hp_str())
         embed.add_field(name="Spell Slots", value=character.spellbook.slots_str())
+        embed.add_field(name="Death Saves", value=str(character.death_saves))
         for counter in character.consumables:
             embed.add_field(name=counter.name, value=counter.full_str())
         await ctx.send(embed=embed)

--- a/tests/cogs5e/gametrack_test.py
+++ b/tests/cogs5e/gametrack_test.py
@@ -111,6 +111,7 @@ class TestGame:
         status_embed.set_author(name=char.name)
         status_embed.add_field(name="Hit Points", value=r".*")
         status_embed.add_field(name="Spell Slots", value=r".*")
+        status_embed.add_field(name="Death Saves", value=r".*")
         for _ in char.consumables:
             status_embed.add_field(name=r".*", value=r".*")
         await dhttp.receive_message(embed=status_embed)

--- a/tests/cogs5e/gametrack_test.py
+++ b/tests/cogs5e/gametrack_test.py
@@ -111,7 +111,6 @@ class TestGame:
         status_embed.set_author(name=char.name)
         status_embed.add_field(name="Hit Points", value=r".*")
         status_embed.add_field(name="Spell Slots", value=r".*")
-        char = await active_character(avrae)
         if char.death_saves.successes != 0 or char.death_saves.fails != 0:
             status_embed.add_field(name="Death Saves", value=r".*")
         for _ in char.consumables:

--- a/tests/cogs5e/gametrack_test.py
+++ b/tests/cogs5e/gametrack_test.py
@@ -111,7 +111,9 @@ class TestGame:
         status_embed.set_author(name=char.name)
         status_embed.add_field(name="Hit Points", value=r".*")
         status_embed.add_field(name="Spell Slots", value=r".*")
-        status_embed.add_field(name="Death Saves", value=r".*")
+        char = await active_character(avrae)
+        if char.death_saves.successes != 0 or char.death_saves.fails != 0:
+            status_embed.add_field(name="Death Saves", value=r".*")
         for _ in char.consumables:
             status_embed.add_field(name=r".*", value=r".*")
         await dhttp.receive_message(embed=status_embed)


### PR DESCRIPTION
### Summary
Small PR that adds death save details to `!g status`. Will only show saves when they are not zero.

Resolves #1237 (AFR-620)
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
