### PR TITLE
2020w42

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -19,7 +19,7 @@ class AliasCharacter(AliasStatBlock):
 
     # helpers
     def _get_consumable(self, name):
-        consumable = next((con for con in self._character.consumables if con.name == name), None)
+        consumable = self._character.get_consumable(name)
         if consumable is None:
             raise ConsumableException(f"There is no counter named {name}.")
         return consumable
@@ -343,7 +343,8 @@ class AliasCustomCounter:
         :return: The cc's new value.
         :rtype: int
         """
-        return self._cc.reset()
+        result = self._cc.reset()
+        return result.new_value  # todo what about the rest of the data?
 
     def __str__(self):
         return str(self._cc)

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -432,7 +432,7 @@ class SimpleEffect:
         return str(self._effect)
 
     def __repr__(self):
-        return f"<SimpleEffect name=f{self.name!r} duration={self.duration!r} remaining={self.remaining!r}>"
+        return f"<SimpleEffect name={self.name!r} duration={self.duration!r} remaining={self.remaining!r}>"
 
     def __eq__(self, other):
         return isinstance(other, SimpleEffect) and self._effect is other._effect

--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -68,7 +68,7 @@ class Dice(commands.Cog):
         if len(out) > 1999:
             out = f"{ctx.author.mention}  :game_die:\n" \
                   f"{str(res)[:100]}...\n" \
-                  f"**Total:** {res.total}"
+                  f"**Total**: {res.total}"
 
         await try_delete(ctx.message)
         await ctx.send(out, allowed_mentions=discord.AllowedMentions(users=[ctx.author]))

--- a/cogs5e/funcs/attackutils.py
+++ b/cogs5e/funcs/attackutils.py
@@ -3,7 +3,17 @@ from utils.functions import a_or_an
 
 
 async def run_attack(ctx, embed, args, caster, attack, targets, combat):
-    """Runs an attack: adds title, handles -f and -thumb args, commits combat, runs automation, edits embed."""
+    """
+    Runs an attack: adds title, handles -f and -thumb args, commits combat, runs automation, edits embed.
+
+    :type ctx: discord.ext.commands.Context
+    :type embed: discord.Embed
+    :type args: utils.argparser.ParsedArguments
+    :type caster: cogs5e.models.sheet.statblock.StatBlock
+    :type attack: cogs5e.models.sheet.attack.Attack
+    :type targets: list of str or list of cogs5e.models.sheet.statblock.StatBlock
+    :type combat: None or cogs5e.models.initiative.Combat
+    """
     if not args.last('h', type_=bool):
         name = caster.get_title_name()
     else:
@@ -22,6 +32,12 @@ async def run_attack(ctx, embed, args, caster, attack, targets, combat):
             .replace('[aname]', attack_name)
     else:
         embed.title = f'{name} {verb} {attack_name}!'
+
+    # arg overrides (#1163)
+    arg_defaults = {
+        'criton': attack.criton, 'phrase': attack.phrase, 'thumb': attack.thumb, 'c': attack.extra_crit_damage
+    }
+    args.update_nx(arg_defaults)
 
     await attack.automation.run(ctx, embed, caster, targets, args, combat=combat, title=embed.title)
     if combat:

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -473,9 +473,9 @@ class GameTrack(commands.Cog):
 
         delta = f"({counter.value - old_value:+})"
         if new_value - counter.value:  # we overflowed somewhere
-          out = f"{str(counter)} {delta}\n({abs(new_value - counter.value)} overflow)"
+            out = f"{str(counter)} {delta}\n({abs(new_value - counter.value)} overflow)"
         else:
-          out = f"{str(counter)} {delta}"
+            out = f"{str(counter)} {delta}"
 
         result_embed.add_field(name=counter.name, value=out)
 
@@ -484,12 +484,16 @@ class GameTrack(commands.Cog):
 
     @customcounter.command(name='create')
     async def customcounter_create(self, ctx, name, *args):
-        """Creates a new custom counter.
+        """
+        Creates a new custom counter.
         __Valid Arguments__
         `-reset <short|long|none>` - Counter will reset to max on a short/long rest, or not ever when "none". Default - will reset on a call of `!cc reset`.
         `-max <max value>` - The maximum value of the counter.
         `-min <min value>` - The minimum value of the counter.
-        `-type <bubble|default>` - Whether the counter displays bubbles to show remaining uses or numbers. Default - numbers."""
+        `-type <bubble|default>` - Whether the counter displays bubbles to show remaining uses or numbers. Default - numbers.
+        `-resetto <value>` - The value to reset the counter to. Default - maximum.
+        `-resetby <value>` - Rather than resetting to a certain value, modify the counter by this much per reset. Supports dice.
+        """
         character: Character = await Character.from_ctx(ctx)
 
         conflict = next((c for c in character.consumables if c.name.lower() == name.lower()), None)
@@ -504,8 +508,11 @@ class GameTrack(commands.Cog):
         _max = args.last('max')
         _min = args.last('min')
         _type = args.last('type')
+        reset_to = args.last('resetto')
+        reset_by = args.last('resetby')
         try:
-            new_counter = CustomCounter.new(character, name, maxv=_max, minv=_min, reset=_reset, display_type=_type)
+            new_counter = CustomCounter.new(character, name, maxv=_max, minv=_min, reset=_reset, display_type=_type,
+                                            reset_to=reset_to, reset_by=reset_by)
             character.consumables.append(new_counter)
             await character.commit(ctx)
         except InvalidArgument as e:
@@ -552,7 +559,7 @@ class GameTrack(commands.Cog):
             counter = await character.select_consumable(ctx, name)
             before = counter.value
             try:
-                counter.reset()
+                counter.reset()  # todo
                 await character.commit(ctx)
             except ConsumableException as e:
                 await ctx.send(f"Counter could not be reset: {e}")

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -144,7 +144,7 @@ class InitTracker(commands.Cog):
         if args.last('controller'):
             controller_name = args.last('controller')
             member = await commands.MemberConverter().convert(ctx, controller_name)
-            controller = str(member.id) if member is not None else controller
+            controller = str(member.id) if member is not None and not member.bot else controller
         if args.last('group'):
             group = args.last('group')
         if args.last('hp'):
@@ -654,6 +654,8 @@ class InitTracker(commands.Cog):
             member = await commands.MemberConverter().convert(ctx, controller_name)
             if member is None:
                 return "\u274c New controller not found."
+            if member.bot:
+                return "\u274c Bots cannot control combatants."
             allowed_mentions.add(member)
             combatant.controller = str(member.id)
             return f"\u2705 {combatant.name}'s controller set to {combatant.controller_mention()}."

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -13,13 +13,14 @@ from aliasing import helpers
 from cogs5e.funcs import attackutils, checkutils, targetutils
 from cogs5e.models.character import Character
 from cogs5e.models.embeds import EmbedWithAuthor, EmbedWithCharacter
-from cogs5e.models.errors import InvalidArgument, NoCombatants, NoSelectionElements, SelectionException
+from cogs5e.models.errors import InvalidArgument, NoSelectionElements, SelectionException
 from cogs5e.models.initiative import Combat, Combatant, CombatantGroup, Effect, MonsterCombatant, PlayerCombatant
 from cogs5e.models.sheet.attack import Attack
 from cogs5e.models.sheet.base import Skill
 from cogs5e.models.sheet.resistance import Resistances
 from cogsmisc.stats import Stats
 from gamedata.lookuputils import select_monster_full, select_spell_full
+from utils import constants
 from utils.argparser import argparse, argsplit
 from utils.functions import confirm, get_guild_member, search_and_select, try_delete
 
@@ -1186,16 +1187,53 @@ class InitTracker(commands.Cog):
             targets = await targetutils.definitely_combat(combat, args, allow_groups=True)
 
         # embed setup
-        embed = discord.Embed()
-        if is_player:
-            embed.colour = combatant.character.get_color()
-        else:
-            embed.colour = random.randint(0, 0xffffff)
+        embed = discord.Embed(color=combatant.get_color())
 
         # run
         await attackutils.run_attack(ctx, embed, args, caster, attack, targets, combat)
 
         await ctx.send(embed=embed)
+
+    @init.command(aliases=['c'])
+    async def check(self, ctx, check, *args):
+        """
+        Rolls an ability check as the current combatant. See `!help check` for valid arguments.
+        """
+        combat = await Combat.from_ctx(ctx)
+        combatant = combat.current_combatant
+        if combatant is None:
+            return await ctx.send("It is not currently anyone's turn.")
+
+        skill_key = await search_and_select(ctx, constants.SKILL_NAMES, check, lambda s: s)
+        embed = discord.Embed(color=combatant.get_color())
+
+        args = await helpers.parse_snippets(args, ctx)
+        args = argparse(args)
+
+        checkutils.run_check(skill_key, combatant, args, embed)
+
+        await ctx.send(embed=embed)
+        await try_delete(ctx.message)
+
+    @init.command(aliases=['s'])
+    async def save(self, ctx, save, *args):
+        """
+        Rolls an ability save as the current combatant. See `!help save` for valid arguments.
+        """
+        combat = await Combat.from_ctx(ctx)
+        combatant = combat.current_combatant
+        if combatant is None:
+            return await ctx.send("It is not currently anyone's turn.")
+
+        embed = discord.Embed(color=combatant.get_color())
+        args = await helpers.parse_snippets(args, ctx)
+        args = argparse(args)
+
+        checkutils.run_save(save, combatant, args, embed)
+
+        # send
+        await ctx.send(embed=embed)
+        await try_delete(ctx.message)
 
     @init.command()
     async def cast(self, ctx, spell_name, *, args=''):
@@ -1296,7 +1334,7 @@ class InitTracker(commands.Cog):
         result = await spell.cast(ctx, combatant, targets, args, combat=combat)
 
         embed = result['embed']
-        embed.colour = random.randint(0, 0xffffff) if not is_character else combatant.character.get_color()
+        embed.colour = combatant.get_color()
         await ctx.send(embed=embed)
         await combat.final()
 

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -488,16 +488,19 @@ class Attack(Effect):
 
         # roll attack against autoctx.target
         if not (hit or miss):
-            formatted_d20 = '1d20'
-            if adv == 1:
-                formatted_d20 = '2d20kh1'
-            elif adv == 2:
-                formatted_d20 = '3d20kh1'
-            elif adv == -1:
-                formatted_d20 = '2d20kl1'
-
+            # reroll before kh/kl (#1199)
+            reroll_str = ''
             if reroll:
-                formatted_d20 = f"{formatted_d20}ro{reroll}"
+                reroll_str = f"ro{reroll}"
+
+            if adv == 1:
+                formatted_d20 = f'2d20{reroll_str}kh1'
+            elif adv == 2:
+                formatted_d20 = f'3d20{reroll_str}kh1'
+            elif adv == -1:
+                formatted_d20 = f'2d20{reroll_str}kl1'
+            else:
+                formatted_d20 = f'1d20{reroll_str}'
 
             to_hit_message = 'To Hit'
             if ac:

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -290,6 +290,10 @@ class Character(StatBlock):
     async def select_consumable(self, ctx, name):
         return await search_and_select(ctx, self.consumables, name, lambda ctr: ctr.name)
 
+    def get_consumable(self, name):
+        """Gets the next custom counter with the exact given name (case-sensitive). Returns None if not found."""
+        return next((con for con in self.consumables if con.name == name), None)
+
     def sync_consumable(self, ctr):
         if self._live_integration:
             self._live_integration.sync_consumable(ctr)
@@ -304,7 +308,7 @@ class Character(StatBlock):
             if ctr.reset_on == scope:
                 before = ctr.value
                 try:
-                    ctr.reset()
+                    ctr.reset()  # todo
                 except NoReset:
                     continue
                 reset.append((ctr, ctr.value - before))

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -306,18 +306,17 @@ class Character(StatBlock):
         reset = []
         for ctr in self.consumables:
             if ctr.reset_on == scope:
-                before = ctr.value
                 try:
-                    ctr.reset()  # todo
+                    result = ctr.reset()
                 except NoReset:
                     continue
-                reset.append((ctr, ctr.value - before))
+                reset.append((ctr, result))
         return reset
 
     # ---------- RESTING ----------
     def on_hp(self):
         """
