### PR TITLE
Move Attack sort from str to initalization

### DIFF
--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -65,7 +65,7 @@ class AttackList:
     def __init__(self, attacks=None):
         if attacks is None:
             attacks = []
-        self.attacks = sorted((atk for atk in attacks), key=lambda atk: str(atk).lower())
+        self.attacks = attacks
 
     @classmethod
     def from_dict(cls, l):  # technicaly from_list, but consistency

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -65,7 +65,7 @@ class AttackList:
     def __init__(self, attacks=None):
         if attacks is None:
             attacks = []
-        self.attacks = attacks
+        self.attacks = sorted((atk for atk in attacks), key=lambda atk: str(atk).lower())
 
     @classmethod
     def from_dict(cls, l):  # technicaly from_list, but consistency
@@ -76,7 +76,7 @@ class AttackList:
 
     # utils
     def build_str(self, caster):
-        return '\n'.join(sorted((atk.build_str(caster) for atk in self.attacks), key=str.lower))
+        return '\n'.join(atk.build_str(caster) for atk in self.attacks)
 
     def __str__(self):
         return '\n'.join(str(atk) for atk in self.attacks)


### PR DESCRIPTION
### Summary
Moves attack list sorting from `str` to class initialization. This fixes the issue of attacks being in different spots in the data vs the str.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
