### PR TITLE
Monster Token Project

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -393,9 +393,9 @@ class Lookup(commands.Cog):
     @commands.command()
     async def token(self, ctx, name=None, *args):
         """
-        Shows a monster's token.
+        Shows a monster or your character's token.
         __Valid Arguments__
-        -border <gold|plain> - Chooses the token border.
+        -border <gold|plain|none> - Chooses the token border.
         """
         if name is None or name.startswith('-'):
             token_cmd = self.bot.get_command('playertoken')
@@ -413,26 +413,20 @@ class Lookup(commands.Cog):
         # select border
         ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
         is_subscriber = ddb_user and ddb_user.subscriber
-        args = argparse(args)
-        border = args.last('border')
+        token_args = argparse(args)
 
         if monster.homebrew:
             # homebrew: generate token
             if not monster.get_image_url():
                 return await ctx.send("This monster has no image.")
-            border_type = img.TokenBorderEnum.GOLD if is_subscriber else img.TokenBorderEnum.PLAIN
-            if border == 'plain':
-                border_type = img.TokenBorderEnum.PLAIN
-            elif border == 'none':
-                border_type = img.TokenBorderEnum.NONE
             try:
-                image = await img.generate_token(monster.get_image_url(), border_type)
+                image = await img.generate_token(monster.get_image_url(), is_subscriber, token_args)
             except Exception as e:
                 return await ctx.send(f"Error generating token: {e}")
         else:
             # official monsters
             token_url = monster.get_token_url(is_subscriber)
-            if border == 'plain':
+            if token_args.last('border') == 'plain':
                 token_url = monster.get_token_url(False)
 
             if not token_url:

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -235,31 +235,6 @@ class Lookup(commands.Cog):
         await (await self._get_destination(ctx)).send(embed=embed)
 
     # ==== monsters ====
-    @commands.command(aliases=['monimage'])
-    async def token(self, ctx, *, name=None):
-        """Shows a monster's image."""
-
-        if name is None:
-            token_cmd = self.bot.get_command('playertoken')
-            if token_cmd is None:
-                return await ctx.send("Error: SheetManager cog not loaded.")
-            return await ctx.invoke(token_cmd)
-
-        choices = await get_monster_choices(ctx, filter_by_license=False)
-        monster = await self._lookup_search3(ctx, {'monster': choices}, name)
-        await Stats.increase_stat(ctx, "monsters_looked_up_life")
-
-        url = monster.get_image_url()
-        embed = EmbedWithAuthor(ctx)
-        embed.title = monster.name
-        embed.description = f"{monster.size} monster."
-
-        if not url:
-            return await ctx.channel.send("This monster has no image.")
-
-        embed.set_image(url=url)
-        await ctx.send(embed=embed)
-
     @commands.command()
     async def monster(self, ctx, *, name: str):
         """Looks up a monster.
@@ -395,6 +370,42 @@ class Lookup(commands.Cog):
                 await ctx.author.send(embed=embed)
             else:
                 await ctx.send(embed=embed)
+
+    async def _do_monster_image(self, ctx, name: str, image_getter):
+        """Handles an image command for a monster (monimage/token)."""
+        choices = await get_monster_choices(ctx, filter_by_license=False)
+        monster = await self._lookup_search3(ctx, {'monster': choices}, name)
+        await Stats.increase_stat(ctx, "monsters_looked_up_life")
+
+        url = image_getter(monster)
+        embed = EmbedWithAuthor(ctx)
+        embed.title = monster.name
+        embed.description = f"{monster.size} monster."
+
+        if not url:
+            return await ctx.channel.send("This monster has no image.")
+
+        embed.set_image(url=url)
+        await ctx.send(embed=embed)
+
+    @commands.command()
+    async def monimage(self, ctx, *, name=None):
+        """Shows a monster's image."""
+        await self._do_monster_image(ctx, name, lambda monster: monster.get_image_url())
+
+    @commands.command()
+    async def token(self, ctx, *, name=None):
+        """Shows a monster's token."""
+        if name is None:
+            token_cmd = self.bot.get_command('playertoken')
+            if token_cmd is None:
+                return await ctx.send("Error: SheetManager cog not loaded.")
+            return await ctx.invoke(token_cmd)
+
+        ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
+        is_subscriber = ddb_user and ddb_user.subscriber
+
+        await self._do_monster_image(ctx, name, lambda monster: monster.get_token_url(is_subscriber))
 
     # ==== spells ====
     @commands.command()

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -351,19 +351,12 @@ class SheetManager(commands.Cog):
         if not char.image:
             return await ctx.send("This character has no image.")
 
-        args = argparse(args)
-        border = args.last('border')
-
+        token_args = argparse(args)
         ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
         is_subscriber = ddb_user and ddb_user.subscriber
