### PR TITLE
Set init status to default to current combatant

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -738,7 +738,7 @@ class InitTracker(commands.Cog):
             await ctx.send("Combatant or group not found.")
             return
 
-        private = 'private' in args.lower()
+        private = 'private' in args.lower() or name == 'private'
         if not isinstance(combatant, CombatantGroup):
             private = private and str(ctx.author.id) == combatant.controller
             status = combatant.get_status(private=private)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -723,7 +723,8 @@ class InitTracker(commands.Cog):
 
     @init.command()
     async def status(self, ctx, name: str = '', *, args: str = ''):
-        """Gets the status of a combatant or group. If no name is specified, it will default to current combatant.
+        """Gets the status of a combatant or group.
+        If no name is specified, it will default to current combatant.
         __Valid Arguments__
         private - PMs the controller of the combatant a more detailed status."""
 

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -723,7 +723,7 @@ class InitTracker(commands.Cog):
 
     @init.command()
     async def status(self, ctx, name: str = '', *, args: str = ''):
-        """Gets the status of a combatant or group.
+        """Gets the status of a combatant or group. If no name is specified, it will default to current combatant.
         __Valid Arguments__
         private - PMs the controller of the combatant a more detailed status."""
 

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -722,12 +722,18 @@ class InitTracker(commands.Cog):
             await ctx.send("No valid options found.")
 
     @init.command()
-    async def status(self, ctx, name: str, *, args: str = ''):
+    async def status(self, ctx, name: str = '', *, args: str = ''):
         """Gets the status of a combatant or group.
         __Valid Arguments__
         private - PMs the controller of the combatant a more detailed status."""
+
         combat = await Combat.from_ctx(ctx)
-        combatant = await combat.select_combatant(name, select_group=True)
+
+        if name == 'private' or name == '':
+            combatant = combat.current_combatant
+        else:
+            combatant = await combat.select_combatant(name, select_group=True)
+
         if combatant is None:
             await ctx.send("Combatant or group not found.")
             return


### PR DESCRIPTION
### Summary
Previously `!i status` required a name, now it will default to the current combatant.

Resolves #1236 (AFR-619)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
