### PR TITLE
Expose list of groups to SimpleCombat

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -94,7 +94,6 @@ class SimpleCombatant(AliasStatBlock):
         self.initmod = int(self._combatant.init_skill)
         self.init = self._combatant.init
         self.effects = [SimpleEffect(e) for e in self._combatant.get_effects()]
-        # self.group = SimpleGroup(self._combatant.group) if self._combatant.group is not None else None
         # deprecated drac 2.1
         self.resists = self.resistances  # use .resistances instead
         self.level = self._combatant.spellbook.caster_level  # use .spellbook.caster_level or .levels.total_level instead

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -13,6 +13,7 @@ class SimpleCombat:
         self._combat: Combat = combat
 
         self.combatants = [SimpleCombatant(c) for c in combat.get_combatants()]
+        self.groups = [SimpleGroup(c) for c in combat.get_groups()]
         if me:
             self.me = SimpleCombatant(me, False)
         else:
@@ -93,6 +94,7 @@ class SimpleCombatant(AliasStatBlock):
         self.initmod = int(self._combatant.init_skill)
         self.init = self._combatant.init
         self.effects = [SimpleEffect(e) for e in self._combatant.get_effects()]
+        # self.group = SimpleGroup(self._combatant.group) if self._combatant.group is not None else None
         # deprecated drac 2.1
         self.resists = self.resistances  # use .resistances instead
         self.level = self._combatant.spellbook.caster_level  # use .spellbook.caster_level or .levels.total_level instead
@@ -333,6 +335,7 @@ class SimpleGroup:
         self._group = group
         self.type = "group"
         self.combatants = [SimpleCombatant(c) for c in self._group.get_combatants()]
+        self.name = group.name
 
     def get_combatant(self, name):
         """

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -334,7 +334,6 @@ class SimpleGroup:
         self._group = group
         self.type = "group"
         self.combatants = [SimpleCombatant(c) for c in self._group.get_combatants()]
-        self.name = group.name
 
     def get_combatant(self, name):
         """

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -189,6 +189,13 @@ class Combat:
                     combatants.append(c)
         return combatants
 
+    def get_groups(self):
+        """
+        Returns a list of all CombatantGroups in a combat
+        :return: A list of all CombatantGroups
+        """
+        return [g for g in self._combatants if isinstance(g, CombatantGroup)]
+
     def add_combatant(self, combatant):
         self._combatants.append(combatant)
         self.sort_combatants()

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -836,6 +836,10 @@ SimpleCombat
         The :class:`~aliasing.api.combat.SimpleCombatant` or :class:`~aliasing.api.combat.SimpleGroup`
         representing the combatant whose turn it is.
 
+    .. attribute:: groups
+
+        A list of all :class:`~aliasing.api.combat.SimpleGroup` in combat.
+
     .. attribute:: me
 
         The :class:`~aliasing.api.combat.SimpleCombatant` representing the active character in combat, or ``None``
@@ -908,6 +912,14 @@ SimpleGroup
     .. attribute:: combatants
 
         A list of all :class:`~aliasing.api.combat.SimpleCombatant` in this group.
+
+        :type: list of :class:`~aliasing.api.combat.SimpleCombatant`
+
+    .. attribute:: name
+
+        The name of the group.
+
+        :type: str
 
     .. attribute:: type
 

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -915,12 +915,6 @@ SimpleGroup
 
         :type: list of :class:`~aliasing.api.combat.SimpleCombatant`
 
-    .. attribute:: name
-
-        The name of the group.
-
-        :type: str
-
     .. attribute:: type
 
         The type of the object (``"group"``), to determine whether this is a group or not.


### PR DESCRIPTION
Summary
========

Expose list of groups to `SimpleCombat`. Also makes the group's name available.

Additions
---------
**For Aliasing**:
`SimpleCombat.groups` - List of `SimpleGroups` in a combat
`SimpleGroup.name` - Name of the group

**Background Methods**
`Combat.get_groups()` - Returns a list of `CombatantGroups`

Issues
-------
Resolves #1284 (AFR-642)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.