### PR TITLE
various workshop bugfixes

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -267,7 +267,7 @@ class SimpleCombatant(AliasStatBlock):
     @property
     def temphp(self):  # deprecated - use temp_hp instead
         """
-        .. deprecated:: 2.1.0
+        .. deprecated:: 2.5.0
             Use ``SimpleCombatant.temp_hp`` instead.
 
         How many temporary hit points the combatant has.
@@ -279,7 +279,7 @@ class SimpleCombatant(AliasStatBlock):
     @property
     def maxhp(self):  # deprecated - use max_hp instead
         """
-        .. deprecated:: 2.1.0
+        .. deprecated:: 2.5.0
             Use ``SimpleCombatant.max_hp`` instead.
 
         The combatant's maximum hit points. ``None`` if not set.
@@ -290,7 +290,7 @@ class SimpleCombatant(AliasStatBlock):
 
     def mod_hp(self, mod: int, overheal: bool = False):  # deprecated - use modify_hp instead
         """
-        .. deprecated:: 2.1.0
+        .. deprecated:: 2.5.0
             Use ``SimpleCombatant.modify_hp()`` instead.
 
         Modifies a combatant's remaining hit points by a value.
@@ -302,7 +302,7 @@ class SimpleCombatant(AliasStatBlock):
 
     def set_thp(self, thp: int):  # deprecated - use set_temp_hp
         """
-        .. deprecated:: 2.1.0
+        .. deprecated:: 2.5.0
             Use ``SimpleCombatant.set_temp_hp()`` instead.
 
         Sets the combatant's temp HP.

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -96,7 +96,7 @@ class AliasChannel:
         """
         :type channel: discord.TextChannel
         """
-        self._name = channel.name
+        self._name = str(channel)
         self._id = channel.id
         self._topic = channel.topic
 

--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -451,7 +451,7 @@ class AliasSkill:
         :param int mod_override: Overrides the skill modifier.
         :rtype: str
         """
-        return self._skill.d20(bool(base_adv), reroll, min_val, mod_override)
+        return self._skill.d20(base_adv, reroll, min_val, mod_override)
 
     def __int__(self):
         return int(self._skill)

--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -540,7 +540,7 @@ class AliasResistances:
     @property
     def vuln(self):
         """
-        A list of damage types that the stat block is resistant to.
+        A list of damage types that the stat block is vulnerable to.
 
         :rtype: list[Resistance]
         """
@@ -558,7 +558,8 @@ class AliasResistances:
     @property
     def neutral(self):
         """
-        A list of damage types that the stat block is vulnerable to.
+        A list of damage types that the stat block ignores in damage calculations. (i.e. will not handle resistances/
+        vulnerabilities/immunities)
 
         :rtype: list[Resistance]
         """

--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -367,7 +367,7 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         """
         Returns the ID of the active Discord channel.
 
-        .. deprecated:: 2.1.0
+        .. deprecated:: 2.5.0
             Use ``ctx.channel.id`` instead.
 
         :rtype: str
