### PR TITLE
Change Class of SimpleRollResult in Vroll docs

### DIFF
--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -54,7 +54,7 @@ def vroll(dice, multiply=1, add=0):
     :param int multiply: How many times to multiply each set of dice by.
     :param int add: How many dice to add to each set of dice.
     :return: The result of the roll.
-    :rtype: :class:`~cogs5e.funcs.scripting.functions.SimpleRollResult`
+    :rtype: :class:`~aliasing.api.functions.SimpleRollResult`
     """
     return _vroll(dice, multiply, add)
 


### PR DESCRIPTION
### Summary
The current docs link `SimpleRollResult` to `cogs5e.functions.scripting.functions.SimpleRollResult` on `vroll`, but the current `SimpleRollResult` class is under `aliasing.api.functions`.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
