### PR TITLE
Change default behavior on err to not PM the user

### DIFF
--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -122,17 +122,20 @@ def safe_range(start, stop=None, step=None):
 
 # err()
 class AliasException(AvraeException):
-    pass
+    def __init__(self, msg, pm_user):
+        super().__init__(msg)
+        self.pm_user = pm_user
 
 
-def err(reason):
+def err(reason, pm_user=True):
     """
     Stops evaluation of an alias and shows the user an error.
 
     :param str reason: The error to show.
+    :param bool pm_user: Whether or not to PM the user the error traceback.
     :raises: AliasException
     """
-    raise AliasException(reason)
+    raise AliasException(reason, pm_user)
 
 
 # typeof()

--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -127,7 +127,7 @@ class AliasException(AvraeException):
         self.pm_user = pm_user
 
 
-def err(reason, pm_user=True):
+def err(reason, pm_user=False):
     """
     Stops evaluation of an alias and shows the user an error.
 

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -393,7 +393,9 @@ async def handle_alias_exception(ctx, err):
 
     tb = ''.join(traceback.format_exception(type(e), e, e.__traceback__, limit=0, chain=False))
     try:
-        if isinstance(e, AliasException) and e.pm_user:
+        if isinstance(e, AliasException) and not e.pm_user:
+            pass
+        else:
             await ctx.author.send(
                 f"```py\n"
                 f"Error {location}:\n"

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -8,6 +8,7 @@ import cogs5e.models.character as character_model
 from aliasing import evaluators
 from aliasing.constants import CVAR_SIZE_LIMIT, GVAR_SIZE_LIMIT, SVAR_SIZE_LIMIT, UVAR_SIZE_LIMIT
 from aliasing.errors import AliasNameConflict, CollectableNotFound, CollectableRequiresLicenses, EvaluationError
+from aliasing.api.functions import AliasException
 from aliasing.personal import Alias, Servalias, Servsnippet, Snippet
 from aliasing.workshop import WorkshopAlias, WorkshopCollection, WorkshopSnippet
 from cogs5e.models.embeds import EmbedWithAuthor
@@ -392,13 +393,14 @@ async def handle_alias_exception(ctx, err):
 
     tb = ''.join(traceback.format_exception(type(e), e, e.__traceback__, limit=0, chain=False))
     try:
-        await ctx.author.send(
-            f"```py\n"
-            f"Error {location}:\n"
-            f"{point_to_error}"
-            f"{tb}\n"
-            f"```"
-            f"This is an issue in a user-created command; do *not* report this on the official bug tracker.")
+        if isinstance(e, AliasException) and e.pm_user:
+            await ctx.author.send(
+                f"```py\n"
+                f"Error {location}:\n"
+                f"{point_to_error}"
+                f"{tb}\n"
+                f"```"
+                f"This is an issue in a user-created command; do *not* report this on the official bug tracker.")
     except:
         pass
     return await ctx.channel.send(err)


### PR DESCRIPTION
Summary
======
Adds an argument in aliasing to `err` to allow for the alias not to PM the user.

![image](https://user-images.githubusercontent.com/16567386/100172599-abf71180-2e96-11eb-99c0-d8d5a4fc0ef1.png)

Issues
------
Resolves #1357 (AFR-684)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
