### PR TITLE
Add descriptions to Init Effects

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -229,7 +229,7 @@ class SimpleCombatant(AliasStatBlock):
         return None
 
     def add_effect(self, name: str, args: str, duration: int = -1, concentration: bool = False, parent=None,
-                   end: bool = False):
+                   end: bool = False, desc: str = None):
         """
         Adds an effect to the combatant.
 
@@ -240,12 +240,13 @@ class SimpleCombatant(AliasStatBlock):
         :param parent: The parent of the effect.
         :type parent: :class:`~aliasing.api.combat.SimpleEffect`
         :param bool end: Whether the effect ticks on the end of turn.
+        :param str desc: A description of the effect.
         """
         existing = self._combatant.get_effect(name, True)
         if existing:
             existing.remove()
         effectObj = Effect.new(self._combatant.combat, self._combatant, duration=duration, name=name, effect_args=args,
-                               concentration=concentration, tick_on_end=end)
+                               concentration=concentration, tick_on_end=end, desc=desc)
         if parent:
             effectObj.set_parent(parent._effect)
         self._combatant.add_effect(effectObj)
@@ -359,6 +360,7 @@ class SimpleEffect:
         self.remaining = self._effect.remaining
         self.effect = self._effect.effect
         self.conc = self._effect.concentration
+        self.desc = self._effect.desc
 
     def __str__(self):
         return str(self._effect)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -925,7 +925,8 @@ class InitTracker(commands.Cog):
         -neutral <damage type> - Removes the combatant's immunity, resistance, or vulnerability to the given damage type.
         __General__
         -ac <ac> - modifies ac temporarily; adds if starts with +/- or sets otherwise.
-        -sb <save bonus> - Adds a bonus to all saving throws."""
+        -sb <save bonus> - Adds a bonus to all saving throws.
+        -desc <"description"> - Adds a description of the effect."""
         combat = await Combat.from_ctx(ctx)
         args = argparse(args)
 
@@ -942,6 +943,7 @@ class InitTracker(commands.Cog):
         conc = args.last('conc', False, bool)
         end = args.last('end', False, bool)
         parent = args.last('parent')
+        desc = args.last('desc')
 
         if parent is not None:
             parent = parent.split('|', 1)
@@ -957,7 +959,7 @@ class InitTracker(commands.Cog):
                 out = "Effect already exists."
             else:
                 effect_obj = Effect.new(combat, combatant, duration=duration, name=effect_name, effect_args=args,
-                                        concentration=conc, tick_on_end=end)
+                                        concentration=conc, tick_on_end=end, desc=desc)
                 result = combatant.add_effect(effect_obj)
                 if parent:
                     effect_obj.set_parent(parent)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -926,7 +926,7 @@ class InitTracker(commands.Cog):
         __General__
         -ac <ac> - modifies ac temporarily; adds if starts with +/- or sets otherwise.
         -sb <save bonus> - Adds a bonus to all saving throws.
-        -desc <"description"> - Adds a description of the effect."""
+        -desc <description> - Adds a description of the effect."""
         combat = await Combat.from_ctx(ctx)
         args = argparse(args)
 

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -938,6 +938,8 @@ class IEffect(Effect):
             desc = autoctx.parse_annostr(self.desc)
             if len(desc) > 500:
                 desc = f"{desc[:500]}..."
+        else:
+            desc = None
 
         duration = autoctx.args.last('dur', duration, int)
         if isinstance(autoctx.target.target, init.Combatant):
@@ -954,7 +956,7 @@ class IEffect(Effect):
                 autoctx.queue(f"**Concentration**: dropped {', '.join([e.name for e in conc_conflict])}")
         else:
             effect = init.Effect.new(None, None, self.name, duration, autoctx.parse_annostr(self.effects),
-                                     tick_on_end=self.tick_on_end, concentration=self.concentration, desc=self.desc)
+                                     tick_on_end=self.tick_on_end, concentration=self.concentration, desc=desc)
             autoctx.queue(f"**Effect**: {str(effect)}")
 
     def build_str(self, caster, evaluator):

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -908,18 +908,20 @@ class TempHP(Effect):
 
 
 class IEffect(Effect):
-    def __init__(self, name: str, duration: int, effects: str, end: bool = False, conc: bool = False, **kwargs):
+    def __init__(self, name: str, duration: int, effects: str, end: bool = False, conc: bool = False,
+                 desc: str = None, **kwargs):
         super(IEffect, self).__init__("ieffect", **kwargs)
         self.name = name
         self.duration = duration
         self.effects = effects
         self.tick_on_end = end
         self.concentration = conc
+        self.desc = desc
 
     def to_dict(self):
         out = super(IEffect, self).to_dict()
         out.update({"name": self.name, "duration": self.duration, "effects": self.effects, "end": self.tick_on_end,
-                    "conc": self.concentration})
+                    "conc": self.concentration, "desc": self.desc})
         return out
 
     def run(self, autoctx):
