### PR TITLE
Add custom advantage parsing

### DIFF
--- a/tests/utiltests/argparser_test.py
+++ b/tests/utiltests/argparser_test.py
@@ -58,6 +58,34 @@ def test_argparse():
     assert args.adv(ea=True) == 2
 
 
+def test_argparse_custom_adv():
+    args = argparse('custom_adv')
+    custom_adv = {
+        'adv': 'custom_adv',
+    }
+
+    assert args.adv(custom=custom_adv) == 1
+    assert args.adv() == 0
+
+    custom_dis = {
+        'dis': 'custom_dis'
+    }
+    assert args.adv(custom=custom_dis) == 0
+
+    args = argparse('custom_dis')
+
+    assert args.adv(custom=custom_dis) == -1
+    assert args.adv() == 0
+
+    custom_ea = {
+        'ea': 'custom_ea'
+    }
+    args = argparse('custom_ea')
+
+    assert args.adv(ea=True, custom=custom_ea) == 2
+    assert args.adv() == 0
+
+
 def test_argparse_ephem():
     args = argparse("""-d5 1d6 adv1 -d 1""")
     for _ in range(4):

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -138,21 +138,32 @@ class ParsedArguments:
         except (ValueError, TypeError):
             raise InvalidArgument(f"{last_arg} cannot be cast to {type_.__name__} (in `{arg}`)")
 
-    def adv(self, ea=False, boolwise=False, ephem=False):
+    def adv(self, ea=False, boolwise=False, ephem=False, custom: dict = None):
         """
         Determines whether to roll with advantage, disadvantage, Elven Accuracy, or no special effect.
 
         :param ea: Whether to parse for elven accuracy.
         :param boolwise: Whether to return an integer or tribool representation.
         :param ephem: Whether to return an ephemeral argument if such exists.
+        :param custom: Dictionary of custom values to parse for. There should be a key for each value you want to overwrite. ``custom={'adv': 'custom_adv'}`` would allow you to parse for advantage if the ``custom_adv`` argument is found.
+
         :return: -1 for dis, 0 for normal, 1 for adv, 2 for ea
         """
+        adv_str, dis_str, ea_str = 'adv', 'dis', 'ea'
+        if custom is not None:
+            if 'adv' in custom:
+                adv_str = custom['adv']
+            if 'dis' in custom:
+                dis_str = custom['dis']
+            if 'ea' in custom:
+                ea_str = custom['ea']
+
         adv = 0
-        if self.last("adv", type_=bool, ephem=ephem):
+        if self.last(adv_str, type_=bool, ephem=ephem):
             adv += 1
-        if has_dis := self.last("dis", type_=bool, ephem=ephem):
+        if has_dis := self.last(dis_str, type_=bool, ephem=ephem):
             adv += -1
-        if ea and self.last("ea", type_=bool, ephem=ephem) and not has_dis:
+        if ea and self.last(ea_str, type_=bool, ephem=ephem) and not has_dis:
             return 2
         if not boolwise:
             return adv


### PR DESCRIPTION
Summary
======

Adds the `custom` kwarg to `ParsedArgument.adv` which allows for the user to override what the function looks for.

![image](https://user-images.githubusercontent.com/16567386/100170901-9b459c00-2e94-11eb-8ad8-cc1fb78e84d7.png)

Example dict of a custom argument:
```py
{
  'adv': 'custom_adv',
  'dis': 'custom_dis',
  'ea': 'custom_ea'
}
```
The current implementation will only pull items from the dictionary that exist, so you can have a custom adv without a custom dis and vice versa.

Note: I realize the doc string is extremely long but I couldn't get it to be <120 characters per line without a line break. I tested it a 
few times with the built docs but I think this way looks the best with what I know.

![image](https://user-images.githubusercontent.com/16567386/100171816-01caba00-2e95-11eb-93a6-3678dc15f2ab.png)

Issues
------
Resolves #1359 (AFR-686)

Checklist
=====
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
