### PR TITLE
2020w39

### DIFF
--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -579,6 +579,7 @@ class AliasSpellbook:
         :type spellbook: cogs5e.models.sheet.spellcasting.Spellbook
         """
         self._spellbook = spellbook
+        self._spells = None
 
     @property
     def dc(self):
@@ -615,6 +616,17 @@ class AliasSpellbook:
         :rtype: int
         """
         return self._spellbook.spell_mod
+
+    @property
+    def spells(self):
+        """
+        The list of spells in this spellbook.
+
+        :rtype: list[AliasSpellbookSpell]
+        """
+        if self._spells is None:
+            self._spells = [AliasSpellbookSpell(s) for s in self._spellbook.spells]
+        return self._spells
 
     def slots_str(self, level):
         """
@@ -701,6 +713,56 @@ class AliasSpellbook:
 
     def __repr__(self):
         return "<AliasSpellbook object>"
+
+
+class AliasSpellbookSpell:
+    def __init__(self, spell):
+        """
+        :type spell: cogs5e.models.sheet.spellcasting.SpellbookSpell
+        """
+        self._spell = spell
+
+    @property
+    def name(self):
+        """
+        The name of the spell.
+
+        :rtype: str
+        """
+        return self._spell.name
+
+    @property
+    def dc(self):
+        """
+        The spell's overridden DC. None if this spell uses the default caster DC.
+
+        :rtype: int or None
+        """
+        return self._spell.dc
+
+    @property
+    def sab(self):
+        """
+        The spell's overridden spell attack bonus. None if this spell uses the default caster spell attack bonus.
+
+        :rtype: int or None
+        """
+        return self._spell.sab
+
+    @property
+    def mod(self):
+        """
+        The spell's overridden spellcasting modifier. None if this spell uses the default caster spellcasting modifier.
+
+        :rtype: int or None
+        """
+        return self._spell.mod
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return f"<AliasSpellbookSpell name={self.name} dc={self.dc} sab={self.sab} mod={self.mod}>"
 
 
 class _SpellProxy:

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -373,7 +373,7 @@ class Lookup(commands.Cog):
                 await ctx.send(embed=embed)
 
     @commands.command()
-    async def monimage(self, ctx, *, name=None):
+    async def monimage(self, ctx, *, name):
         """Shows a monster's image."""
         choices = await get_monster_choices(ctx, filter_by_license=False)
         monster = await self._lookup_search3(ctx, {'monster': choices}, name)

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -412,7 +412,7 @@ class Lookup(commands.Cog):
 
         # select border
         ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
-        is_subscriber = ddb_user and ddb_user.subscriber
+        is_subscriber = ddb_user and ddb_user.is_subscriber
         token_args = argparse(args)
 
         if monster.homebrew:

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -395,7 +395,7 @@ class Lookup(commands.Cog):
         """
         Shows a monster or your character's token.
         __Valid Arguments__
-        -border <gold|plain|none> - Chooses the token border.
+        -border <plain|none (player token only)> - Chooses the token border.
         """
         if name is None or name.startswith('-'):
             token_cmd = self.bot.get_command('playertoken')

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -395,7 +395,7 @@ class Lookup(commands.Cog):
         """
         Shows a monster or your character's token.
         __Valid Arguments__
-        -border <plain|none (player token only)> - Chooses the token border.
+        -border <plain|none (player token only)> - Overrides the token border.
         """
         if name is None or name.startswith('-'):
             token_cmd = self.bot.get_command('playertoken')

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -7,9 +7,9 @@ from d20 import roll
 import aliasing.evaluators
 import cogs5e.models.character as character_api
 import cogs5e.models.initiative as init
+from aliasing.errors import EvaluationError
 from cogs5e.models import embeds
 from cogs5e.models.errors import AvraeException, InvalidArgument, InvalidSaveType
-from aliasing.errors import EvaluationError
 from cogs5e.models.sheet.resistance import Resistances, do_resistances
 from utils.dice import RerollableStringifier
 from utils.functions import maybe_mod
