### PR TITLE
Update pbpUtils.py

### DIFF
--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -79,7 +79,9 @@ class PBPUtils(commands.Cog):
     async def br(self, ctx):
         """Prints a scene break."""
         await try_delete(ctx.message)
-        await ctx.send("``` ```")
+        await ctx.send("""```
+ 
+```""")
 
     @commands.command(hidden=True)
     async def pythag(self, ctx, num1: int, num2: int):


### PR DESCRIPTION
"Fixes" AFR-702

### Summary
This "fixes" AFR-702 by making `break` have triplequotes surrounding the graves, a linebreak, a space on an "empty" line, another linebreak, and then triplequotes. I'm overexplaining a 5 character change. Note: The code change was not tested on a personal clone of Avrae, but one of my own d.py bots

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [?] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
