### PR TITLE
Adds handling for resetto or resetby when no max

### DIFF
--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -130,7 +130,7 @@ class CustomCounter:
             raise InvalidArgument("Bubble display requires a max and min value.")
 
         # sanity checks
-        if maxv is None and reset not in ('none', None):
+        if maxv is None and reset not in ('none', None) and not (reset_to or reset_by):
             raise InvalidArgument("Reset passed but no maximum passed.")
         if reset_to is not None and reset_by is not None:
             raise InvalidArgument("Both `resetto` and `resetby` arguments found.")


### PR DESCRIPTION
Resolves #1345
### Summary
CC creation now allows not providing `max` when providing either `resetto` or `resetby`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
