### PR TITLE
Expose alias invocation name

### DIFF
--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -17,6 +17,7 @@ class AliasContext:
         self._channel = AliasChannel(ctx.channel)
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
+        self._invoked_with = ctx.invoked_with
 
     @property
     def guild(self):
@@ -54,8 +55,18 @@ class AliasContext:
         """
         return self._prefix
 
+    @property
+    def invoked_with(self):
+        """
+        The name the alias was invoked with.
+
+        :rtype: str
+        """
+        return self._invoked_with
+
     def __repr__(self):
-        return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix}>"
+        return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix} " \
+               f"name={self.name}>"
 
 
 class AliasGuild:

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -66,7 +66,7 @@ class AliasContext:
 
     def __repr__(self):
         return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix}" \
-               f" name={self.invoked_with}>"
+               f" invoked_with={self.invoked_with}>"
 
 
 class AliasGuild:

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -66,7 +66,7 @@ class AliasContext:
 
     def __repr__(self):
         return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix} " \
-               f"name={self.name}>"
+               f"name={self.invoked_with}>"
 
 
 class AliasGuild:

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -17,7 +17,7 @@ class AliasContext:
         self._channel = AliasChannel(ctx.channel)
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
-        self._invoked_with = ctx.invoked_with
+        self._alias = ctx.invoked_with
 
     @property
     def guild(self):
@@ -56,17 +56,22 @@ class AliasContext:
         return self._prefix
 
     @property
-    def invoked_with(self):
+    def alias(self):
         """
         The name the alias was invoked with.
+        Note: When used in a base command, this will return the deepest sub-command, but when used in an alias it will
+        return the base command.
+
+        >>> !test {{ctx.alias}}
+        'test'
 
         :rtype: str
         """
-        return self._invoked_with
+        return self._alias
 
     def __repr__(self):
         return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix}" \
-               f" invoked_with={self.invoked_with}>"
+               f" alias={self.alias}>"
 
 
 class AliasGuild:

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -65,8 +65,8 @@ class AliasContext:
         return self._invoked_with
 
     def __repr__(self):
-        return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix} " \
-               f"name={self.invoked_with}>"
+        return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix}" \
+               f" name={self.invoked_with}>"
 
 
 class AliasGuild:


### PR DESCRIPTION
### Summary
Exposes the name the alias was invoked with under `ctx.invoked_with`

Resolves #1294 (AFR-650)

![image](https://user-images.githubusercontent.com/16567386/95135780-f67bcd80-0732-11eb-842b-baa4ba43b2b9.png)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.