-        border_type = img.TokenBorderEnum.GOLD if is_subscriber else img.TokenBorderEnum.PLAIN
-        if border == 'plain':
-            border_type = img.TokenBorderEnum.PLAIN
-        elif border == 'none':
-            border_type = img.TokenBorderEnum.NONE
 
         try:
-            processed = await img.generate_token(char.image, border_type)
+            processed = await img.generate_token(char.image, is_subscriber, token_args)
         except Exception as e:
             return await ctx.send(f"Error generating token: {e}")
 

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -31,7 +31,7 @@ class Monster(StatBlock, Sourced):
                  la_per_round=3, passiveperc: int = None,
                  # augmented
                  resistances: Resistances = None, attacks: AttackList = None, proper: bool = False,
-                 image_url: str = None, spellcasting=None,
+                 image_url: str = None, spellcasting=None, token_free_fp=None, token_sub_fp=None,
                  # sourcing
                  homebrew=False, **kwargs):
         if traits is None:
@@ -89,6 +89,8 @@ class Monster(StatBlock, Sourced):
         self.la_per_round = la_per_round
         self.proper = proper
         self.image_url = image_url
+        self.token_free_fp = token_free_fp
+        self.token_sub_fp = token_sub_fp
         # resistances including notes, e.g. "Bludgeoning from nonmagical weapons"
         self._displayed_resistances = display_resists or resistances
 
@@ -115,6 +117,7 @@ class Monster(StatBlock, Sourced):
                    d['la_per_round'], d['passiveperc'],
                    # augmented
                    resistances, attacks, d['proper'], d['image_url'], spellcasting=spellcasting,
+                   token_free_fp=d['token_free'], token_sub_fp=d['token_sub'],
                    # sourcing
                    source=d['source'], entity_id=d['id'], page=d['page'], url=d['url'], is_free=d['isFree'])
 
@@ -228,6 +231,12 @@ class Monster(StatBlock, Sourced):
     def get_image_url(self):
         """Returns a monster's image URL."""
         return self.image_url or ''
+
+    def get_token_url(self, is_sub=False):
+        """Returns a monster's token URL."""
+        if is_sub:
+            return self.token_sub_fp
+        return self.token_free_fp
 
     # ---- setter overrides ----
     @property

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -6,6 +6,7 @@ from cogs5e.models.sheet.base import BaseStats, Levels, Saves, Skills
 from cogs5e.models.sheet.resistance import Resistances
 from cogs5e.models.sheet.spellcasting import Spellbook
 from cogs5e.models.sheet.statblock import StatBlock
+from utils import config
 from utils.constants import SKILL_MAP
 from utils.functions import a_or_an, bubble_format
 from .shared import Sourced
@@ -235,8 +236,8 @@ class Monster(StatBlock, Sourced):
     def get_token_url(self, is_sub=False):
         """Returns a monster's token URL."""
         if is_sub:
-            return self.token_sub_fp
-        return self.token_free_fp
+            return f"{config.MONSTER_TOKEN_ENDPOINT}/{self.token_sub_fp}"
+        return f"{config.MONSTER_TOKEN_ENDPOINT}/{self.token_free_fp}"
 
     # ---- setter overrides ----
     @property

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -235,6 +235,8 @@ class Monster(StatBlock, Sourced):
 
     def get_token_url(self, is_sub=False):
         """Returns a monster's token URL."""
+        if not self.token_free_fp:
+            return None
         if is_sub:
             return f"{config.MONSTER_TOKEN_ENDPOINT}/{self.token_sub_fp}"
         return f"{config.MONSTER_TOKEN_ENDPOINT}/{self.token_free_fp}"

--- a/tests/static/compendium/srd-bestiary.json
+++ b/tests/static/compendium/srd-bestiary.json
@@ -141,7 +141,7 @@
     "actions": [
       {
         "name": "Dagger",
-        "desc": "_Melee or_Ranged Weapon Attack:__ +5 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit:_ 4 (1d4 + 2) piercing damage."
+        "desc": "_Melee or Ranged Weapon Attack:_ +5 to hit, reach 5 ft. or range 20/60 ft., one target. _Hit:_ 4 (1d4 + 2) piercing damage."
       }
     ],
     "reactions": [],
@@ -154,7 +154,7 @@
         "2": 3,
         "3": 3,
         "4": 3,
-        "5": 0,
+        "5": 1,
         "6": 0,
         "7": 0,
         "8": 0,
@@ -165,13 +165,29 @@
         "2": 3,
         "3": 3,
         "4": 3,
-        "5": 0,
+        "5": 1,
         "6": 0,
         "7": 0,
         "8": 0,
         "9": 0
       },
       "spells": [
+        {
+          "name": "Fire Bolt",
+          "strict": true
+        },
+        {
+          "name": "Light",
+          "strict": true
+        },
+        {
+          "name": "Mage Hand",
+          "strict": true
+        },
+        {
+          "name": "Prestidigitation",
+          "strict": true
+        },
         {
           "name": "Detect Magic",
           "strict": true
@@ -215,6 +231,10 @@
         {
           "name": "Ice Storm",
           "strict": true
+        },
+        {
+          "name": "Cone of Cold",
+          "strict": true
         }
       ],
       "dc": 14,
@@ -229,6 +249,8 @@
       "immune": [],
       "vuln": []
     },