@@ -378,7 +378,7 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         """
         Returns the ID of the active Discord guild, or None if in DMs.
 
-        .. deprecated:: 2.1.0
+        .. deprecated:: 2.5.0
             Use ``ctx.guild.id`` instead.
 
         :rtype: str

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -579,7 +579,7 @@ class Lookup(commands.Cog):
             the_entity, the_etype = e
             if the_entity.homebrew:
                 return f"{the_entity.name} ({HOMEBREW_EMOJI})"
-            elif can_access(the_etype, available_ids[the_etype]):
+            elif can_access(the_entity, available_ids[the_etype]):
                 return the_entity.name
             return f"{the_entity.name}\\*"
 

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -445,7 +445,7 @@ Custom Counters
 
     .. function:: cc_exists(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().cc_exists()`` instead.
 
         Returns whether a custom counter exists.
@@ -456,7 +456,7 @@ Custom Counters
 
     .. function:: cc_str(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().cc_str()`` instead.
 
         Returns a string representing a custom counter.
@@ -475,7 +475,7 @@ Custom Counters
 
     .. function:: create_cc(name, minVal=None, maxVal=None, reset=None, dispType=None)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().create_cc()`` instead.
 
         Creates a custom counter. If a counter with the same name already exists, it will replace it.
@@ -488,7 +488,7 @@ Custom Counters
 
     .. function:: create_cc_nx(name, minVal=None, maxVal=None, reset=None, dispType=None)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().create_cc_nx()`` instead.
 
         Creates a custom counter if one with the given name does not already exist.
@@ -499,7 +499,7 @@ Custom Counters
 
     .. function:: delete_cc(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().delete_cc()`` instead.
 
         Deletes a custom counter.
@@ -509,7 +509,7 @@ Custom Counters
 
     .. function:: get_cc(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().get_cc()`` instead.
 
         Gets the value of a custom counter.
@@ -522,7 +522,7 @@ Custom Counters
 
     .. function:: get_cc_max(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().get_cc_max()`` instead.
 
         Gets the maximum value of a custom counter.
@@ -534,7 +534,7 @@ Custom Counters
 
     .. function:: get_cc_min(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().get_cc_min()`` instead.
 
         Gets the minimum value of a custom counter.
@@ -546,14 +546,14 @@ Custom Counters
 
     .. function:: mod_cc(name, value, strict=False)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().mod_cc()`` instead.
 
         Modifies the value of a custom counter. Equivalent to ``set_cc(name, get_cc(name) + value, strict)``.
 
     .. function:: set_cc(name, value, strict=False)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().set_cc()`` instead.
 
         Sets the value of a custom counter.
@@ -570,7 +570,7 @@ Spell Slots
 
     .. function:: get_slots(level)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().spellbook.get_slots()`` instead.
 
         Gets the number of remaining spell slots of a given level that a character has.
@@ -581,7 +581,7 @@ Spell Slots
 
     .. function:: get_slots_max(level)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().spellbook.get_slots_max()`` instead.
 
         Gets the maximum number of spell slots of a given level that a character has.
@@ -592,7 +592,7 @@ Spell Slots
 
     .. function:: set_slots(level, value)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().spellbook.set_slots()`` instead.
 
         Sets how many spell slots of a given level a character has.
@@ -603,7 +603,7 @@ Spell Slots
 
     .. function:: slots_str(level)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().spellbook.slots_str()`` instead.
 
         Returns a string representing how many spell slots a character has of a given level.
@@ -614,7 +614,7 @@ Spell Slots
 
     .. function:: use_slot(level)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().spellbook.use_slot()`` instead.
 
         Uses one spell slot of a given level. Equivalent to ``set_slots(level, get_slots(level) - 1)``.
@@ -626,7 +626,7 @@ Hit Points
 
     .. function:: get_hp()
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().hp`` instead.
 
         :returns: The character's current hit points.
@@ -634,7 +634,7 @@ Hit Points
 
     .. function:: get_temphp()
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().temp_hp`` instead.
 
         :returns: The character's current temporary hit points.
@@ -642,14 +642,14 @@ Hit Points
 
     .. function:: hp_str()
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().hp_str()`` instead.
 
         Returns a string representing a character's current HP, max HP, and temp HP.
 
     .. function:: mod_hp(value, overflow=True)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().modify_hp()`` instead.
 
         Modifies the character's remaining hit points by *value*. If *value* is negative, will deal damage to temp HP first.
@@ -659,7 +659,7 @@ Hit Points
 
     .. function:: set_hp(value)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().set_hp()`` instead.
 
         Sets the character's remaining hit points. Ignores temp HP.
@@ -668,7 +668,7 @@ Hit Points
 
     .. function:: set_temphp(value)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().set_temp_hp()`` instead.
 
         Sets the character's remaining temp HP.
@@ -686,7 +686,7 @@ Cvars
 
     .. function:: delete_cvar(name)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().delete_cvar()`` instead.
 
         Deletes a custom character variable. Does nothing if the cvar does not exist.
@@ -695,7 +695,7 @@ Cvars
 
     .. function:: set_cvar(name, value)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().set_cvar()`` instead.
 
         Sets a custom character variable, which will be available in all scripting contexts using this character.
@@ -705,7 +705,7 @@ Cvars
 
     .. function:: set_cvar_nx(name, value)
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``character().set_cvar_nx()`` instead.
 
         Sets a custom character variable if it is not already set.
@@ -720,7 +720,7 @@ Other
 
     .. function:: get_raw()
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Deprecated without replacement. Use ``character()`` to get a representation of the character instead.
 
         Returns a raw representation of character data.
@@ -794,7 +794,7 @@ SimpleCombatant
 
     .. attribute:: level
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``SimpleCombatant.levels.total_level`` or ``SimpleCombatant.spellbook.caster_level`` instead.
 
         The combatant's spellcaster level. ``0`` if the combatant is not a player or spellcaster.
@@ -803,7 +803,7 @@ SimpleCombatant
 
     .. attribute:: resists
 
-        .. deprecated:: 2.2.0
+        .. deprecated:: 2.5.0
             Use ``SimpleCombatant.resistances`` instead.
 
         The combatant's resistances, immunities, and vulnerabilities.


### PR DESCRIPTION
Cleans up some bugs in the nightly release of the workshop.

- fixes `AliasSkill.d20()` defaulting to dis
- fixes some documentation saying the wrong things
- fixes running aliases in PMs
- fixes issue where selection menus would be broken