### PR TITLE
Add nocrit arg to nullify critical attacks.

### DIFF
--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -155,6 +155,7 @@ class Dice(commands.Cog):
         *hit* - automatically hits
         *miss* - automatically misses
         *crit* - automatically crits if hit
+        *nocrit* - nullifies critical hits
         *max* - deals max damage
         *magical* - makes the damage type magical
 

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -1034,6 +1034,7 @@ class InitTracker(commands.Cog):
         *hit* - The attack automatically hits.
         *miss* - The attack automatically misses.
         *crit* - The attack automatically crits.
+        *nocrit* - Nullifies critical hits.
         *max* - Maximizes damage rolls.
 
         -h - Hides rolled values.
@@ -1095,6 +1096,7 @@ class InitTracker(commands.Cog):
         *hit* - The attack automatically hits.
         *miss* - The attack automatically misses.
         *crit* - The attack automatically crits.
+        *nocrit* - Nullifies critical hits.
         *max* - Maximizes damage rolls.
 
         -h - Hides rolled values.

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -446,6 +446,7 @@ class Attack(Effect):
         args = autoctx.args
         adv = args.adv(ea=True, ephem=True)
         crit = args.last('crit', None, bool, ephem=True) and 1
+        nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
         hit = args.last('hit', None, bool, ephem=True) and 1
         miss = (args.last('miss', None, bool, ephem=True) and not hit) and 1
         b = args.join('b', '+', ephem=True)
@@ -546,13 +547,13 @@ class Attack(Effect):
 
             if itercrit == 2:
                 damage += self.on_miss(autoctx)
-            elif itercrit == 1:
+            elif itercrit == 1 and not nocrit:
                 damage += self.on_crit(autoctx)
             else:
                 damage += self.on_hit(autoctx)
         elif hit:
             autoctx.queue(f"**To Hit**: Automatic hit!")
-            if crit:
+            if crit and not nocrit:
                 damage += self.on_crit(autoctx)
             else:
                 damage += self.on_hit(autoctx)
@@ -737,6 +738,7 @@ class Damage(Effect):
         d_args = args.get('d', [], ephem=True)
         c_args = args.get('c', [], ephem=True)
         crit_arg = args.last('crit', None, bool, ephem=True)
+        nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
         max_arg = args.last('max', None, bool, ephem=True)
         magic_arg = args.last('magical', None, bool, ephem=True)
         mi_arg = args.last('mi', None, int)
@@ -780,7 +782,8 @@ class Damage(Effect):
             dice_ast.roll = d20.ast.BinOp(dice_ast.roll, '+', d_ast.roll)
 
         # crit
-        in_crit = autoctx.in_crit or crit_arg
+        # nocrit (#1216)
+        in_crit = (autoctx.in_crit or crit_arg) and not nocrit
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:
             dice_ast = d20.utils.tree_map(_crit_mapper, dice_ast)

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -520,6 +520,10 @@ class Attack(Effect):
             else:
                 itercrit = to_hit_roll.crit
 
+            # nocrit
+            if itercrit == 1 and nocrit:
+                itercrit = 0
+
             # -ac #
             target_has_ac = not autoctx.target.is_simple and autoctx.target.ac is not None
             if target_has_ac:
@@ -547,12 +551,13 @@ class Attack(Effect):
 
             if itercrit == 2:
                 damage += self.on_miss(autoctx)
-            elif itercrit == 1 and not nocrit:
+            elif itercrit == 1:
                 damage += self.on_crit(autoctx)
             else:
                 damage += self.on_hit(autoctx)
         elif hit:
             autoctx.queue(f"**To Hit**: Automatic hit!")
+            # nocrit and crit cancel out
             if crit and not nocrit:
                 damage += self.on_crit(autoctx)
             else:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -88,6 +88,7 @@ class SheetManager(commands.Cog):
         *hit* - automatically hits
         *miss* - automatically misses
         *crit* - automatically crits if hit
+        *nocrit* - nullifies critical hits
         *max* - deals max damage
         *magical* - makes the damage type magical
 


### PR DESCRIPTION
Summary
========

Adds the `-nocrit` argument for attack spells and attacks (notably the Target and Damage automation effects)

Issues
-------
Resolves #1216 (AFR-606)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.