+    "token_free": null,
+    "token_sub": null,
     "attacks": [
       {
         "name": "Dagger",
@@ -425,6 +447,8 @@
       "immune": [],
       "vuln": []
     },
+    "token_free": "16939-f.png",
+    "token_sub": "16939-s.png",
     "attacks": [
       {
         "name": "Dagger",
@@ -648,6 +672,8 @@
       "immune": [],
       "vuln": []
     },
+    "token_free": "16939-f.png",
+    "token_sub": "16939-s.png",
     "attacks": [
       {
         "name": "Dagger",

--- a/utils/config.py
+++ b/utils/config.py
@@ -11,6 +11,7 @@ NUM_SHARDS = int(os.getenv('NUM_SHARDS')) if 'NUM_SHARDS' in os.environ else Non
 RELOAD_INTERVAL = os.getenv('RELOAD_INTERVAL', '0')  # compendium static data reload interval
 ECS_METADATA_ENDPT = os.getenv('ECS_CONTAINER_METADATA_URI')  # set by ECS
 OWNER_ID = int(os.getenv('DISCORD_OWNER_USER_ID', 0))
+MONSTER_TOKEN_ENDPOINT = os.getenv('MONSTER_TOKEN_ENDPOINT')  # S3: monster tokens
 
 # ---- mongo/redis ----
 MONGO_URL = os.getenv('MONGO_URL', "mongodb://localhost:27017")

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -47,7 +47,8 @@ SOURCE_MAP = {
     'IMR': 'Infernal Machine Rebuild', 'MFFV1': "Mordenkainen's Fiendish Folio Volume 1", 'SD': 'Sapphire Dragon',
     'EGtW': "Explorer's Guide to Wildemount", 'OGA': 'One Grung Above', 'MOoT': 'Mythic Odysseys of Theros',
     'WA': 'Frozen Sick', 'TSCF': 'The Sunless Citadel (Free)', 'TFoFF': 'The Forge of Fury (Free)',
-    'LRDToB': 'Legends of Runeterra: Dark Tides of Bilgewater', 'IDRotF': 'Icewind Dale: Rime of the Frostmaiden'
+    'LRDToB': 'Legends of Runeterra: Dark Tides of Bilgewater', 'IDRotF': 'Icewind Dale: Rime of the Frostmaiden',
+    'TCoE': 'Tasha’s Cauldron of Everything'
 }
 SOURCE_SLUG_MAP = {
     'BR': 'basic-rules', 'PHB': 'players-handbook', 'DMG': 'dungeon-masters-guide',
@@ -71,7 +72,8 @@ SOURCE_SLUG_MAP = {
     'IMR': 'infernal-machine-rebuild', 'MFFV1': 'mordenkainens-fiendish-folio-volume-1', 'SD': 'sapphire-dragon',
     'EGtW': 'explorers-guide-to-wildemount', 'OGA': 'one-grung-above', 'MOoT': 'mythic-odysseys-of-theros',
     'WA': 'frozen-sick', 'TSCF': 'the-sunless-citadel-free', 'TFoFF': 'the-forge-of-fury-free',
-    'LRDToB': 'legends-of-runeterra-dark-tides-of-bilgewater', 'IDRotF': 'icewind-dale-rime-of-the-frostmaiden'
+    'LRDToB': 'legends-of-runeterra-dark-tides-of-bilgewater', 'IDRotF': 'icewind-dale-rime-of-the-frostmaiden',
+    'TCoE': 'tashas-cauldron-of-everything'
 }
 PARTNERED_SOURCES = ('LRDToB',)
 UA_SOURCES = ('UA',)

--- a/utils/img.py
+++ b/utils/img.py
@@ -100,7 +100,7 @@ async def fetch_monster_image(img_url: str):
     async with aiohttp.ClientSession() as session:
         async with session.get(img_url) as resp:
             if not 199 < resp.status < 300:
-                raise ExternalImportError(f"I was unable to download the image to tokenize. "
+                raise ExternalImportError(f"I was unable to retrieve the monster token. "
                                           f"({resp.status} {resp.reason})")
             img_bytes = await resp.read()
 


### PR DESCRIPTION
### Summary

Depends on avrae/avrae-terraform#58

Adds code to display monster tokens.
- Resolves #1217 
- splits `!token` and `!monimage` to get monster tokens and images, respectively
- monster tokens are cached until bot restart per cluster
- refactored `img.generate_token` to handle border selection

*When releasing, set `DO_RELEASE=0` in travis, let TF do the release!*

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
