### PR TITLE
Allow aliases to set combatant groups

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -236,26 +236,7 @@ class SimpleCombatant(AliasStatBlock):
         if not isinstance(group, str):
             raise ValueError('Group name must be a string.')
 
-        # copied and modified from !i opt code
-
-        combat = self._combatant.combat
-        combatant = self._combatant
-        current = combatant.combat.current_combatant
-        was_current = combatant is current or \
-                      (isinstance(current, CombatantGroup) and combatant in current and len(current) == 1)
-
-        combat.remove_combatant(combatant, ignore_remove_hook=True)
-        if group.lower() == 'none':
-            combat.add_combatant(combatant)
-            if was_current:
-                combat.goto_turn(combatant, True)
-            return None
-        else:
-            c_group = combat.get_group(group, create=combatant.init)
-            c_group.add_combatant(combatant)
-            if was_current:
-                combat.goto_turn(combatant, True)
-            return SimpleGroup(c_group)
+        return self._combatant.set_group(group_name=group)
 
     def set_note(self, note: str):
         """

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -225,6 +225,38 @@ class SimpleCombatant(AliasStatBlock):
             raise ValueError("Combatants must have a name.")
         self._combatant.name = str(name)
 
+    def set_group(self, group: str):
+        """
+        Sets the combatant's group
+
+        :param str group: The name of the group. "None" to remove from group.
+        :return: The combatant's new group, or None if the combatant was removed from a group.
+        :rtype: :class:`~aliasing.api.combat.SimpleGroup` or None   
+        """
+        if not isinstance(group, str):
+            raise ValueError('Group name must be a string.')
+
+        # copied and modified from !i opt code
+
+        combat = self._combatant.combat
+        combatant = self._combatant
+        current = combatant.combat.current_combatant
+        was_current = combatant is current or \
+                      (isinstance(current, CombatantGroup) and combatant in current and len(current) == 1)
+
+        combat.remove_combatant(combatant, ignore_remove_hook=True)
+        if group.lower() == 'none':
+            combat.add_combatant(combatant)
+            if was_current:
+                combat.goto_turn(combatant, True)
+            return None
+        else:
+            c_group = combat.get_group(group, create=combatant.init)
+            c_group.add_combatant(combatant)
+            if was_current:
+                combat.goto_turn(combatant, True)
+            return SimpleGroup(c_group)
+
     def set_note(self, note: str):
         """
         Sets the combatant's note.

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -225,16 +225,16 @@ class SimpleCombatant(AliasStatBlock):
             raise ValueError("Combatants must have a name.")
         self._combatant.name = str(name)
 
-    def set_group(self, group: str):
+    def set_group(self, group):
         """
         Sets the combatant's group
 
-        :param str group: The name of the group. "None" to remove from group.
+        :param str group: The name of the group. None to remove from group.
         :return: The combatant's new group, or None if the combatant was removed from a group.
         :rtype: :class:`~aliasing.api.combat.SimpleGroup` or None   
         """
-        if not isinstance(group, str):
-            raise ValueError('Group name must be a string.')
+        if not (isinstance(group, str) or group is None):
+            raise ValueError('Group name must be a string or None.')
 
         return self._combatant.set_group(group_name=group)
 

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -236,7 +236,11 @@ class SimpleCombatant(AliasStatBlock):
         if not (isinstance(group, str) or group is None):
             raise ValueError('Group name must be a string or None.')
 
-        return self._combatant.set_group(group_name=group)
+        group = self._combatant.set_group(group_name=group)
+        if group is None:
+            return None
+
+        return SimpleGroup(group)
 
     def set_note(self, note: str):
         """

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -684,22 +684,11 @@ class InitTracker(commands.Cog):
 
         @option()
         async def group(combatant):
-            current = combat.current_combatant
-            was_current = combatant is current or \
-                          (isinstance(current, CombatantGroup) and combatant in current and len(current) == 1)
             group_name = args.last('group')
-            combat.remove_combatant(combatant, ignore_remove_hook=True)
-            if group_name.lower() == 'none':
-                combat.add_combatant(combatant)
-                if was_current:
-                    combat.goto_turn(combatant, True)
+            new_group = combatant.set_group(group_name=group_name)
+            if new_group is None:
                 return f"\u2705 {combatant.name} removed from all groups."
-            else:
-                c_group = combat.get_group(group_name, create=combatant.init)
-                c_group.add_combatant(combatant)
-                if was_current:
-                    combat.goto_turn(combatant, True)
-                return f"\u2705 {combatant.name} added to group {c_group.name}."
+            return f"\u2705 {combatant.name} added to group {new_group.name}."
 
         @option(pass_group=True)
         async def name(combatant):

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -688,12 +688,14 @@ class Combatant(StatBlock):
     def group(self, value):
         self._group = value
 
-    def set_group(self, group_name: str):
+    def set_group(self, group_name):
         current = self.combat.current_combatant
         was_current = self is current or \
                       (isinstance(current, CombatantGroup) and self in current and len(current) == 1)
         self.combat.remove_combatant(self, ignore_remove_hook=True)
-        if group_name.lower() == 'none':
+        if isinstance(group_name, str) and group_name.lower() == 'none':
+            group_name = None
+        if group_name is None:
             self.combat.add_combatant(self)
             if was_current:
                 self.combat.goto_turn(self, True)

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -688,6 +688,23 @@ class Combatant(StatBlock):
     def group(self, value):
         self._group = value
 
+    def set_group(self, group_name: str):
+        current = self.combat.current_combatant
+        was_current = self is current or \
+                      (isinstance(current, CombatantGroup) and self in current and len(current) == 1)
+        self.combat.remove_combatant(self, ignore_remove_hook=True)
+        if group_name.lower() == 'none':
+            self.combat.add_combatant(self)
+            if was_current:
+                self.combat.goto_turn(self, True)
+            return None
+        else:
+            c_group = self.combat.get_group(group_name, create=self.init)
+            c_group.add_combatant(self)
+            if was_current:
+                self.combat.goto_turn(self, True)
+            return c_group
+
     def add_effect(self, effect):
         # handle name conflict
         if self.get_effect(effect.name, True):


### PR DESCRIPTION
Summary
======
Allows aliases to set the group of a combatant.

Adds `Combatant.set_group(group_name: str)`
Changes `!i opt` to use the new method on Combatant
Adds `SimpleCombatant.set_group(group: str)` which uses `Combatant.set_group`


Issues
------

Resolves #1317 

Checklist
=====
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
