### PR TITLE
Add Built-In Enumerate to Aliasing Context

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -22,7 +22,7 @@ from utils.dice import PersistentRollContext
 
 DEFAULT_BUILTINS = {
     # builtins
-    'floor': floor, 'ceil': ceil, 'round': round, 'len': len, 'max': max, 'min': min,
+    'floor': floor, 'ceil': ceil, 'round': round, 'len': len, 'max': max, 'min': min, 'enumerate': enumerate,
     'range': safe_range, 'sqrt': sqrt, 'sum': sum, 'any': any, 'all': all, 'time': time.time,
     # ours
     'roll': roll, 'vroll': vroll, 'err': err, 'typeof': typeof,

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -232,7 +232,7 @@ Python Builtins
 
     :param x: The value to convert.
     :type x: iterable
-    :return: The float.
+    :return: iterable of count and objects.
     :rtype: iterator
 
 .. function:: float(x)

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -226,6 +226,15 @@ Python Builtins
     :return: The smallest integer >= x.
     :rtype: int
 
+.. function:: enumerate(x)
+
+    Returns a iterable of tuples containing a count and the values from the iterable.
+
+    :param x: The value to convert.
+    :type x: iterable
+    :return: The float.
+    :rtype: iterator
+
 .. function:: float(x)
 
     Converts *x* to a floating point number.

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -232,8 +232,8 @@ Python Builtins
 
     :param x: The value to convert.
     :type x: iterable
-    :return: iterable of count and objects.
-    :rtype: iterator
+    :return: enumerate of count and objects.
+    :rtype: iterable[tuple[int, any]]
 
 .. function:: float(x)
 


### PR DESCRIPTION
### Summary
Adds `enumerate` to the aliasing context

Not 100% sure if I did the docs right.

Resolves #1185 (AFR-590)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.