-        Returns a list of all the reset counters and their deltas in [(counter, delta)].
+        Returns a list of all the reset counters and their reset results in [(counter, result)].
         Resets but does not return Death Saves.
         """
         reset = []
@@ -326,42 +325,45 @@ class Character(StatBlock):
             self.death_saves.reset()
         return reset
 
-    def short_rest(self):
+    def short_rest(self, cascade=True):
         """
-        Returns a list of all the reset counters and their deltas in [(counter, delta)].
+        Returns a list of all the reset counters and their reset results in [(counter, result)].
         Resets but does not return Spell Slots or Death Saves.
         """
         reset = []
-        reset.extend(self.on_hp())
+        if cascade:
+            reset.extend(self.on_hp())
         reset.extend(self._reset_custom('short'))
         if self.get_setting('srslots', False):
             self.spellbook.reset_slots()
         return reset
 
-    def long_rest(self):
+    def long_rest(self, cascade=True):
         """
         Resets all applicable consumables.
-        Returns a list of all the reset counters and their deltas in [(counter, delta)].
+        Returns a list of all the reset counters and their reset results in [(counter, result)].
         Resets but does not return HP, Spell Slots, or Death Saves.
         """
         reset = []
-        reset.extend(self.on_hp())
-        reset.extend(self.short_rest())
+        if cascade:
+            reset.extend(self.on_hp())
+            reset.extend(self.short_rest(cascade=False))
         reset.extend(self._reset_custom('long'))
         self.reset_hp()
         if not self.get_setting('srslots', False):
             self.spellbook.reset_slots()
         return reset
 
-    def reset_all_consumables(self):
+    def reset_all_consumables(self, cascade=True):
         """