@@ -936,7 +938,7 @@ class IEffect(Effect):
         if isinstance(autoctx.target.target, init.Combatant):
             effect = init.Effect.new(autoctx.target.target.combat, autoctx.target.target, self.name,
                                      duration, autoctx.parse_annostr(self.effects), tick_on_end=self.tick_on_end,
-                                     concentration=self.concentration)
+                                     concentration=self.concentration, desc=self.desc)
             if autoctx.conc_effect:
                 if autoctx.conc_effect.combatant is autoctx.target.target and self.concentration:
                     raise InvalidArgument("Concentration spells cannot add concentration effects to the caster.")
@@ -947,7 +949,7 @@ class IEffect(Effect):
                 autoctx.queue(f"**Concentration**: dropped {', '.join([e.name for e in conc_conflict])}")
         else:
             effect = init.Effect.new(None, None, self.name, duration, autoctx.parse_annostr(self.effects),
-                                     tick_on_end=self.tick_on_end, concentration=self.concentration)
+                                     tick_on_end=self.tick_on_end, concentration=self.concentration, desc=self.desc)
             autoctx.queue(f"**Effect**: {str(effect)}")
 
     def build_str(self, caster, evaluator):

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -934,11 +934,16 @@ class IEffect(Effect):
         else:
             duration = self.duration
 
+        if self.desc:
+            desc = autoctx.parse_annostr(self.desc)
+            if len(desc) > 500:
+                desc = f"{desc[:500]}..."
+
         duration = autoctx.args.last('dur', duration, int)
         if isinstance(autoctx.target.target, init.Combatant):
             effect = init.Effect.new(autoctx.target.target.combat, autoctx.target.target, self.name,
                                      duration, autoctx.parse_annostr(self.effects), tick_on_end=self.tick_on_end,
-                                     concentration=self.concentration, desc=self.desc)
+                                     concentration=self.concentration, desc=desc)
             if autoctx.conc_effect:
                 if autoctx.conc_effect.combatant is autoctx.target.target and self.concentration:
                     raise InvalidArgument("Concentration spells cannot add concentration effects to the caster.")

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -1239,7 +1239,8 @@ class Effect:
                   'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus'}
 
     def __init__(self, combat, combatant, name: str, duration: int, remaining: int, effect: dict,
-                 concentration: bool = False, children: list = None, parent: dict = None, tonend: bool = False):
+                 concentration: bool = False, children: list = None, parent: dict = None,
+                 tonend: bool = False, desc: str = None):
         if children is None:
             children = []
         self.combat = combat
@@ -1252,10 +1253,11 @@ class Effect:
         self.children = children
         self.parent = parent
         self.ticks_on_end = tonend
+        self.desc = desc
 
     @classmethod
     def new(cls, combat, combatant, name, duration, effect_args, concentration: bool = False, character=None,
-            tick_on_end=False):
+            tick_on_end=False, desc: str = None):
         if isinstance(effect_args, str):
             if (combatant and isinstance(combatant, PlayerCombatant)) or character:
                 effect_args = argparse(effect_args, combatant.character or character)
@@ -1278,7 +1280,7 @@ class Effect:
         except (ValueError, TypeError):
             raise InvalidArgument("Effect duration must be an integer.")
         return cls(combat, combatant, name, duration, duration, effect_dict, concentration=concentration,
-                   tonend=tick_on_end)
+                   tonend=tick_on_end, desc=desc)
 
     def set_parent(self, parent):
         """Sets the parent of an effect."""
@@ -1314,6 +1316,8 @@ class Effect:
         out.append(self.get_parenthetical())
         if self.concentration:
             out.append("<C>")
+        if self.desc:
+            out.append(f"\n - {self.desc}")
         return ' '.join(out)
 
     def get_short_str(self):
@@ -1432,4 +1436,4 @@ class Effect:
     def to_dict(self):
         return {'name': self.name, 'duration': self.duration, 'remaining': self.remaining, 'effect': self.effect,
                 'concentration': self.concentration, 'children': self.children, 'parent': self.parent,
-                'tonend': self.ticks_on_end}
+                'tonend': self.ticks_on_end, 'desc': self.desc}


### PR DESCRIPTION
### Summary
This adds a `-desc` argument to `!init effect`, as well as to automation and `SimpleCombatant.add_effect()`.

I still need to add this to the actual Automation editor for spells and attacks, but I confirmed it works with `!attack import` using a modified JSON to add the `desc` tag to an ieffect.

![image](https://user-images.githubusercontent.com/5848891/94962063-1309d280-04b3-11eb-8102-bf744e74f5cd.png)

![image](https://user-images.githubusercontent.com/5848891/94962312-7bf14a80-04b3-11eb-9f09-99e4865e25ef.png)

Resolves #890 (AFR-465)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
