### PR TITLE
Add an option to not remove monsters at below 0 hp

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -402,19 +402,18 @@ class InitTracker(commands.Cog):
             await Stats.increase_stat(ctx, "rounds_init_tracked_life")
 
         out.append(combat.get_turn_str())
-        next_deleted = False
+        removed = []
         for co in to_remove:
-            # prevent error when the current combatant is the only combatant
-            if co == combat.next_combatant:
-                next_deleted = True
             combat.remove_combatant(co)
-            out.append("{} automatically removed from combat.\n".format(co.name))
+            removed.append("{} automatically removed from combat.\n".format(co.name))
 
-        if next_deleted and len(combat.get_combatants()) == 0:
-            await ctx.send("\n".join(out))
-            await ctx.send('No remaining combatants.')
+        next_mentions = combat.get_turn_str_mentions()
+        out += removed
+        if next_mentions is not None:
+            await ctx.send("\n".join(out), allowed_mentions=next_mentions)
         else:
-            await ctx.send("\n".join(out), allowed_mentions=combat.get_turn_str_mentions())
+            await ctx.send('\n'.join(removed))
+            await ctx.send('No combatants remain.')
         await combat.final()
 
     @init.command(name="prev", aliases=['previous', 'rewind'])

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -399,7 +399,7 @@ class InitTracker(commands.Cog):
         except NoCombatants:
             # If we removed the last combatant, catch NoCombatants so we can display the removed Combatants
             if removed:
-                advanced_round, messages = False, ''
+                advanced_round, messages = False, []
             # Otherwise re-raise the error.
             else:
                 raise

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -407,7 +407,7 @@ class InitTracker(commands.Cog):
         next_mentions = combat.get_turn_str_mentions()
         out += removed
         if combat.current_combatant is None or len(combat.get_combatants()) == 0:
-            out.append('No combatants remain.')
+            removed.append('\nNo combatants remain.')
             await ctx.send('\n'.join(removed))
         else:
             await ctx.send("\n".join(out), allowed_mentions=next_mentions)

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -389,13 +389,16 @@ class Combat:
 
     def get_turn_str_mentions(self):
         """Gets the :class:`discord.AllowedMentions` for the users mentioned in the current turn str."""
+        if self.current_combatant is None:
+            return None
         if isinstance(self.current_combatant, CombatantGroup):
             user_ids = {discord.Object(id=int(comb.controller)) for comb in self.current_combatant.get_combatants()}
         else:
             user_ids = {discord.Object(id=int(self.current_combatant.controller))}
 
         if self.options.get('turnnotif'):
-            user_ids.add(discord.Object(id=int(self.next_combatant.controller)))
+            if self.next_combatant is not None:
+                user_ids.add(discord.Object(id=int(self.next_combatant.controller)))
         return discord.AllowedMentions(users=list(user_ids))
 
     @staticmethod

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -367,6 +367,9 @@ class Combat:
     def get_turn_str(self):
         nextCombatant = self.current_combatant
 
+        if nextCombatant is None:
+            return None
+
         if isinstance(nextCombatant, CombatantGroup):
             thisTurn = nextCombatant.get_combatants()
             outStr = "**Initiative {} (round {})**: {} ({})\n{}"
@@ -390,15 +393,14 @@ class Combat:
     def get_turn_str_mentions(self):
         """Gets the :class:`discord.AllowedMentions` for the users mentioned in the current turn str."""
         if self.current_combatant is None:
-            return None
+            return discord.AllowedMentions.none()
         if isinstance(self.current_combatant, CombatantGroup):
             user_ids = {discord.Object(id=int(comb.controller)) for comb in self.current_combatant.get_combatants()}
         else:
             user_ids = {discord.Object(id=int(self.current_combatant.controller))}
 
-        if self.options.get('turnnotif'):
-            if self.next_combatant is not None:
-                user_ids.add(discord.Object(id=int(self.next_combatant.controller)))
+        if self.options.get('turnnotif') and self.next_combatant is not None:
+            user_ids.add(discord.Object(id=int(self.next_combatant.controller)))
         return discord.AllowedMentions(users=list(user_ids))
 
     @staticmethod


### PR DESCRIPTION
### Summary
Adds an option to not remove `MonsterCombatant`s when they are below 0 hp
Fixes bug where removing a monster as the last combatant would error.

Resolves #1194 (AFR-595)
Fixes #1286 (AVR-658)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
