### PR TITLE
Add setting to disable sending PM's in Combat

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -65,7 +65,8 @@ class InitTracker(commands.Cog):
         dyn - Dynamic initiative; Rerolls all initiatves at the start of a round.
         turnnotif - Notifies the controller of the next combatant in initiative.
         deathdelete - Disables deleting monsters below 0 hp.
-        -name <name> - Sets a name for the combat instance."""
+        -name <name> - Sets a name for the combat instance.
+        nopm - Disables sending a PM when a combatant is damaged."""
         await Combat.ensure_unique_chan(ctx)
 
         options = {}
@@ -79,6 +80,8 @@ class InitTracker(commands.Cog):
             options['turnnotif'] = True
         if args.last('deathdelete', False, bool):
             options['deathdelete'] = True
+        if args.last('nopm', False, bool):
+            options['nopm'] = True
 
         temp_summary_msg = await ctx.send("```Awaiting combatants...```")
         Combat.message_cache[temp_summary_msg.id] = temp_summary_msg  # add to cache
@@ -532,7 +535,8 @@ class InitTracker(commands.Cog):
         dyn - Dynamic initiative; Rerolls all initiatves at the start of a round.
         turnnotif - Notifies the controller of the next combatant in initiative.
         deathdelete - Toggles removing monsters below 0 HP.
-        -name <name> - Sets a name for the combat instance"""
+        -name <name> - Sets a name for the combat instance
+        nopm - Disables sending a PM when a combatant is damaged."""
         args = argparse(settings)
         combat = await Combat.from_ctx(ctx)
         options = combat.options
@@ -550,6 +554,9 @@ class InitTracker(commands.Cog):
         if args.last('deathdelete', default=False, type_=bool):
             options['deathdelete'] = not options.get('deathdelete', False)
             out += f"Monsters at 0 HP will be {'left' if options['deathdelete'] else 'removed'}.\n"
+        if args.last('nopm', False, bool):
+            options['nopm'] = not options.get('nopm', False)
+            out += f"Attacks against hidden combatants {'will not' if options['nopm'] else 'will'} send PM's.\n"
 
         combat.options = options
         await combat.commit()

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -1387,8 +1387,9 @@ class InitTracker(commands.Cog):
             combat = await Combat.from_ctx(ctx)
 
             try:
-                await ctx.author.send(f"End of combat report: {combat.round_num} rounds "
-                                      f"{combat.get_summary(True)}")
+                if not combat.options.get('nopm', False):
+                    await ctx.author.send(f"End of combat report: {combat.round_num} rounds "
+                                          f"{combat.get_summary(True)}")
 
                 summary = await combat.get_summary_msg()
                 await summary.edit(content=combat.get_summary() + " ```-----COMBAT ENDED-----```")

--- a/cogs5e/models/automation.py
+++ b/cogs5e/models/automation.py
@@ -82,6 +82,9 @@ class Automation:
             after(autoctx)
 
         autoctx.build_embed()
+        if combat:
+            if combat.options.get('nopm', False):
+                return
         for user, msgs in autoctx.pm_queue.items():
             try:
                 member = await get_guild_member(ctx.guild, int(user))

--- a/cogs5e/models/initiative.py
+++ b/cogs5e/models/initiative.py
@@ -773,6 +773,8 @@ class Combatant(StatBlock):
         """Sends a message to the combatant's controller."""
         if ctx.guild is None:
             raise RequiresContext("message_controller requires a guild context.")
+        if not self.combat.options.get('nopm', False):
+            return
         member = await get_guild_member(ctx.guild, int(self.controller))
         if member is None:  # member is not in the guild, oh well
             return


### PR DESCRIPTION
Summary
======
Adds a meta-setting to initiative to not send PM's for attacks in Combat

Can be used liked -
* `!i begin nopm` 
* `!i meta nopm`

Issues
------
Resolves #1393 (AFR-704)

Checklist
======
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