@@ -201,10 +201,11 @@ class AutomationContext:
 
         original_names = self.evaluator.builtins.copy()
         self.evaluator.builtins.update(self.metavars)
+        expr = annostr.strip('{}')
         try:
-            out = self.evaluator.eval(annostr.strip('{}'))
+            out = self.evaluator.eval(expr)
         except Exception as ex:
-            raise EvaluationError(ex, annostr.strip('{}'))
+            raise AutomationEvaluationException(ex, expr)
         self.evaluator.builtins = original_names
         return out
 
@@ -1132,6 +1133,15 @@ class StopExecution(AutomationException):
 
 class TargetException(AutomationException):
     pass
+
+
+class AutomationEvaluationException(EvaluationError, AutomationException):
+    """
+    An error occurred while evaluating Draconic in automation.
+    """
+
+    def __init__(self, original, expression):
+        super().__init__(original, expression)  # EvaluationError.__init__()
 
 
 class NoSpellDC(AutomationException):

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -163,15 +163,16 @@ class CustomCounter:
             raise CounterOutOfBounds()
 
         new_value = min(max(minv, new_value), maxv)
-        self._value = new_value
+        self._value = int(new_value)
 
         if self.live_id:
             self._character.sync_consumable(self)
+        return self._value
 
     def reset(self):
         if self.reset_on == 'none' or self.max is None:
             raise NoReset()
-        self.set(self.get_max())
+        return self.set(self.get_max())
 
     def full_str(self):
         _min = self.get_min()

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -353,7 +353,7 @@ class SheetManager(commands.Cog):
 
         token_args = argparse(args)
         ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
-        is_subscriber = ddb_user and ddb_user.subscriber
+        is_subscriber = ddb_user and ddb_user.is_subscriber
 
         try:
             processed = await img.generate_token(char.image, is_subscriber, token_args)

--- a/cogs5e/sheets/dicecloud.py
+++ b/cogs5e/sheets/dicecloud.py
@@ -13,7 +13,7 @@ from math import ceil, floor
 import draconic
 
 from cogs5e.models.character import Character
-from cogs5e.models.dicecloud.client import dicecloud_client
+from cogs5e.models.dicecloud.client import DicecloudClient
 from cogs5e.models.dicecloud.errors import DicecloudException
 from cogs5e.models.errors import ExternalImportError
 from cogs5e.models.sheet.attack import Attack, AttackList
@@ -101,7 +101,7 @@ class DicecloudParser(SheetLoaderABC):
     async def get_character(self):
         """Saves the character JSON data to this object."""
         url = self.url
-        character = await dicecloud_client.get_character(url)
+        character = await DicecloudClient.getInstance().get_character(url)
         character['_id'] = url
         self.character_data = character
         return character
@@ -294,6 +294,7 @@ class DicecloudParser(SheetLoaderABC):
         return spellbook
 
     def is_live(self):
+        dicecloud_client = DicecloudClient.getInstance()
         if dicecloud_client.user_id in self.character_data['characters'][0]['writers'] \
                 or dicecloud_client.user_id == self.character_data['characters'][0]['owner']:
             return 'dicecloud'

--- a/cogsmisc/core.py
+++ b/cogsmisc/core.py
@@ -6,7 +6,7 @@ Created on Dec 26, 2016
 import random
 import time
 from datetime import datetime, timedelta
-from math import floor, isnan
+from math import floor, isfinite
 
 import discord
 import psutil
@@ -45,7 +45,7 @@ class Core(commands.Cog):
         pong = await ctx.send("Pong.")
         delta = datetime.utcnow() - now
         httping = floor(delta.total_seconds() * 1000)