-        Returns a list of all the reset counters and their deltas in [(counter, delta)].
+        Returns a list of all the reset counters and their reset results in [(counter, result)].
         Resets but does not return HP, Spell Slots, or Death Saves.
         """
         reset = []
-        reset.extend(self.on_hp())
-        reset.extend(self.short_rest())
-        reset.extend(self.long_rest())
+        if cascade:
+            reset.extend(self.on_hp())
+            reset.extend(self.short_rest(cascade=False))
+            reset.extend(self.long_rest(cascade=False))
         reset.extend(self._reset_custom(None))
         return reset
 

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -1,5 +1,4 @@
 import logging
-import random
 
 import cachetools
 
@@ -150,7 +149,7 @@ class Character(StatBlock):
 
     # ---------- Basic CRUD ----------
     def get_color(self):
-        return self.options.get('color') or random.randint(0, 0xffffff)
+        return self.options.get('color', super().get_color())
 
     @property
     def owner(self):

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -1430,17 +1430,27 @@ class Effect:
         self.combatant.remove_effect(self)
 
     def on_name_change(self, old_name, new_name):
-        for effect in self.get_children_effects():
+        for child_ref in self.children:
+            effect = self.get_child_effect(child_ref)
             effect.parent['combatant'] = new_name
+            # #1315 - if parent/child hierarchy is on the same combatant it can be weird
+            # eventually, this should be fixed by todo asssigning unique ids to combatants
+            if child_ref['combatant'] == old_name:
+                child_ref['combatant'] = new_name
 
         if self.parent:
             parent = self.get_parent_effect()
+            if parent is None:
+                return
             for child in parent.children:
                 if child['combatant'] == old_name:
                     child['combatant'] = new_name
 
     def get_parent_effect(self):
-        return self.combat.get_combatant(self.parent['combatant'], True).get_effect(self.parent['effect'], True)
+        combatant = self.combat.get_combatant(self.parent['combatant'], True)
+        if combatant is None:
+            return None
+        return combatant.get_effect(self.parent['effect'], True)
 
     def get_children_effects(self):
         """Returns an iterator of Effects of this Effect's children."""

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -259,7 +259,7 @@ class Combat:
         for c in self._combatants:
             init_roll = roll(c.init_skill.d20())
             c.init = init_roll.total
