### PR TITLE
Adds get_consumable to AliasCharacter

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -44,7 +44,7 @@ class AliasCharacter(AliasStatBlock):
             self._consumables = [AliasCustomCounter(cc) for cc in self._character.consumables]
         return self._consumables
 
-    def get_consumable(self, name):
+    def cc(self, name):
         """
         Gets the AliasCustomCounter with the name `name`
 
@@ -53,7 +53,7 @@ class AliasCharacter(AliasStatBlock):
         :rtype: AliasCustomCounter
         :raises: :exc:`ConsumableException` if the counter does not exist.
         """
-        return self._get_consumable(name)
+        return AliasCustomCounter(self._get_consumable(name))
 
     def get_cc(self, name):
         """

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -44,6 +44,17 @@ class AliasCharacter(AliasStatBlock):
             self._consumables = [AliasCustomCounter(cc) for cc in self._character.consumables]
         return self._consumables
 
+    def get_consumable(self, name):
+        """
+        Gets the AliasCustomCounter with the name `name`
+
+        :param str name: The name of the custom counter to get.
+        :returns: The custom counter.
+        :rtype: AliasCustomCounter
+        :raises: :exc:`ConsumableException` if the counter does not exist.
+        """
+        return self._get_consumable(name)
+
     def get_cc(self, name):
         """
         Gets the value of a custom counter.


### PR DESCRIPTION
Summary
========

Adds the ability to get the `AliasConsumable` from a name. I implemented it as a non-breaking change, but I am interested to see what people think about making it a breaking change by replacing `AliasCharacter.get_cc`

Additions
---------
`AliasCharacter.cc(name: str)` - Returns the `AliasConsumable` from the name.

Issues
-------
Resolves #1339 (AFR-671)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.