-        wsping = floor(self.bot.latency * 1000) if not isnan(self.bot.latency) else "Unknown"
+        wsping = floor(self.bot.latency * 1000) if isfinite(self.bot.latency) else "Unknown"
         await pong.edit(content=f"Pong.\nHTTP Ping = {httping} ms.\nWS Ping = {wsping} ms.")
 
     @commands.command()

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -49,6 +49,7 @@ class CollectableManagementGroup(commands.Group):
         # helpers
         self.binding_key = 'alias_bindings' if self.is_alias else 'snippet_bindings'
         self.obj_name = 'alias' if self.is_alias else 'snippet'
+        self.obj_copy_command = self.obj_name  # when an item is viewed, we show the non-server version of the command
         self.obj_name_pl = 'aliases' if self.is_alias else 'snippets'
 
         if self.is_server:
@@ -101,7 +102,7 @@ class CollectableManagementGroup(commands.Group):
         await obj.commit(ctx.bot.mdb)
 
         out = f'{self.obj_name.capitalize()} `{name}` added.' \
-              f'```py\n{ctx.prefix}{self.name} {name} {code}\n```'
+              f'```py\n{ctx.prefix}{self.obj_copy_command} {name} {code}\n```'
 
         if len(out) > 2000:
             out = f'{self.obj_name.capitalize()} `{name}` added.\n' \
@@ -117,7 +118,7 @@ class CollectableManagementGroup(commands.Group):
         if collectable is None:
             return await ctx.send(f"No {self.obj_name} named {name} found.")
         elif isinstance(collectable, self.personal_cls):  # personal
-            out = f'**{name}**: ```py\n{ctx.prefix}{self.name} {collectable.name} {collectable.code}\n```'
+            out = f'**{name}**: ```py\n{ctx.prefix}{self.obj_copy_command} {collectable.name} {collectable.code}\n```'
             out = out if len(out) <= 2000 else f'**{collectable.name}**:\nCommand output too long to display.'
             return await ctx.send(out)
         else:  # collection
@@ -426,7 +427,7 @@ class Customization(commands.Cog):
         Requires __Administrator__ Discord permissions or a role called "Server Aliaser".
         If a user and a server have aliases with the same name, the user alias will take priority.
         """,
-        checks=[guild_only_check]
+        checks=[guild_only_check], aliases=['serveralias']
     )
 
     snippet = CollectableManagementGroup(
@@ -473,7 +474,7 @@ class Customization(commands.Cog):
         Requires __Administrator__ Discord permissions or a role called "Server Aliaser".
         If a user and a server have snippets with the same name, the user snippet will take priority.
         """,
-        checks=[guild_only_check]
+        checks=[guild_only_check], aliases=['serversnippet']
     )
 
     @commands.command()

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -150,7 +150,10 @@ class CollectableManagementGroup(commands.Group):
                                              ', '.join(sorted(user_obj_names)))
 
         async for subscription_doc in self.workshop_sub_meth(ctx):