-            rolls[c.name] = init_roll
+            rolls[c] = init_roll
         self.sort_combatants()
 
         # reset current turn
@@ -267,8 +267,9 @@ class Combat:
         self._current_index = None
 
         order = []
-        for combatant_name, init_roll in sorted(rolls.items(), key=lambda r: r[1].total, reverse=True):
-            order.append(f"{init_roll.result}: {combatant_name}")
+        for combatant, init_roll in sorted(rolls.items(), key=lambda r: (r[1].total, int(r[0].init_skill)),
+                                           reverse=True):
+            order.append(f"{init_roll.result}: {combatant.name}")
 
         order = "\n".join(order)
 

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -1025,6 +1025,9 @@ class PlayerCombatant(Combatant):
     def get_scope_locals(self):
         return {**self.character.get_scope_locals(), **super().get_scope_locals()}
 
+    def get_color(self):
+        return self.character.get_color()
+
     # ==== serialization ====
     @classmethod
     async def from_dict(cls, raw, ctx, combat):

--- a/cogs5e/models/sheet/base.py
+++ b/cogs5e/models/sheet/base.py
@@ -119,15 +119,17 @@ class Skill:
         else:
             adv = None
 
-        if adv is False:
-            base = f"2d20kl1"
-        elif adv is True:
-            base = f"2d20kh1"
-        else:
-            base = f"1d20"
-
+        # reroll string (#1199)
+        reroll_str = ''
         if reroll:
