### PR TITLE
Add channel category to AliasContext

### DIFF
--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -71,8 +71,8 @@ class AliasContext:
 
 
     def __repr__(self):
-        return f"<AliasContext guild={self.guild} channel={self.channel} category={self.category} author={self.author}"\
-               f" prefix={self.prefix} alias={self.alias}>"
+        return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix} " \
+               f"alias={self.alias}>"
 
 
 class AliasGuild:
@@ -121,8 +121,7 @@ class AliasChannel:
         self._name = str(channel)
         self._id = channel.id
         self._topic = channel.topic if not isinstance(channel, discord.DMChannel) else None
-        self._category = AliasCategory(channel.category) if hasattr(channel, 'category') \
-                                                            and channel.category is not None else None
+        self._category = AliasCategory(channel.category) if getattr(channel, 'category', None) is not None else None
 
     @property
     def name(self):
@@ -233,7 +232,7 @@ class AliasCategory:
     @property
     def name(self):
         """
-        The name of the category, not including the preceding hash (#).
+        The name of the category
 
         :rtype: str
         """

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -15,8 +15,6 @@ class AliasContext:
         """
         self._guild = None if ctx.guild is None else AliasGuild(ctx.guild)
         self._channel = AliasChannel(ctx.channel)
-        self._category = AliasCategory(ctx.channel.category) if hasattr(ctx.channel, 'category') \
-                                                                and ctx.channel.category is not None else None
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with
@@ -71,14 +69,6 @@ class AliasContext:
         """
         return self._alias
 
-    @property
-    def category(self):
-        """
-        The category of the channel the alias was run in
-
-        :rtype: :class:`~aliasing.api.context.AliasContext`
-        """
-        return self._category
 
     def __repr__(self):
         return f"<AliasContext guild={self.guild} channel={self.channel} category={self.category} author={self.author}"\
@@ -131,6 +121,8 @@ class AliasChannel:
         self._name = str(channel)
         self._id = channel.id
         self._topic = channel.topic if not isinstance(channel, discord.DMChannel) else None
+        self._category = AliasCategory(channel.category) if hasattr(channel, 'category') \
+                                                            and channel.category is not None else None
 
     @property
     def name(self):
@@ -158,6 +150,15 @@ class AliasChannel:
         :rtype: str
         """
         return self._topic
+
+    @property
+    def category(self):
+        """
+        The category of the channel the alias was run in
+
+        :rtype: :class:`~aliasing.api.context.AliasCategory` or None
+        """
+        return self._category
 
     def __str__(self):
         return self.name
@@ -224,7 +225,7 @@ class AliasCategory:
 
     def __init__(self, category):
         """
-        :type channel: discord.TextChannel
+        :type channel: discord.ChannelCategory
         """
         self._name = str(category)
         self._id = category.id
@@ -232,7 +233,7 @@ class AliasCategory:
     @property
     def name(self):
         """
-        The name of the channel, not including the preceding hash (#).
+        The name of the category, not including the preceding hash (#).
 
         :rtype: str
         """
@@ -241,7 +242,7 @@ class AliasCategory:
     @property
     def id(self):
         """
-        The ID of the channel.
+        The ID of the category.
 
         :rtype: int
         """

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -15,7 +15,8 @@ class AliasContext:
         """
         self._guild = None if ctx.guild is None else AliasGuild(ctx.guild)
         self._channel = AliasChannel(ctx.channel)
-        self._category = None if ctx.channel.category is None else AliasCategory(ctx.channel.category)
+        self._category = AliasCategory(ctx.channel.category) if hasattr(ctx.channel, 'category') \
+                                                                and ctx.channel.category is not None else None
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -15,6 +15,7 @@ class AliasContext:
         """
         self._guild = None if ctx.guild is None else AliasGuild(ctx.guild)
         self._channel = AliasChannel(ctx.channel)
+        self._category = AliasCategory(ctx.channel.category)
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with
@@ -69,9 +70,18 @@ class AliasContext:
         """
         return self._alias
 
+    @property
+    def category(self):
+        """
+        The category of the channel the alias was run in
+
+        :rtype: :class:`~aliasing.api.context.AliasContext`
+        """
+        return self._category
+
     def __repr__(self):
-        return f"<AliasContext guild={self.guild} channel={self.channel} author={self.author} prefix={self.prefix}" \
-               f" alias={self.alias}>"
+        return f"<AliasContext guild={self.guild} channel={self.channel} category={self.category} author={self.author}"\
+               f" prefix={self.prefix} alias={self.alias}>"
 
 
 class AliasGuild:
@@ -204,3 +214,37 @@ class AliasAuthor:
 
     def __str__(self):
         return f"{self.name}#{self.discriminator}"
+
+
+class AliasCategory:
+    """
+    Represents the category of the Discord channel an alias was invoked in.
+    """
+
+    def __init__(self, category):
+        """
+        :type channel: discord.TextChannel
+        """
+        self._name = str(category)
+        self._id = category.id
+
+    @property
+    def name(self):
+        """
+        The name of the channel, not including the preceding hash (#).
+
+        :rtype: str
+        """
+        return self._name
+
+    @property
+    def id(self):
+        """
+        The ID of the channel.
+
+        :rtype: int
+        """
+        return self._id
+
+    def __str__(self):
+        return self.name

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -15,7 +15,7 @@ class AliasContext:
         """
         self._guild = None if ctx.guild is None else AliasGuild(ctx.guild)
         self._channel = AliasChannel(ctx.channel)
-        self._category = AliasCategory(ctx.channel.category)
+        self._category = None if ctx.channel.category is None else AliasCategory(ctx.channel.category)
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -1035,6 +1035,12 @@ AliasChannel
 .. autoclass:: aliasing.api.context.AliasChannel()
     :members:
 
+AliasCategory
+^^^^^^^^^^^^
+
+.. autoclass:: aliasing.api.context.AliasCategory()
+    :members:
+
 AliasAuthor
 ^^^^^^^^^^^
 


### PR DESCRIPTION
# Summary
Adds a property to AliasContext to represent the category of the channel that it has been executed in.

Resolves #1333 

## Methods added

`AliasChannel` -

* `AliasChannel.category`

`AliasCategory` -

* `AliasCategory.name`
* `AliasCategory.id`

# Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