-            the_collection = await workshop.WorkshopCollection.from_id(ctx, subscription_doc['object_id'])
+            try:
+                the_collection = await workshop.WorkshopCollection.from_id(ctx, subscription_doc['object_id'])
+            except workshop.CollectionNotFound:
+                continue
             if bindings := subscription_doc[self.binding_key]:
                 has_at_least_1 = True
                 embed.add_field(name=the_collection.name, value=', '.join(sorted(ab['name'] for ab in bindings)),

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -948,10 +948,16 @@ AliasCharacter
     :members:
     :inherited-members:
 
+AliasCustomCounter
+^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: aliasing.api.character.AliasCustomCounter()
+    :members:
+
 AliasDeathSaves
 ^^^^^^^^^^^^^^^
 
-.. autoclass:: aliasing.api.character.AliasDeathSaves
+.. autoclass:: aliasing.api.character.AliasDeathSaves()
     :members:
 
 StatBlock Models
@@ -1124,3 +1130,9 @@ AliasSpellbook
         Returns whether the spell named *spell* (str) is known.
 
         :type: bool
+
+AliasSpellbookSpell
+"""""""""""""""""""
+
+.. autoclass:: aliasing.api.statblock.AliasSpellbookSpell()
+    :members:

--- a/gamedata/ddb.py
+++ b/gamedata/ddb.py
@@ -9,12 +9,9 @@ from boto3.dynamodb.conditions import Key
 
 from cogsmisc.stats import Stats
 # auth service
-from utils.config import DDB_AUTH_AUDIENCE as AUDIENCE, \
-    DDB_AUTH_EXPIRY_SECONDS as EXPIRY_SECONDS, \
-    DDB_AUTH_ISSUER as ISSUER, \
-    DDB_AUTH_SECRET as MY_SECRET, \
-    DDB_WATERDEEP_SECRET as WATERDEEP_SECRET, \
-    DDB_AUTH_SERVICE_URL as AUTH_BASE_URL
+from utils.config import DDB_AUTH_AUDIENCE as AUDIENCE, DDB_AUTH_EXPIRY_SECONDS as EXPIRY_SECONDS, \
+    DDB_AUTH_ISSUER as ISSUER, DDB_AUTH_SECRET as MY_SECRET, DDB_AUTH_SERVICE_URL as AUTH_BASE_URL, \
+    DDB_WATERDEEP_SECRET as WATERDEEP_SECRET
 # dynamo
 # env: AWS_ACCESS_KEY_ID
 # env: AWS_SECRET_ACCESS_KEY
@@ -330,6 +327,11 @@ class BeyondUser:
     @property
     def is_staff(self):
         return 'D&D Beyond Staff' in self.roles
+
+    @property
+    def is_subscriber(self):
+        """Used to count staff and insiders as subscribers."""
+        return self.subscriber or self.is_insider or self.is_staff
 
 
 class UserEntitlements:

--- a/notes/workshop-tags.txt
+++ b/notes/workshop-tags.txt
@@ -1,0 +1,80 @@
+!admin workshop tags add barbarian Barbarian Classes
+!admin workshop tags add bard Bard Classes
+!admin workshop tags add cleric Cleric Classes
+!admin workshop tags add druid Druid Classes
+!admin workshop tags add fighter Fighter Classes
+!admin workshop tags add monk Monk Classes
+!admin workshop tags add paladin Paladin Classes
+!admin workshop tags add ranger Ranger Classes
+!admin workshop tags add rogue Rogue Classes
+!admin workshop tags add sorcerer Sorcerer Classes
+!admin workshop tags add warlock Warlock Classes
+!admin workshop tags add wizard Wizard Classes
+!admin workshop tags add artificer Artificer Classes
+!admin workshop tags add blood-hunter "Blood Hunter" Classes
+
+!admin workshop tags add dragonborn Dragonborn Races
+!admin workshop tags add dwarf Dwarf Races
+!admin workshop tags add elf Elf Races
+!admin workshop tags add gnome Gnome Races
+!admin workshop tags add half-elf Half-Elf Races
+!admin workshop tags add halfling Halfling Races
+!admin workshop tags add half-orc Half-Orc Races
+!admin workshop tags add human Human Races
+!admin workshop tags add tiefling Tiefling Races
+!admin workshop tags add leonin Leonin Races
+!admin workshop tags add satyr Satyr Races
+!admin workshop tags add aarakocra Aarakocra Races
+!admin workshop tags add genasi Genasi Races
+!admin workshop tags add goliath Goliath Races
+!admin workshop tags add aasimar Aasimar Races
+!admin workshop tags add bugbear Bugbear Races
+!admin workshop tags add firbolg Firbolg Races
+!admin workshop tags add goblin Goblin Races
+!admin workshop tags add hobgoblin Hobgoblin Races
+!admin workshop tags add kenku Kenku Races
+!admin workshop tags add kobold Kobold Races
+!admin workshop tags add lizardfolk Lizardfolk Races
+!admin workshop tags add orc Orc Races
+!admin workshop tags add tabaxi Tabaxi Races
+!admin workshop tags add triton Triton Races
+!admin workshop tags add yuan-ti-pureblood "Yuan-ti Pureblood" Races
+!admin workshop tags add tortle Tortle Races
+!admin workshop tags add changeling Changeling Races
+!admin workshop tags add kalashtar Kalashtar Races
+!admin workshop tags add shifter Shifter Races
+!admin workshop tags add warforged Warforged Races
+!admin workshop tags add gith Gith Races
+!admin workshop tags add centaur Centaur Races
+!admin workshop tags add loxodon Loxodon Races
+!admin workshop tags add minotaur Minotaur Races
+!admin workshop tags add simic-hybrid "Simic Hybrid" Races
+!admin workshop tags add vedalken Vedalken Races
+!admin workshop tags add locathah Locathah Races
+!admin workshop tags add grung Grung Races
+
+!admin workshop tags add players-handbook "Player's Handbook" Books
+!admin workshop tags add dungeon-masters-guide "Dungeon Master's Guide" Books
+!admin workshop tags add monster-manual "Monster Manual" Books
+!admin workshop tags add volos-guide-to-monsters "Volo's Guide to Monsters" Books
+!admin workshop tags add xanathars-guide-to-everything "Xanathar's Guide to Everything" Books
+!admin workshop tags add mordenkainens-tome-of-foes "Mordenkainen's Tome of Foes" Books
+!admin workshop tags add eberron-rising-from-the-last-war "Eberron: Rising from the Last War" Books
+!admin workshop tags add guildmasters-guide-to-ravnica "Guildmaster's Guide to Ravnica" Books
+!admin workshop tags add explorers-guide-to-wildemount "Explorer's Guide to WIldemount" Books
+!admin workshop tags add mythic-odysseys-of-theros "Mythic Odysseys of Theros" Books
+!admin workshop tags add sword-coast-adventurers-guide "Sword Coast Adventurer's Guide" Books
+!admin workshop tags add adventure-book "Adventure Book" Books
+
+!admin workshop tags add class Class Other
+!admin workshop tags add race Race Other
+!admin workshop tags add subclass Subclass Other
+!admin workshop tags add spell Spell Other
+!admin workshop tags add item Item Other
+!admin workshop tags add monster Monster Other
+!admin workshop tags add feat Feat Other
+!admin workshop tags add utility Utility Other
+!admin workshop tags add initiative Initiative Other
+!admin workshop tags add noncore-5e "Noncore 5e" Other
+!admin workshop tags add non-5e Non-5e Other
+!admin workshop tags add homebrew Homebrew Other

--- a/utils/help.py
+++ b/utils/help.py
@@ -229,8 +229,9 @@ class AvraeHelp(HelpCommand):
         keys = command.split(' ')
         cmd = bot.all_commands.get(keys[0])
         if cmd is None:
-            alias = (await aliasing.helpers.get_personal_alias_named(ctx, keys[0])) \
-                    or (await aliasing.helpers.get_server_alias_named(ctx, keys[0]))
+            alias = await aliasing.helpers.get_personal_alias_named(ctx, keys[0])
+            if alias is None and ctx.guild is not None:
+                alias = await aliasing.helpers.get_server_alias_named(ctx, keys[0])
             if alias is not None:
                 return await self.send_alias_help(alias, keys)
             else:


### PR DESCRIPTION
### Summary
Followup update to v2.5.0, scheduled for release Tuesday.

- fixes an issue where asking for help on a non-existant command in private messages would error
- fixes an issue where infinite ping (i.e. bot has not yet connected to discord gateway) caused an overflowerror
- fixes an issue where a required argument to `!monimage` was marked optional
- made help on `!token` a little clearer 
- fixes an issue where being subscribed to a deleted workshop collection could cause looking up alias lists to error
- DDB staff/insiders now count as subscribers
- added custom counters, spellbook spells, cvars, etc to AliasCharacter API
- fixes an issue where a cluster would give up trying to connect to Dicecloud if it failed to on startup (Fixes #1263)
- fixes `!serveralias` no longer being an alias of `!servalias` 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
