### PR TITLE
Allow adding combatants with starting note

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -312,6 +312,7 @@ class InitTracker(commands.Cog):
         -p <value> - Places combatant at the given value, instead of rolling.
         -h - Hides HP, AC, Resists, etc.
         -group <group> - Adds the combatant to a group.
+        -note <note> - Sets the combatant's note.
         [user snippet]
         """
         char: Character = await Character.from_ctx(ctx)
@@ -347,7 +348,7 @@ class InitTracker(commands.Cog):
 
         me = await PlayerCombatant.from_character(char, ctx, combat, controller, init, private)
 
-        # -note (#1211
+        # -note (#1211)
         if note:
             me.notes = note
 

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -111,6 +111,7 @@ class InitTracker(commands.Cog):
         -immune <damage type> - Gives the combatant immunity to the given damage type.
         -vuln <damage type> - Gives the combatant vulnerability to the given damage type.
         adv/dis - Rolls the initiative check with advantage/disadvantage.
+        -note <note> - Sets the combatant's note.
         """
         private = False
         place = None
@@ -150,6 +151,8 @@ class InitTracker(commands.Cog):
         if args.last('ac'):
             ac = args.last('ac', type_=int)
 
+        note = args.last('note')
+
         for k in ('resist', 'immune', 'vuln'):
             resists[k] = args.get(k)
 
@@ -176,6 +179,10 @@ class InitTracker(commands.Cog):
         if thp and thp > 0:
             me.temp_hp = thp
 
+        # -note (#1211)
+        if note:
+            me.notes = note
+
         if group is None:
             combat.add_combatant(me)
             await ctx.send(f"{name} was added to combat with initiative {init_roll_skeleton}.")
@@ -200,7 +207,9 @@ class InitTracker(commands.Cog):
         -rollhp - Rolls the monsters HP, instead of using the default value.
         -hp <hp> - Sets starting HP.
         -thp <thp> - Sets starting THP.
-        -ac <ac> - Sets the combatant's starting AC."""
+        -ac <ac> - Sets the combatant's starting AC.
+        -note <note> - Sets the combatant's note.
+        """
 
         monster = await select_monster_full(ctx, monster_name, pm=True)
 
@@ -216,6 +225,7 @@ class InitTracker(commands.Cog):
         thp = args.last('thp', type_=int)
         ac = args.last('ac', type_=int)
         n = args.last('n', 1, int)
+        note = args.last('note')
         name_template = args.last('name', monster.name[:2].upper() + '#')
         init_skill = monster.skills.initiative
 
@@ -268,6 +278,10 @@ class InitTracker(commands.Cog):
                 # -thp (#1142)
                 if thp and thp > 0:
                     me.temp_hp = thp
+
+                # -note (#1211)
+                if note:
+                    me.notes = note
 
                 if group is None:
                     combat.add_combatant(me)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -323,6 +323,7 @@ class InitTracker(commands.Cog):
 
         p = args.last('p', type_=int)
         group = args.last('group')
+        note = args.last('note')
 
         if p is None:
             args.ignore('rr')
@@ -345,6 +346,10 @@ class InitTracker(commands.Cog):
             return
 
         me = await PlayerCombatant.from_character(char, ctx, combat, controller, init, private)
+
+        # -note (#1211
+        if note:
+            me.notes = note
 
         if group is None:
             combat.add_combatant(me)


### PR DESCRIPTION
### Summary
Adds `-note <note>` as an argument to `!init add` and `!init madd`

Resolves #1211 (AFR-603)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