-            base = f"{base}ro{reroll}"
+            reroll_str = f"ro{reroll}"
+
+        if adv is False:
+            base = f"2d20{reroll_str}kl1"
+        elif adv is True:
+            base = f"2d20{reroll_str}kh1"
+        else:
+            base = f"1d20{reroll_str}"
 
         if min_val:
             base = f"{base}mi{min_val}"

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -116,7 +116,8 @@ class CustomCounter:
 
     def to_dict(self):
         return {"name": self.name, "value": self._value, "minv": self.min, "maxv": self.max, "reset": self.reset_on,
-                "display_type": self.display_type, "live_id": self.live_id}
+                "display_type": self.display_type, "live_id": self.live_id, "reset_to": self.reset_to,
+                "reset_by": self.reset_by}
 
     @classmethod
     def new(cls, character, name, minv=None, maxv=None, reset=None, display_type=None, live_id=None,
@@ -154,10 +155,11 @@ class CustomCounter:
             if max_value is not None and reset_to_value > max_value:
                 raise InvalidArgument("Reset to value is greater than max value.")
 
-        try:
-            d20.parse(reset_by)
-        except d20.RollSyntaxError:
-            raise InvalidArgument(f"{reset_by} (`resetby`) cannot be interpreted as a number or dice string.")
+        if reset_by is not None:
+            try:
+                d20.parse(reset_by)
+            except d20.RollSyntaxError:
+                raise InvalidArgument(f"{reset_by} (`resetby`) cannot be interpreted as a number or dice string.")
 
         # set initial value
         initial_value = max(0, min_value or 0)
@@ -258,6 +260,11 @@ class CustomCounter:
                 val += f"**Range**: \u2264{_max}\n"
         if _reset:
             val += f"**Resets On**: {_reset}\n"
+        if self.reset_to is not None:
+            reset_to = self._character.evaluate_math(self.reset_to)
+            val += f"**Resets To**: {reset_to}"
+        if self.reset_by is not None:
+            val += f"**On Reset**: +{self.reset_by}"
         return val.strip()
 
     def __str__(self):

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -187,6 +187,11 @@ class CustomCounter:
                 self._max_value = self._character.evaluate_math(self.max)
         return self._max_value
 
+    def get_reset_to(self):
+        if self.reset_to is None:
+            return None
+        return self._character.evaluate_math(self.reset_to)
+
     @property
     def value(self):
         return self._value
@@ -218,7 +223,7 @@ class CustomCounter:
 
         # reset to: fixed value
         if self.reset_to is not None:
-            target_value = self._character.evaluate_math(self.reset_to)
+            target_value = self.get_reset_to()
             new_value = self.set(target_value)
             delta = f"{new_value - old_value:+}"
 
@@ -261,8 +266,7 @@ class CustomCounter:
         if _reset:
             val += f"**Resets On**: {_reset}\n"
         if self.reset_to is not None:
-            reset_to = self._character.evaluate_math(self.reset_to)
-            val += f"**Resets To**: {reset_to}"
+            val += f"**Resets To**: {self.get_reset_to()}"
         if self.reset_by is not None:
             val += f"**On Reset**: +{self.reset_by}"
         return val.strip()

--- a/cogs5e/models/sheet/statblock.py
+++ b/cogs5e/models/sheet/statblock.py
@@ -1,3 +1,5 @@
+import random
+
 from cogs5e.models.sheet.attack import AttackList
 from cogs5e.models.sheet.base import BaseStats, Levels, Saves, Skills
 from cogs5e.models.sheet.resistance import Resistances
@@ -126,6 +128,9 @@ class StatBlock:
     # ----- Display -----
     def get_title_name(self):
         return self._name
+
+    def get_color(self):
+        return random.randint(0, 0xffffff)
 
     # ----- HP -----
     def hp_str(self):

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -128,16 +128,25 @@ class SheetManager(commands.Cog):
     async def attack_add(self, ctx, name, *args):
         """
         Adds an attack to the active character.
-        __Arguments__
-        -d [damage]: How much damage the attack should do.
-        -b [to-hit]: The to-hit bonus of the attack.
-        -desc [description]: A description of the attack.
+        __Valid Arguments__
+        -d <damage> - How much damage the attack should do.
+        -b <to-hit> - The to-hit bonus of the attack.
+        -desc <description> - A description of the attack.
+        -verb <verb> - The verb to use for this attack. (e.g. "Padellis <verb> a dagger!")
+        proper - This attack's name is a proper noun.
+        -criton <#> - This attack crits on a number other than a natural 20.
+        -phrase <text> - Some flavor text to add to each attack with this attack.
+        -thumb <image url> - The attack's image.
+        -c <extra crit damage> - How much extra damage (beyond doubling dice) this attack does on a crit.
         """
         character: Character = await Character.from_ctx(ctx)
         parsed = argparse(args)
 
         attack = Attack.new(name, bonus_calc=parsed.join('b', '+'),
-                            damage_calc=parsed.join('d', '+'), details=parsed.join('desc', '\n'))
+                            damage_calc=parsed.join('d', '+'), details=parsed.join('desc', '\n'),
+                            verb=parsed.last('verb'), proper=parsed.last('proper', False, bool),
+                            criton=parsed.last('criton', type_=int), phrase=parsed.join('phrase', '\n'),
+                            thumb=parsed.last('thumb'), extra_crit_damage=parsed.last('c'))
 
         conflict = next((a for a in character.overrides.attacks if a.name.lower() == attack.name.lower()), None)
         if conflict:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -517,7 +517,7 @@ class SheetManager(commands.Cog):
         `talent true/false` - Enables/disables whether to apply a rogue's Reliable Talent on checks you're proficient with."""
         char = await Character.from_ctx(ctx)
 
-        out = ['Operations complete!']
+        out = []
         skip = False
         for i, arg in enumerate(args):
             if skip:
@@ -525,6 +525,10 @@ class SheetManager(commands.Cog):
             if arg in CHARACTER_SETTINGS:
                 skip = True
                 out.append(CHARACTER_SETTINGS[arg].run(ctx, char, list_get(i + 1, None, args)))
+
+        if not out:
+            return await ctx.send(f"No valid settings found. See `{ctx.prefix}help {ctx.invoked_with}` for a list "
+                                  f"of valid settings.")
 
         await char.commit(ctx)
         await ctx.send('\n'.join(out))

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -348,6 +348,7 @@ class GoogleSheet(SheetLoaderABC):
                 levelcell = f"N{rownum}"
                 classname = self.additional.value(namecell)
                 if classname:
+                    classname = re.sub(r'[.$]', '_', classname)  # sentry-H7 - invalid class names
                     classlevel = int(self.additional.value(levelcell))
                     level_dict[classname] = classlevel
                 else:  # classes should be top-aligned

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -921,6 +921,12 @@ SimpleEffect
 .. autoclass:: aliasing.api.combat.SimpleEffect()
     :members:
 
+    .. attribute:: combatant_name
+
+        The name of the combatant this effect is on.
+
+        :type: str
+
     .. attribute:: conc
 
         Whether the effect requires concentration.
@@ -950,6 +956,12 @@ SimpleEffect
         The remaining duration of the effect, in rounds.
 
         :type: int
+
+    .. attribute:: ticks_on_end
+
+        Whether the effect duration ticks at the end of the combatant's turn or at the start.
+
+        :type: bool
 
 SimpleRollResult
 ----------------

--- a/tests/utiltests/argparser_test.py
+++ b/tests/utiltests/argparser_test.py
@@ -48,6 +48,15 @@ def test_argparse():
     args = argparse("""adv dis adv""")
     assert args.adv() == 0
 
+    args = argparse("""adv dis ea""")
+    assert args.adv() == 0
+
+    args = argparse("""ea""")
+    assert args.adv() == 2
+
+    args = argparse("""adv ea""")
+    assert args.adv() == 2
+
 
 def test_argparse_ephem():
     args = argparse("""-d5 1d6 adv1 -d 1""")

--- a/tests/utiltests/argparser_test.py
+++ b/tests/utiltests/argparser_test.py
@@ -49,13 +49,13 @@ def test_argparse():
     assert args.adv() == 0
 
     args = argparse("""adv dis ea""")
-    assert args.adv() == 0
+    assert args.adv(ea=True) == 0
 
     args = argparse("""ea""")
-    assert args.adv() == 2
+    assert args.adv(ea=True) == 2
 
     args = argparse("""adv ea""")
-    assert args.adv() == 2
+    assert args.adv(ea=True) == 2
 
 
 def test_argparse_ephem():

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -150,9 +150,9 @@ class ParsedArguments:
         adv = 0
         if self.last("adv", type_=bool, ephem=ephem):
             adv += 1
-        if self.last("dis", type_=bool, ephem=ephem):
+        if has_dis := self.last("dis", type_=bool, ephem=ephem):
             adv += -1
-        if ea and self.last("ea", type_=bool, ephem=ephem) and adv > -1:
+        if ea and self.last("ea", type_=bool, ephem=ephem) and not has_dis:
             return 2
         if not boolwise:
             return adv

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -181,6 +181,28 @@ class ParsedArguments:
         for context in self._contexts.values():
             del context[arg]
 
+    def update(self, new):
+        """
+        Updates the arguments in this argument list from a dict.
+
+        :param new: The new values for each argument.
+        :type new: dict[str, str] or dict[str, list[str]]
+        """
+        for k, v in new.items():
+            self[k] = v
+
+    def update_nx(self, new):
+        """
+        Like ``.update()``, but only fills in arguments that were not already parsed. Ignores the argument if the
+        value is None.
+
+        :param new: The new values for each argument.
+        :type new: dict[str, str] or dict[str, list[str]] or dict[str, None]
+        """
+        for k, v in new.items():
+            if k not in self and v is not None:
+                self[k] = v
+
     # ephemeral setup
     def _parse_ephemeral(self, argdict):
         for key in argdict:
@@ -270,6 +292,10 @@ class ParsedArguments:
         return len(self._parsed)
 
     def __setitem__(self, key, value):
+        """
+        :type key: str
+        :type value: str or list[str]
+        """
         if not isinstance(value, list):
             value = [value]
         self._parsed[key] = value

--- a/utils/dice.py
+++ b/utils/dice.py
@@ -4,7 +4,7 @@ import d20
 class VerboseMDStringifier(d20.MarkdownStringifier):
     def _str_expression(self, node):
         return f"**{node.comment or 'Result'}**: {self._stringify(node.roll)}\n" \
-               f"**Total:** {int(node.total)}"
+               f"**Total**: {int(node.total)}"
 
 
 class PersistentRollContext(d20.RollContext):


### PR DESCRIPTION
### Summary
- Resolves #1301 
- Resolves #1259 
- Resolves #1212 (by making it so bots cannot control combatants in init)
- Resolves #1241 (display an error if no settings were actually changed)
- Resolves #450 (finally!)
    - adds 2 new properties to `CustomCounter` 
    - breaking: `CustomCounter.reset()` now returns a namedtuple rather than an int
- Resolves #1308 
- Resolves #1199 
- Resolves #1163 (also see api and dashboard PRs)
- Resolves #1305 (adds parent and children properties)
- Resolves #1310 (adds controller and group name properties)
- Resolves #1200 
- Resolves #1315 
- Fixes SENTRY-H7 (gsheet import could import invalid class names)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
