### PR TITLE
Tutorials: Framework and Quickstart

### DIFF
--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -156,7 +156,7 @@ class Dice(commands.Cog):
         await ctx.send(f"{ctx.author.mention}\n{out}", allowed_mentions=discord.AllowedMentions(users=[ctx.author]))
         await Stats.increase_stat(ctx, "dice_rolled_life")
 
-    @commands.group(aliases=['ma', 'monster_attack'], invoke_without_command=True)
+    @commands.group(name='monattack', aliases=['ma', 'monster_attack'], invoke_without_command=True)
     async def monster_atk(self, ctx, monster_name, atk_name=None, *, args=''):
         """Rolls a monster's attack.
         __Valid Arguments__
@@ -231,7 +231,7 @@ class Dice(commands.Cog):
         monster_name = monster.get_title_name()
         return await ctx.send(f"{monster_name}'s attacks:\n{monster.attacks.build_str(monster)}")
 
-    @commands.command(aliases=['mc'])
+    @commands.command(name='moncheck', aliases=['mc', 'monster_check'])
     async def monster_check(self, ctx, monster_name, check, *args):
         """Rolls a check for a monster.
         __Valid Arguments__
@@ -269,7 +269,7 @@ class Dice(commands.Cog):
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
 
-    @commands.command(aliases=['ms'])
+    @commands.command(name='monsave', aliases=['ms', 'monster_save'])
     async def monster_save(self, ctx, monster_name, save_stat, *args):
         """Rolls a save for a monster.
         __Valid Arguments__
@@ -301,7 +301,7 @@ class Dice(commands.Cog):
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
 
-    @commands.command(aliases=['mcast'])
+    @commands.command(name='moncast', aliases=['mcast', 'monster_cast'])
     async def monster_cast(self, ctx, monster_name, spell_name, *args):
         """
         Casts a spell as a monster.

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -10,8 +10,10 @@ from utils import checks
 from utils.aldclient import discord_user_to_dict
 from utils.functions import confirm, get_guild_member, search_and_select
 from .ddblink import DDBLink
+from .init_dm import DMInitiative
 from .models import TutorialStateMap
 from .quickstart import Quickstart
+from .runningthegame import RunningTheGame
 from .spellcasting import Spellcasting
 
 
@@ -23,8 +25,12 @@ class Tutorials(commands.Cog):
     # tutorial keys should never change - if needed, change the name in the constructor to change the display name
     tutorials = {
         "quickstart": Quickstart(),
+        # "playingthegame": None,
         "ddblink": DDBLink(),
-        "spellcasting": Spellcasting()
+        "spellcasting": Spellcasting(),
+        "runningthegame": RunningTheGame(),
+        # "init_player": None,
+        "init_dm": DMInitiative()
     }
 
     def __init__(self, bot):

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -13,6 +13,21 @@ class Tutorials(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
+    @commands.group()
+    async def tutorial(self, ctx):
+        """Shows the current tutorial objective, or lists the available tutorials if one is not active."""
+        pass
+
+    @tutorial.command(name='skip')
+    async def tutorial_skip(self, ctx):
+        """Skips the current objective, and moves on to the next part of the tutorial."""
+        pass
+
+    @tutorial.command(name='end')
+    async def tutorial_end(self, ctx):
+        """Ends the current tutorial."""
+        pass
+
 
 def setup(bot):
     cog = Tutorials(bot)

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -9,6 +9,7 @@ from cogs5e.models.embeds import EmbedWithAuthor
 from utils.functions import confirm, get_guild_member, search_and_select
 from .example import ExampleTutorial
 from .models import TutorialStateMap
+from .quickstart import Quickstart
 
 
 class Tutorials(commands.Cog):
@@ -18,7 +19,7 @@ class Tutorials(commands.Cog):
 
     # tutorial keys should never change - if needed, change the name in the constructor to change the display name
     tutorials = {
-        "test_example": ExampleTutorial(name="example", description="this is an example tutorial")
+        "quickstart": Quickstart()
     }
 
     def __init__(self, bot):

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -27,7 +27,7 @@ class Tutorials(commands.Cog):
 
     # ==== commands ====
     @commands.group(invoke_without_command=True)
-    async def tutorial(self, ctx, name=None):
+    async def tutorial(self, ctx, *, name=None):
         """
         Shows the current tutorial objective, lists the available tutorials if one is not active, or begins a new tutorial.
         """

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -9,9 +9,10 @@ from cogs5e.models.embeds import EmbedWithAuthor
 from utils import checks
 from utils.aldclient import discord_user_to_dict
 from utils.functions import confirm, get_guild_member, search_and_select
-from .example import ExampleTutorial
+from .ddblink import DDBLink
 from .models import TutorialStateMap
 from .quickstart import Quickstart
+from .spellcasting import Spellcasting
 
 
 class Tutorials(commands.Cog):
@@ -21,7 +22,9 @@ class Tutorials(commands.Cog):
 
     # tutorial keys should never change - if needed, change the name in the constructor to change the display name
     tutorials = {
-        "quickstart": Quickstart()
+        "quickstart": Quickstart(),
+        "ddblink": DDBLink(),
+        "spellcasting": Spellcasting()
     }
 
     def __init__(self, bot):

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -56,7 +56,8 @@ class Tutorials(commands.Cog):
         """Lists the available tutorials."""
         embed = EmbedWithAuthor(ctx)
         embed.title = "Available Tutorials"
-        embed.description = f"Use `{ctx.prefix}tutorial <name>` to select a tutorial from the ones available below!"
+        embed.description = f"Use `{ctx.prefix}tutorial <name>` to select a tutorial from the ones available below!\n" \
+                            f"First time here? Try `{ctx.prefix}tutorial quickstart`!"
         for tutorial in self.tutorials.values():
             embed.add_field(name=tutorial.name, value=tutorial.description, inline=False)
         await ctx.send(embed=embed)

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -4,11 +4,17 @@ are registered here. The tutorial commands are also registered here, as part of 
 """
 from discord.ext import commands
 
+from .example import ExampleTutorial
+
 
 class Tutorials(commands.Cog):
     """
     Commands to help learn how to use the bot.
     """
+
+    tutorials = {
+        "test_example": ExampleTutorial()
+    }
 
     def __init__(self, bot):
         self.bot = bot
@@ -16,16 +22,43 @@ class Tutorials(commands.Cog):
     @commands.group()
     async def tutorial(self, ctx):
         """Shows the current tutorial objective, or lists the available tutorials if one is not active."""
+        # get user map
+        # if tutorial is none:
+        #   list available
+        # else:
+        #   get tutorial state
+        #   if none:
+        #       error
+        #   run tutorial state objective
         pass
 
     @tutorial.command(name='skip')
     async def tutorial_skip(self, ctx):
         """Skips the current objective, and moves on to the next part of the tutorial."""
+        # confirm
+        # run tutorial state transition
+        # commit new state map
         pass
 
     @tutorial.command(name='end')
     async def tutorial_end(self, ctx):
         """Ends the current tutorial."""
+        # confirm
+        # delete tutorial state map
+        pass
+
+    # main listener entrypoint
+    @commands.Cog.listener()
+    async def on_command_completion(self, ctx):
+        # get user map
+        # get tutorial
+        # if none:
+        #   error
+        # get tutorial state
+        # if none:
+        #   error
+        # run tutorial state listener
+        # commit new state map if needed (how to handle transition?)
         pass
 
 

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -2,10 +2,11 @@
 Main entrypoint for the tutorials extension. The tutorials themselves can be found in this module, and
 are registered here. The tutorial commands are also registered here, as part of the Help cog.
 """
+import discord
 from discord.ext import commands
 
 from cogs5e.models.embeds import EmbedWithAuthor
-from utils.functions import confirm, search_and_select
+from utils.functions import confirm, get_guild_member, search_and_select
 from .example import ExampleTutorial
 from .models import TutorialStateMap
 
@@ -104,6 +105,15 @@ class Tutorials(commands.Cog):
 
         # run tutorial state listener
         await state.listener(ctx, user_state)
+
+    @commands.Cog.listener()
+    async def on_guild_join(self, guild):
+        owner = await get_guild_member(guild, guild.owner_id)
+        if owner is not None:
+            try:
+                await owner.send("blep")  # todo display getting started guide
+            except discord.HTTPException:
+                pass
 
     # ==== helpers ====
     def get_tutorial_and_state(self, user_state):

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -38,7 +38,7 @@ class Tutorials(commands.Cog):
 
     # ==== commands ====
     @commands.group(invoke_without_command=True)
-    @checks.feature_flag('commands.tutorial.enabled')
+    @checks.feature_flag('command.tutorial.enabled')
     async def tutorial(self, ctx, *, name=None):
         """
         Shows the current tutorial objective, lists the available tutorials if one is not active, or begins a new tutorial.
@@ -64,7 +64,7 @@ class Tutorials(commands.Cog):
             await self.tutorial_list(ctx)
 
     @tutorial.command(name='list')
-    @checks.feature_flag('commands.tutorial.enabled')
+    @checks.feature_flag('command.tutorial.enabled')
     async def tutorial_list(self, ctx):
         """Lists the available tutorials."""
         embed = EmbedWithAuthor(ctx)
@@ -76,7 +76,7 @@ class Tutorials(commands.Cog):
         await ctx.send(embed=embed)
 
     @tutorial.command(name='skip')
-    @checks.feature_flag('commands.tutorial.enabled')
+    @checks.feature_flag('command.tutorial.enabled')
     async def tutorial_skip(self, ctx):
         """Skips the current objective, and moves on to the next part of the tutorial."""
         user_state = await TutorialStateMap.from_ctx(ctx)
@@ -95,7 +95,7 @@ class Tutorials(commands.Cog):
         await state.transition(ctx, user_state)
 
     @tutorial.command(name='end')
-    @checks.feature_flag('commands.tutorial.enabled')
+    @checks.feature_flag('command.tutorial.enabled')
     async def tutorial_end(self, ctx):
         """Ends the current tutorial."""
         user_state = await TutorialStateMap.from_ctx(ctx)

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -4,7 +4,10 @@ are registered here. The tutorial commands are also registered here, as part of 
 """
 from discord.ext import commands
 
+from cogs5e.models.embeds import EmbedWithAuthor
+from utils.functions import confirm, search_and_select
 from .example import ExampleTutorial
+from .models import TutorialStateMap
 
 
 class Tutorials(commands.Cog):
@@ -12,56 +15,106 @@ class Tutorials(commands.Cog):
     Commands to help learn how to use the bot.
     """
 
+    # tutorial keys should never change - if needed, change the name in the constructor to change the display name
     tutorials = {
-        "test_example": ExampleTutorial()
+        "test_example": ExampleTutorial(name="example", description="this is an example tutorial")
     }
 
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.group()
-    async def tutorial(self, ctx):
-        """Shows the current tutorial objective, or lists the available tutorials if one is not active."""
+    # ==== commands ====
+    @commands.group(invoke_without_command=True)
+    async def tutorial(self, ctx, name=None):
+        """
+        Shows the current tutorial objective, lists the available tutorials if one is not active, or begins a new tutorial.
+        """
         # get user map
-        # if tutorial is none:
-        #   list available
-        # else:
-        #   get tutorial state
-        #   if none:
-        #       error
-        #   run tutorial state objective
-        pass
+        user_state = await TutorialStateMap.from_ctx(ctx)
+
+        if user_state is not None:
+            tutorial, state = self.get_tutorial_and_state(user_state)
+            if tutorial is None or state is None:
+                await ctx.send(f"The tutorial you were running no longer exists. "
+                               f"Please run `{ctx.prefix}tutorial end` to start a new tutorial!")
+                return
+            # show tutorial state objective
+            await state.objective(ctx, user_state)
+        elif name is not None:
+            # begin tutorial with name
+            key, tutorial = await search_and_select(ctx, list(self.tutorials.items()), name, lambda tup: tup[1].name)
+            new_state = TutorialStateMap.new(ctx, key, tutorial)
+            await new_state.transition(ctx, tutorial.first_state)
+        else:
+            # list available tutorials
+            await self.tutorial_list(ctx)
+
+    @tutorial.command(name='list')
+    async def tutorial_list(self, ctx):
+        """Lists the available tutorials."""
+        embed = EmbedWithAuthor(ctx)
+        embed.title = "Available Tutorials"
+        embed.description = f"Use `{ctx.prefix}tutorial <name>` to select a tutorial from the ones available below!"
+        for tutorial in self.tutorials.values():
+            embed.add_field(name=tutorial.name, value=tutorial.description, inline=False)
+        await ctx.send(embed=embed)
 
     @tutorial.command(name='skip')
     async def tutorial_skip(self, ctx):
         """Skips the current objective, and moves on to the next part of the tutorial."""
+        user_state = await TutorialStateMap.from_ctx(ctx)
+        if user_state is None:
+            return await ctx.send("You are not currently running a tutorial.")
+        tutorial, state = self.get_tutorial_and_state(user_state)
+        if tutorial is None or state is None:
+            return await ctx.send(f"The tutorial you were running no longer exists. "
+                                  f"Please run `{ctx.prefix}tutorial end` to start a new tutorial!")
         # confirm
+        result = await confirm(ctx, "Are you sure you want to skip the current tutorial objective?")
+        if not result:
+            return await ctx.send("Ok, aborting.")
         # run tutorial state transition
         # commit new state map
-        pass
+        await state.transition(ctx, user_state)
 
     @tutorial.command(name='end')
     async def tutorial_end(self, ctx):
         """Ends the current tutorial."""
+        user_state = await TutorialStateMap.from_ctx(ctx)
+        if user_state is None:
+            return await ctx.send("You are not currently running a tutorial.")
         # confirm
+        result = await confirm(ctx, "Are you sure you want to end the current tutorial?")
+        if not result:
+            return await ctx.send("Ok, aborting.")
         # delete tutorial state map
-        pass
+        await user_state.end_tutorial(ctx)
+        await ctx.send("Ok, ended the tutorial.")
 
-    # main listener entrypoint
+    # ==== main listener entrypoint ====
     @commands.Cog.listener()
     async def on_command_completion(self, ctx):
         # get user map
-        # get tutorial
-        # if none:
-        #   error
-        # get tutorial state
-        # if none:
-        #   error
+        user_state = await TutorialStateMap.from_ctx(ctx)
+        if user_state is None:
+            return
+        tutorial, state = self.get_tutorial_and_state(user_state)
+        if tutorial is None or state is None:
+            return
+
         # run tutorial state listener
-        # commit new state map if needed (how to handle transition?)
-        pass
+        await state.listener(ctx, user_state)
+
+    # ==== helpers ====
+    def get_tutorial_and_state(self, user_state):
+        tutorial = self.tutorials.get(user_state.tutorial_key)
+        if tutorial is None:
+            return None, None
+        state = tutorial.states.get(user_state.state_key)
+        return tutorial, state
 
 
+# discord ext boilerplate
 def setup(bot):
     cog = Tutorials(bot)
     bot.add_cog(cog)

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -1,0 +1,20 @@
+"""
+Main entrypoint for the tutorials extension. The tutorials themselves can be found in this module, and
+are registered here. The tutorial commands are also registered here, as part of the Help cog.
+"""
+from discord.ext import commands
+
+
+class Tutorials(commands.Cog):
+    """
+    Commands to help learn how to use the bot.
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+
+def setup(bot):
+    cog = Tutorials(bot)
+    bot.add_cog(cog)
+    bot.help_command.cog = cog

--- a/cogsmisc/tutorials/ddblink.py
+++ b/cogsmisc/tutorials/ddblink.py
@@ -2,7 +2,6 @@
 This is an example tutorial not designed to be run. It demonstrates how to use tutorial states and can be used
 as a stub to build new tutorials from.
 """
-import asyncio
 
 from .models import Tutorial, TutorialEmbed, TutorialState, state
 
@@ -23,9 +22,7 @@ class DDBLink(Tutorial):
             embed.description = f"""
             Did you know you can use all your D&D Beyond content in Avrae for free?  It's pretty easy to set up!
 
-            First, visit your [Account Settings](https://www.dndbeyond.com/account) page in D&D Beyond.  You'll see \
-            an option there to link your Discord account. Make sure you’re logged in with the correct Discord account \
-            when you do so.
+            First, visit your [Account Settings](https://www.dndbeyond.com/account) page in D&D Beyond.  You'll see an option there to link your Discord account. Make sure you’re logged in with the correct Discord account when you do so.
             
             Once that's done, come back here and use `{ctx.prefix}ddb` to confirm.
             ```
@@ -40,8 +37,7 @@ class DDBLink(Tutorial):
                 if user is None:
                     embed = TutorialEmbed(self, ctx)
                     embed.description = f"""
-                    Looks like your D&D Beyond account isn't connected yet. Make sure you’re logged in with the \
-                    correct Discord account, and check again in a few minutes!
+                    Looks like your D&D Beyond account isn't connected yet. Make sure you’re logged in with the         correct Discord account, and check again in a few minutes!
                     """
                     await ctx.send(embed=embed)
                 else:
@@ -56,8 +52,7 @@ class DDBLink(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Content Lookup"
             embed.description = f"""
-            Now that you’re set up, let’s try it out!  Use `{ctx.prefix}spell <name>` to look up a spell. Avrae will \
-            give you the full details for any spell you have [in D&D Beyond](https://www.dndbeyond.com/spells).
+            Now that you’re set up, let’s try it out!  Use `{ctx.prefix}spell <name>` to look up a spell. Avrae will give you the full details for any spell you have [in D&D Beyond](https://www.dndbeyond.com/spells).
             ```
             {ctx.prefix}spell <name>
             ```
@@ -71,14 +66,9 @@ class DDBLink(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            You got it!  If you’re a spellcaster, now you can even cast `{ctx.prefix}cast` those spells, too. \
-            It also works with all of the other lookup commands as well, like `{ctx.prefix}monster`,  \
-            `{ctx.prefix}item`, or  `{ctx.prefix}feat`.
+            You got it!  If you’re a spellcaster, now you can even cast `{ctx.prefix}cast` those spells, too. It also works with all of the other lookup commands as well, like `{ctx.prefix}monster`,  `{ctx.prefix}item`, or  `{ctx.prefix}feat`.
 
-            Plus, you can share the fun with the rest of your party using D&D Beyond's \
-            [Campaign Content Sharing](https://dndbeyond.zendesk.com/hc/en-us/articles/115011257067-Campaign-Content-Sharing-and-You). \
-            That lets the whole group share their unlocked game content with each other, and it works here in Avrae, \
-            too!
+            Plus, you can share the fun with the rest of your party using D&D Beyond's [Campaign Content Sharing](https://dndbeyond.zendesk.com/hc/en-us/articles/115011257067-Campaign-Content-Sharing-and-You). That lets the whole group share their unlocked game content with each other, and it works here in Avrae, too!
             """
             await ctx.send(embed=embed)
             await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/ddblink.py
+++ b/cogsmisc/tutorials/ddblink.py
@@ -1,8 +1,3 @@
-"""
-This is an example tutorial not designed to be run. It demonstrates how to use tutorial states and can be used
-as a stub to build new tutorials from.
-"""
-
 from .models import Tutorial, TutorialEmbed, TutorialState, state
 
 

--- a/cogsmisc/tutorials/ddblink.py
+++ b/cogsmisc/tutorials/ddblink.py
@@ -1,0 +1,84 @@
+"""
+This is an example tutorial not designed to be run. It demonstrates how to use tutorial states and can be used
+as a stub to build new tutorials from.
+"""
+import asyncio
+
+from .models import Tutorial, TutorialEmbed, TutorialState, state
+
+
+class DDBLink(Tutorial):
+    name = "D&D Beyond Link"
+    description = """
+    *5 minutes*
+    Learn how to link your D&D Beyond and Discord accounts to use your D&D Beyond content in Avrae, import your \
+    private characters, sync rolls with your D&D Beyond campaign, and more!
+    """
+
+    @state(first=True)
+    class LinkingYourAccount(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Linking Your Account"
+            embed.description = f"""
+            Did you know you can use all your D&D Beyond content in Avrae for free?  It's pretty easy to set up!
+
+            First, visit your [Account Settings](https://www.dndbeyond.com/account) page in D&D Beyond.  You'll see \
+            an option there to link your Discord account. Make sure you’re logged in with the correct Discord account \
+            when you do so.
+            
+            Once that's done, come back here and use `{ctx.prefix}ddb` to confirm.
+            ```
+            {ctx.prefix}ddb
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('ddb'):
+                user = await ctx.bot.ddb.get_ddb_user(ctx, ctx.author.id)
+                if user is None:
+                    embed = TutorialEmbed(self, ctx)
+                    embed.description = f"""
+                    Looks like your D&D Beyond account isn't connected yet. Make sure you’re logged in with the \
+                    correct Discord account, and check again in a few minutes!
+                    """
+                    await ctx.send(embed=embed)
+                else:
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            await state_map.transition(ctx, self.tutorial.ContentLookup)
+
+    @state()
+    class ContentLookup(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Content Lookup"
+            embed.description = f"""
+            Now that you’re set up, let’s try it out!  Use `{ctx.prefix}spell <name>` to look up a spell. Avrae will \
+            give you the full details for any spell you have [in D&D Beyond](https://www.dndbeyond.com/spells).
+            ```
+            {ctx.prefix}spell <name>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('spell'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            You got it!  If you’re a spellcaster, now you can even cast `{ctx.prefix}cast` those spells, too. \
+            It also works with all of the other lookup commands as well, like `{ctx.prefix}monster`,  \
+            `{ctx.prefix}item`, or  `{ctx.prefix}feat`.
+
+            Plus, you can share the fun with the rest of your party using D&D Beyond's \
+            [Campaign Content Sharing](https://dndbeyond.zendesk.com/hc/en-us/articles/115011257067-Campaign-Content-Sharing-and-You). \
+            That lets the whole group share their unlocked game content with each other, and it works here in Avrae, \
+            too!
+            """
+            await ctx.send(embed=embed)
+            await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/example.py
+++ b/cogsmisc/tutorials/example.py
@@ -4,24 +4,28 @@ from .models import Tutorial, TutorialState, state
 class ExampleTutorial(Tutorial):
     @state()
     class FirstState(TutorialState):
+        async def objective(self, ctx, state_map):
+            await ctx.send("FirstState objective - run echo to move on")
+
         async def listener(self, ctx, state_map):
             await ctx.send("FirstState listener")
-
-        async def objective(self, ctx, state_map):
-            await ctx.send("FirstState objective")
+            if ctx.command is ctx.bot.get_command('echo'):
+                await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):
             await ctx.send("FirstState transition")
-            await state_map.transition(self.tutorial.SecondState)
+            await state_map.transition(ctx, self.tutorial.SecondState)
 
     @state()
     class SecondState(TutorialState):
+        async def objective(self, ctx, state_map):
+            await ctx.send("SecondState objective - run attack to move on")
+
         async def listener(self, ctx, state_map):
             await ctx.send("SecondState listener")
-
-        async def objective(self, ctx, state_map):
-            await ctx.send("SecondState objective")
+            if ctx.command is ctx.bot.get_command('attack'):
+                await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):
             await ctx.send("SecondState transition")
-            return None
+            await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/example.py
+++ b/cogsmisc/tutorials/example.py
@@ -1,0 +1,27 @@
+from .models import Tutorial, TutorialState, state
+
+
+class ExampleTutorial(Tutorial):
+    @state()
+    class FirstState(TutorialState):
+        async def listener(self, ctx, state_map):
+            await ctx.send("FirstState listener")
+
+        async def objective(self, ctx, state_map):
+            await ctx.send("FirstState objective")
+
+        async def transition(self, ctx, state_map):
+            await ctx.send("FirstState transition")
+            await state_map.transition(self.tutorial.SecondState)
+
+    @state()
+    class SecondState(TutorialState):
+        async def listener(self, ctx, state_map):
+            await ctx.send("SecondState listener")
+
+        async def objective(self, ctx, state_map):
+            await ctx.send("SecondState objective")
+
+        async def transition(self, ctx, state_map):
+            await ctx.send("SecondState transition")
+            return None

--- a/cogsmisc/tutorials/example.py
+++ b/cogsmisc/tutorials/example.py
@@ -6,6 +6,12 @@ from .models import Tutorial, TutorialState, state
 
 
 class ExampleTutorial(Tutorial):
+    name = "Example"
+    description = """
+    *9001 minutes*
+    These are some words about what this tutorial is
+    """
+
     @state()
     class FirstState(TutorialState):
         async def objective(self, ctx, state_map):

--- a/cogsmisc/tutorials/example.py
+++ b/cogsmisc/tutorials/example.py
@@ -1,3 +1,7 @@
+"""
+This is an example tutorial not designed to be run. It demonstrates how to use tutorial states and can be used
+as a stub to build new tutorials from.
+"""
 from .models import Tutorial, TutorialState, state
 
 

--- a/cogsmisc/tutorials/init_dm.py
+++ b/cogsmisc/tutorials/init_dm.py
@@ -84,7 +84,7 @@ class DMInitiative(Tutorial):
             embed.description = f"""
             By default, Avrae gives each monster a unique ID using the first two letters of its name and a number.  If you check your pinned messages, you should see DE1 added to the fight.
             
-            There are other arguments you can use here, too, to control how the monster is added.  You can give it a special name (`-name Cerberus`), add a few at once (`-n 3`), and more.  Check `{ctx.prefix}help i madd` for the full list.
+            There are other arguments you can use here, too, to control how the monster is added.  You can give it a special name (`-name Woofer`), add a few at once (`-n 3`), and more.  Check `{ctx.prefix}help i madd` for the full list.
             
             Just for fun, you can also use `{ctx.prefix}monimage death dog` to give your players a frightening look at the monstrosity bearing down on them.
             """

--- a/cogsmisc/tutorials/init_dm.py
+++ b/cogsmisc/tutorials/init_dm.py
@@ -241,7 +241,10 @@ class DMInitiative(Tutorial):
         async def listener(self, ctx, state_map):
             if ctx.channel.id != state_map.persist_data.get('channel_id'):
                 return
-            if ctx.command is ctx.bot.get_command('i hp'):
+            if ctx.command in (
+                    ctx.bot.get_command('i hp set'),
+                    ctx.bot.get_command('i hp')
+            ):
                 the_combat = await Combat.from_ctx(ctx)
                 woofer = get_the_woofer(the_combat)
                 if woofer is None:
@@ -277,7 +280,10 @@ class DMInitiative(Tutorial):
         async def listener(self, ctx, state_map):
             if ctx.channel.id != state_map.persist_data.get('channel_id'):
                 return
-            if ctx.command is ctx.bot.get_command('i hp'):
+            if ctx.command in (
+                    ctx.bot.get_command('i hp max'),
+                    ctx.bot.get_command('i hp')
+            ):
                 the_combat = await Combat.from_ctx(ctx)
                 woofer = get_the_woofer(the_combat)
                 if woofer is None:
@@ -347,7 +353,7 @@ class DMInitiative(Tutorial):
                                        f"run `{ctx.prefix}tutorial` to add Orkira back and continue.")
                         return
 
-                if orkira.get_effects():  # relatively loose check, just checks for any effect, not necessarily SW
+                if orkira.get_effect("Spiritual Weapon"):
                     await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):
@@ -419,7 +425,7 @@ class DMInitiative(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Effects III"
             embed.description = f"""
-            If you look closely, you'll notice this effect comes with a new attack.  This attack has the same name as the effect (in this case, `"spiritual weapon"`), which you can verify by checking her attacks (`{ctx.prefix}i a Orkira list`).
+            If you look closely, you'll notice this effect comes with a new attack.  This attack has the same name as the effect (in this case, `"spiritual weapon"`), which you can verify by checking her attacks (`{ctx.prefix}i a list Orkira`).
             
             The help text there also says Orkira can spend her bonus action to use that attack now.  Let's give it a try!
             ```
@@ -452,7 +458,7 @@ class DMInitiative(Tutorial):
             embed.description = f"""
             When an effect's duration expires, it will end automatically.  Cases often arise, however, that could cause it to end early.  Perhaps an enemy wizard cast dispel magic.  In such an event, we can end the effect early using `{ctx.prefix}init re <name> [effect]`.
             ```
-            !i re Orkira "spiritual weapon"
+            {ctx.prefix}i re Orkira "spiritual weapon"
             ```
             """
             await ctx.send(embed=embed)
@@ -469,13 +475,13 @@ class DMInitiative(Tutorial):
                     await self.transition(ctx, state_map)
                     return
 
-                if not orkira.get_effects():
+                if not orkira.get_effect("Spiritual Weapon"):
                     await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            If you look once more at the pinned message or at Orkira's status, that effect is no longer there.  The attack it provided is also gone, which you can verify with `{ctx.prefix}i a Orkira list`.
+            If you look once more at the pinned message or at Orkira's status, that effect is no longer there.  The attack it provided is also gone, which you can verify with `{ctx.prefix}i a list Orkira`.
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -490,7 +496,7 @@ class DMInitiative(Tutorial):
             embed.description = f"""
             Combatants can similarly be removed.  If Orkira defeats the death dog (changing its status to `<Dead>`), it will be removed automatically at the end of its turn.  For now, it's going to avoid that fate and choose to flee instead.  We can remove it manually with `{ctx.prefix}init remove <name>`.
             ```
-            !i remove DE1
+            {ctx.prefix}i remove DE1
             ```
             """
             await ctx.send(embed=embed)

--- a/cogsmisc/tutorials/init_dm.py
+++ b/cogsmisc/tutorials/init_dm.py
@@ -1,0 +1,561 @@
+import asyncio
+
+from cogs5e.models.errors import CombatNotFound
+from cogs5e.models.initiative import Combat, MonsterCombatant
+from gamedata.compendium import compendium
+from utils.functions import confirm
+from .models import Tutorial, TutorialEmbed, TutorialState, state
+
+
+class DMInitiative(Tutorial):
+    name = "Initiative (DM)"
+    description = """
+    *20 minutes*
+    When your players fall head first into conflict (despite your warnings), Avrae's combat tracker is a fantastic addition to your DM toolset. This tutorial goes over how to set up and run an enounter using the initiative tracker, as a Dungeon Master.
+    """
+
+    @state(first=True)
+    class StartingCombat(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Starting Combat"
+            embed.description = f"""
+            *The creature turns to face you, the sharp fangs of its twin heads gleaming in the moonlight as it rushes to attack.  Roll for initiative!*
+            
+            When your players fall head first into conflict (despite your warnings), Avrae's combat tracker is a fantastic addition to your DM toolset.  It handles all the fine details so you can focus on what matters: the story.
+            
+            The first step is a simple one.  Let's start initiative.
+            ```
+            {ctx.prefix}init begin
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            # The tutorial person ran !init begin and there is an active combat in the channel
+            if ctx.command is ctx.bot.get_command('init begin'):
+                try:
+                    await Combat.from_ctx(ctx)
+                except CombatNotFound:
+                    return
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            state_map.persist_data['channel_id'] = ctx.channel.id
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            It begins!  As you can see, Avrae has pinned a new post to your Discord channel.  This post will automatically update as the fight plays out, giving you an easy look at turn order, health, and active effects.  Keep an eye on it as we continue.
+            
+            In the following steps, we'll be using `{ctx.prefix}i` as a shortcut for `{ctx.prefix}init`.  When Avrae lists a command like `{ctx.prefix}[init|i]`, that means you can use either name for the same command.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.AddCombatants)
+
+    @state()
+    class AddCombatants(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Adding Combatants"
+            embed.description = f"""
+            Now it's time to add our combatants.  Your players can use `{ctx.prefix}i join` to add their active characters while you bring the monsters.  For that, you'll need `{ctx.prefix}init madd <monster_name> [args...]`.
+            
+            If you've connected your D&D Beyond account, you can use any monster you have unlocked.  But for now, let's use one from the free Basic Rules: the death dog.
+            
+            Because this monster's name has more than one word, you'll need to place quotes around it for Avrae to add correctly.
+            ```
+            {ctx.prefix}i madd "death dog"
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            # !init madd and there is a death dog in combat
+            if ctx.command is ctx.bot.get_command('i madd'):
+                the_combat = await Combat.from_ctx(ctx)
+                if get_the_woofer(the_combat) is not None:
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            By default, Avrae gives each monster a unique ID using the first two letters of its name and a number.  If you check your pinned messages, you should see DE1 added to the fight.
+            
+            There are other arguments you can use here, too, to control how the monster is added.  You can give it a special name (`-name Cerberus`), add a few at once (`-n 3`), and more.  Check `{ctx.prefix}help i madd` for the full list.
+            
+            Just for fun, you can also use `{ctx.prefix}monimage death dog` to give your players a frightening look at the monstrosity bearing down on them.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.TurnOrder)
+
+    @state()
+    class TurnOrder(TutorialState):
+        async def objective(self, ctx, state_map):
+            if not state_map.data.get('has_added_orkira'):
+                the_combat = await Combat.from_ctx(ctx)
+                await add_orkira(ctx, the_combat)
+                await ctx.send("Orkira Illdrex was added to combat with initiative 1.")
+                state_map.data['has_added_orkira'] = True
+                await state_map.commit(ctx)
+                await asyncio.sleep(2)
+
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Turn Order"
+            embed.description = f"""
+            Now that your player, Orkira, has joined the fight too, let's begin.  Use `{ctx.prefix}i next` after each turn to move to the next combatant.  Try it now to start the death dog's turn.
+            ```
+            {ctx.prefix}i next
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i next'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            There are other commands you can use to control the turn order as well.  While `{ctx.prefix}i next` goes forward, `{ctx.prefix}i prev` goes back.  You can also jump to a specific combatant with `{ctx.prefix}i move <name>`.
+            
+            If you check your pins again, you'll also see that DE1 is now highlighted, indicating the current turn.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.Attacks1)
+
+    @state()
+    class Attacks1(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Taking Your Turn - Attacks"
+            embed.description = f"""
+            Your death dog got the higher roll for initiative, so it goes first.  Let's have it move in to attack, which you can do with `{ctx.prefix}init [attack|a] <atk_name> [args]`.  (We'll be using the `{ctx.prefix}i a` shortcut here).
+            
+            First we'll enter the name of our attack, `bite`.  Then we need to tell it to target our player.  For that, we add `-t` followed by the target's name.  In this case, it's `-t Orkira`.
+            ```
+            {ctx.prefix}i a bite -t Orkira
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i a') and '-t ' in ctx.message.content:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            When you attack, Avrae first compares the roll to the target's AC.  On a hit, it automatically rolls the damage and subtracts it from the target's HP.  It even accounts for resistance, immunity, and vulnerability, too.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.Attacks2)
+
+    @state()
+    class Attacks2(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Taking Your Turn - Attacks II"
+            embed.description = f"""
+            If your first attack didn't land, good news: your death dog has multiattack.  Let's make one more bite attack, but this time we'll make sure it hits by adding `hit`.  If you hit already, you can have some fun here instead.  Try attacking with advantage (`adv`) or giving Orkira resistance (`-resist piercing`) instead.
+            ```
+            {ctx.prefix}i a bite -t Orkira hit
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i a') and '-t ' in ctx.message.content:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Good!  Next time you can have it make both attacks at once (by adding `-rr 2`) or by giving it multiple targets (`-t Orkira -t Briv`).  There's plenty of other ways you can adjust your attack, too.  Check `{ctx.prefix}help i a` for the full list.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.HitPoints1)
+
+    @state()
+    class HitPoints1(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Hit Points"
+            embed.description = f"""
+            Since Orkira has now taken some damage, try checking that pinned message again.  You can see it's been updated to reflect her current HP.
+            
+            You might also notice, however, that the death dog's exact HP is not shown.  It's simply stated as `<Healthy>`.  Let's manually apply some damage using `{ctx.prefix}init hp <name> [hp]`.
+            ```
+            {ctx.prefix}i hp DE1 -1
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i hp'):
+                the_combat = await Combat.from_ctx(ctx)
+                woofer = get_the_woofer(the_combat)
+                if woofer is None:
+                    await ctx.send(f"Uh oh, looks like I can't find the Death Dog. "
+                                   f"Try readding it with `{ctx.prefix}i madd \"Death Dog\"`")
+                    return
+                if woofer.hp < woofer.max_hp:
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            await state_map.transition(ctx, self.tutorial.HitPoints2)
+
+    @state()
+    class HitPoints2(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Hit Points II"
+            embed.description = f"""
+            As you can see, DE1 has changed from `<Healthy>` to `<Injured>`.  This gives players a rough idea of a creature's health without spoiling things entirely.  Since you, the DM, control that creature, you have also received a direct message from Avrae revealing its actual HP.
+            
+            As the battle continues and our creature drops to half of its max HP, that status will change again.  Let's use `{ctx.prefix}init hp set <name> <hp>` this time to set its HP to a specific value.
+            ```
+            {ctx.prefix}i hp set DE1 15
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i hp'):
+                the_combat = await Combat.from_ctx(ctx)
+                woofer = get_the_woofer(the_combat)
+                if woofer is None:
+                    await ctx.send(f"Uh oh, looks like I can't find the Death Dog. "
+                                   f"Try readding it with `{ctx.prefix}i madd \"Death Dog\"`")
+                    return
+                if woofer.hp == 15:
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Our death dog is now `<Bloodied>`, indicating that it has taken significant damage.  Its displayed health will change again at 15% to `<Critical>`, and at 0 to `<Dead>`.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.HitPoints3)
+
+    @state()
+    class HitPoints3(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Hit Points III"
+            embed.description = f"""
+            Now since the death dog hasn't actually taken damage in our fight here, let's reset its health using `{ctx.prefix}init hp max <name>`.
+            ```
+            {ctx.prefix}i hp max DE1
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i hp'):
+                the_combat = await Combat.from_ctx(ctx)
+                woofer = get_the_woofer(the_combat)
+                if woofer is None:
+                    await ctx.send(f"Uh oh, looks like I can't find the Death Dog. "
+                                   f"Try readding it with `{ctx.prefix}i madd \"Death Dog\"`")
+                    return
+                if woofer.hp == woofer.max_hp:
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            await state_map.transition(ctx, self.tutorial.EndingYourTurn)
+
+    @state()
+    class EndingYourTurn(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Ending Your Turn"
+            embed.description = f"""
+            DE1 is back to `<Healthy>` and ready for the fight, but that's all it can do for now.  Let's end our turn and move to the next combatant.
+            ```
+            {ctx.prefix}i next
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i next'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            await state_map.transition(ctx, self.tutorial.Spellcasting)
+
+    @state()
+    class Spellcasting(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Taking Your Turn II - Spellcasting"
+            embed.description = f"""
+            Orkira the cleric is up next.  Normally your players would run their own commands here, but when it's their turn in initiative, you can also act for them.  The same `{ctx.prefix}init` commands always work for the current combatant, whether it's a monster or a player.
+            
+            As for Orkira herself, she has one big advantage over your death dog: spellcasting!  The command this time is `{ctx.prefix}init cast <spell_name> [args]`.
+            
+            Let's summon a spiritual weapon and target our death dog (`-t DE1`).  Don't forget those quotes around the spell name since it's more than one word.
+            ```
+            {ctx.prefix}i cast "spiritual weapon" -t DE1
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i cast'):
+                the_combat = await Combat.from_ctx(ctx)
+                orkira = get_orkira(combat=the_combat)
+                if orkira is None:
+                    addback = await confirm(ctx,
+                                            "Uh oh, it looks like Orkira isn't in the fight anymore. "
+                                            "Would you like me to add her back?")
+                    if addback:
+                        orkira = await add_orkira(ctx, the_combat)
+                        await ctx.send("Ok. I've added her back to the fight - try again!")
+                    else:
+                        await ctx.send(f"Ok. If you'd like to continue this tutorial later, "
+                                       f"run `{ctx.prefix}tutorial` to add Orkira back and continue.")
+                        return
+
+                if orkira.get_effects():  # relatively loose check, just checks for any effect, not necessarily SW
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Avrae automatically subtracts the spell slot and will stop you from casting if you don't have a slot to spare.  And just like attacks, spell commands can be adjusted in a number of other ways.  You can upcast with `-l <level>` (that's **-l** for **-l**evel), use `-i` to -**i**gnore requirements (when using a spell scroll, for example), and more.  See `!help i cast` for the full list.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.Effects)
+
+    @state()
+    class Effects(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Effects"
+            embed.description = f"""
+            Go ahead and check that pinned message again.  If you look at Orkira, you should see that spell did something more than just make an attack.  That's called an effect.  Among other things, it's used to track the duration for the spell we just cast.
+            
+            Let's fast forward our combat a little bit.  Use `{ctx.prefix}i skipround` to jump ahead to Orkira's next turn.
+            ```
+            {ctx.prefix}i skipround
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i skipround'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            If you check that pin now, you'll see it's down to just 9 rounds left.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(2)
+            await state_map.transition(ctx, self.tutorial.Effects2)
+
+    @state()
+    class Effects2(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Effects II"
+            embed.description = f"""
+            So what else does this effect do?  We can take a closer look at Orkira to find out, using `{ctx.prefix}init status [name] [args]`.
+            ```
+            {ctx.prefix}i status Orkira
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i status') and 'o' in ctx.message.content.lower():
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            await state_map.transition(ctx, self.tutorial.Effects3)
+
+    @state()
+    class Effects3(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Effects III"
+            embed.description = f"""
+            If you look closely, you'll notice this effect comes with a new attack.  This attack has the same name as the effect (in this case, `"spiritual weapon"`), which you can verify by checking her attacks (`{ctx.prefix}i a Orkira list`).
+            
+            The help text there also says Orkira can spend her bonus action to use that attack now.  Let's give it a try!
+            ```
+            {ctx.prefix}i a "spiritual weapon" -t DE1
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i a') and '-t ' in ctx.message.content:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Effects can also be used to add a damage bonus, grant resistance, and more.  You can also add them manually as needed.  Check out `{ctx.prefix}help i effect` for the full details.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.Effects4)
+
+    @state()
+    class Effects4(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Effects IV"
+            embed.description = f"""
+            When an effect's duration expires, it will end automatically.  Cases often arise, however, that could cause it to end early.  Perhaps an enemy wizard cast dispel magic.  In such an event, we can end the effect early using `{ctx.prefix}init re <name> [effect]`.
+            ```
+            !i re Orkira "spiritual weapon"
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i re'):
+                the_combat = await Combat.from_ctx(ctx)
+                orkira = get_orkira(combat=the_combat)
+                if orkira is None:
+                    await ctx.send("Uh oh, it looks like Orkira isn't in the fight anymore. "
+                                   "Let's move on to the next part of the tutorial.")
+                    await self.transition(ctx, state_map)
+                    return
+
+                if not orkira.get_effects():
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            If you look once more at the pinned message or at Orkira's status, that effect is no longer there.  The attack it provided is also gone, which you can verify with `{ctx.prefix}i a Orkira list`.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.RemovingCombatants)
+
+    @state()
+    class RemovingCombatants(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Removing Combatants"
+            embed.description = f"""
+            Combatants can similarly be removed.  If Orkira defeats the death dog (changing its status to `<Dead>`), it will be removed automatically at the end of its turn.  For now, it's going to avoid that fate and choose to flee instead.  We can remove it manually with `{ctx.prefix}init remove <name>`.
+            ```
+            !i remove DE1
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i remove'):
+                the_combat = await Combat.from_ctx(ctx)
+                woofer = get_the_woofer(combat=the_combat)
+                if woofer is None:
+                    await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            await state_map.transition(ctx, self.tutorial.EndingCombat)
+
+    @state()
+    class EndingCombat(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Ending Combat"
+            embed.description = f"""
+            The death dog runs, tail between its legs, leaving Orkira the victor.  With the fight over, we can now end initiative.
+            ```
+            {ctx.prefix}i end
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.channel.id != state_map.persist_data.get('channel_id'):
+                return
+            if ctx.command is ctx.bot.get_command('i end'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = "Congratulations!  You've run your first successful combat."
+            await ctx.send(embed=embed)
+            await state_map.end_tutorial(ctx)
+
+
+async def add_orkira(ctx, combat):
+    priest = compendium.lookup_by_entitlement('monster', 16985)
+    orkira = MonsterCombatant.from_monster(
+        monster=priest,
+        ctx=ctx,
+        combat=combat,
+        name="Orkira Illdrex",
+        controller_id=str(ctx.author.id),
+        init=1,
+        private=False,
+        hp=50
+    )
+    combat.add_combatant(orkira)
+    await combat.final()
+    return orkira
+
+
+def get_the_woofer(combat):
+    """Gets the next death dog in combat (hopefully DE1?)"""
+    return next((c for c in combat.get_combatants()
+                 if isinstance(c, MonsterCombatant) and c.monster_name == 'Death Dog'), None)
+
+
+def get_orkira(combat):
+    """Gets Orkira (hopefully?)"""
+    return combat.get_combatant("Orkira Illdrex", strict=True)

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -91,11 +91,15 @@ class TutorialStateMap:
     The tutorial and state a given user is in, along with any user-specific data that state might need.
     """
 
-    def __init__(self, user_id, tutorial_key, state_key, data, **_):
+    def __init__(self, user_id, tutorial_key, state_key, data, persist_data=None, **_):
+        if persist_data is None:
+            persist_data = {}
+
         self.user_id = user_id
         self.tutorial_key = tutorial_key
         self.state_key = state_key
-        self.data = data
+        self.data = data  # state-specific data
+        self.persist_data = persist_data  # sticks around the whole tutorial
 
     # db/ser
     @classmethod
@@ -111,7 +115,8 @@ class TutorialStateMap:
 
     def to_dict(self):
         return {
-            "user_id": self.user_id, "tutorial_key": self.tutorial_key, "state_key": self.state_key, "data": self.data
+            "user_id": self.user_id, "tutorial_key": self.tutorial_key, "state_key": self.state_key, "data": self.data,
+            "persist_data": self.persist_data
         }
 
     async def commit(self, ctx):
@@ -123,7 +128,7 @@ class TutorialStateMap:
 
     @classmethod
     def new(cls, ctx, tutorial_key, tutorial):
-        return cls(ctx.author.id, tutorial_key, tutorial.first_state.key, {})
+        return cls(ctx.author.id, tutorial_key, tutorial.first_state.key, {}, {})
 
     # state transitions
     async def transition(self, ctx, new_state):

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -1,0 +1,84 @@
+"""
+Misc data models for tutorials.
+"""
+import abc
+
+
+class Tutorial:
+    """
+    Base class for all tutorials. Each tutorial should subclass this class, and use the @state decorator to
+    register states.
+    """
+
+    def __init__(self):
+        self.states = {}
+
+        # iterate over members to find state registrations
+        for name in dir(self):
+            if not name.startswith('_'):
+                value = getattr(self, name)
+                if isinstance(value, TutorialState):
+                    self.states[value.key] = value
+                    value.tutorial = self
+
+
+class TutorialState(abc.ABC):
+    """
+    Base class for all tutorial states. Each state should subclass and implement these methods.
+    """
+
+    def __init__(self, key=None):
+        self.key = key or type(self).__name__
+        self.tutorial = None
+
+    async def listener(self, ctx, state_map):
+        """
+        Called after a user in this state runs any bot command.
+
+        :type ctx: discord.ext.commands.Context
+        :type state_map: TutorialStateMap
+        """
+        raise NotImplementedError
+
+    async def objective(self, ctx, state_map):
+        """
+        Displays the current objective.
+
+        :type ctx: discord.ext.commands.Context
+        :type state_map: TutorialStateMap
+        """
+        raise NotImplementedError
+
+    async def transition(self, ctx, state_map):
+        """
+        Returns the key of the new TutorialState to transition to, or None to end the tutorial.
+
+        :type ctx: discord.ext.commands.Context
+        :type state_map: TutorialStateMap
+        """
+        raise NotImplementedError
+
+
+class TutorialStateMap:
+    """
+    The tutorial and state a given user is in, along with any user-specific data that state might need.
+    """
+
+    def __init__(self, user_id, tutorial_key, state_key, data):
+        self.user_id = user_id
+        self.tutorial_key = tutorial_key
+        self.state_key = state_key
+        self.data = data
+
+
+# registration decorators
+# use @state to register states inside a Tutorial class
+# then register the Tutorial in the cog
+
+def state(key=None):
+    """Registers the class as a TutorialState in the Tutorial."""
+
+    def deco(cls):
+        return cls(key=key)
+
+    return deco

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -10,16 +10,27 @@ class Tutorial:
     register states.
     """
 
-    def __init__(self):
+    def __init__(self, name, description):
+        self.name = name
+        self.description = description
+
         self.states = {}
+        self.first_state = None
 
         # iterate over members to find state registrations
-        for name in dir(self):
-            if not name.startswith('_'):
-                value = getattr(self, name)
-                if isinstance(value, TutorialState):
-                    self.states[value.key] = value
-                    value.tutorial = self
+        # what do you mean, 'hack'? :)
+        for member in dir(self):
+            value = getattr(self, member)
+            if isinstance(value, TutorialState):
+                self.states[value.key] = value
+                value.tutorial = self
+                if value.first:
+                    if self.first_state is not None:
+                        raise ValueError(f"Found 2 first states in tutorial {self.name!r}: "
+                                         f"({self.first_state.key}, {value.key})")
+                    self.first_state = value
+        if self.first_state is None:
+            self.first_state = list(self.states.values())[0]  # just get the first state
 
 
 class TutorialState(abc.ABC):
@@ -27,18 +38,10 @@ class TutorialState(abc.ABC):
     Base class for all tutorial states. Each state should subclass and implement these methods.
     """
 
-    def __init__(self, key=None):
+    def __init__(self, key=None, first=False):
         self.key = key or type(self).__name__
         self.tutorial = None
-
-    async def listener(self, ctx, state_map):
-        """
-        Called after a user in this state runs any bot command.
-
-        :type ctx: discord.ext.commands.Context
-        :type state_map: TutorialStateMap
-        """
-        raise NotImplementedError
+        self.first = first
 
     async def objective(self, ctx, state_map):
         """
@@ -49,9 +52,19 @@ class TutorialState(abc.ABC):
         """
         raise NotImplementedError
 
+    async def listener(self, ctx, state_map):
+        """
+        Called after a user in this state runs any bot command. Check against objectives and run transition if necessary
+
+        :type ctx: discord.ext.commands.Context
+        :type state_map: TutorialStateMap
+        """
+        raise NotImplementedError
+
     async def transition(self, ctx, state_map):
         """
-        Returns the key of the new TutorialState to transition to, or None to end the tutorial.
+        Should display any necessary text before a transition, then call state_map.transition() to transition or
+        state_map.end_tutorial() to end.
 
         :type ctx: discord.ext.commands.Context
         :type state_map: TutorialStateMap
@@ -64,21 +77,59 @@ class TutorialStateMap:
     The tutorial and state a given user is in, along with any user-specific data that state might need.
     """
 
-    def __init__(self, user_id, tutorial_key, state_key, data):
+    def __init__(self, user_id, tutorial_key, state_key, data, **_):
         self.user_id = user_id
         self.tutorial_key = tutorial_key
         self.state_key = state_key
         self.data = data
+
+    # db/ser
+    @classmethod
+    async def from_ctx(cls, ctx):
+        d = await ctx.bot.mdb.tutorial_map.find_one({"user_id": ctx.author.id})
+        if d is None:
+            return None
+        return cls.from_dict(d)
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)
+
+    def to_dict(self):
+        return {
+            "user_id": self.user_id, "tutorial_key": self.tutorial_key, "state_key": self.state_key, "data": self.data
+        }
+
+    async def commit(self, ctx):
+        await ctx.bot.mdb.tutorial_map.update_one(
+            {"user_id": self.user_id},
+            {"$set": self.to_dict()},
+            upsert=True
+        )
+
+    @classmethod
+    def new(cls, ctx, tutorial_key, tutorial):
+        return cls(ctx.author.id, tutorial_key, tutorial.first_state.key, {})
+
+    # state transitions
+    async def transition(self, ctx, new_state):
+        self.state_key = new_state.key
+        self.data = {}
+        await self.commit(ctx)
+        await new_state.objective(ctx, self)
+
+    async def end_tutorial(self, ctx):
+        await ctx.bot.mdb.tutorial_map.delete_one({"user_id": self.user_id})
 
 
 # registration decorators
 # use @state to register states inside a Tutorial class
 # then register the Tutorial in the cog
 
-def state(key=None):
+def state(key=None, first=False):
     """Registers the class as a TutorialState in the Tutorial."""
 
     def deco(cls):
-        return cls(key=key)
+        return cls(key=key, first=first)
 
     return deco

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -26,7 +26,7 @@ class Tutorial(abc.ABC):
         if self.description is None:
             raise ValueError(f"Description not supplied in tutorial {type(self).__name__} or constructor")
         else:
-            self.description = textwrap.dedent(self.description.strip())
+            self.description = textwrap.dedent(self.description).strip()
 
         self.states = {}
         self.first_state = None

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -151,10 +151,11 @@ def state(key=None, first=False):
 class TutorialEmbed(EmbedWithAuthor):
     """Embed with author avatar, nick, color, and tutorial footer set."""
 
-    def __init__(self, tstate: TutorialState, ctx, **kwargs):
+    def __init__(self, tstate: TutorialState, ctx, footer=True, **kwargs):
         super().__init__(ctx, **kwargs)
-        self.set_footer(
-            text=f"{tstate.tutorial.name} | {ctx.prefix}tutorial skip to skip | {ctx.prefix}tutorial end to end")
+        if footer:
+            self.set_footer(
+                text=f"{tstate.tutorial.name} | {ctx.prefix}tutorial skip to skip | {ctx.prefix}tutorial end to end")
 
         self._description = self.Empty
 

--- a/cogsmisc/tutorials/quickstart.py
+++ b/cogsmisc/tutorials/quickstart.py
@@ -25,9 +25,9 @@ class Quickstart(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Using Bot Commands"
             embed.description = f"""
-            Each command in Avrae starts with a *prefix*, or a short string of symbols at the start of a message. By \
-            default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only run a command \
-            if a message starts with this prefix.
+            Each command in Avrae starts with a *prefix*, or a short string of characters at the start of a message. \
+            By default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only run a \
+            command if a message starts with this prefix.
             
             To use a command in Avrae, type the prefix, then the name of the command. For example, to roll a d20, send \
             a message containing `{ctx.prefix}roll d20`. Try it now!
@@ -118,7 +118,7 @@ class Quickstart(Tutorial):
             `{ctx.prefix}check <skill>`, `{ctx.prefix}save <ability>`, and `{ctx.prefix}attack <action>`. 
 
             For example, you can make a Stealth check with `{ctx.prefix}check stealth`, a Dexterity save with \
-            `{ctx.prefix}save dex`, and an unarmed attack with `{ctx.prefix}attack unarmed`. Try these now!
+            `{ctx.prefix}save dex`, and an unarmed attack with `{ctx.prefix}attack "Unarmed Strike"`. Try these now!
             ```
             {ctx.prefix}check <skill>
             {ctx.prefix}save <ability>

--- a/cogsmisc/tutorials/quickstart.py
+++ b/cogsmisc/tutorials/quickstart.py
@@ -1,0 +1,156 @@
+import asyncio
+
+from cogs5e.models.character import Character
+from cogs5e.models.errors import NoCharacter
+from utils import config
+from .models import Tutorial, TutorialEmbed, TutorialState, checklist, state
+
+
+class Quickstart(Tutorial):
+    name = "Quickstart"
+    description = """
+    *10 minutes*
+    New to Avrae or Discord bots in general? This tutorial will help you get started with Avrae's command system, \
+    rolling dice, and importing a D&D Beyond character into Discord.
+    """
+
+    @state(first=True)
+    class Start(TutorialState):
+        async def objective(self, ctx, state_map):
+            # does the server have a custom prefix?
+            server_prefix_override = ""
+            if ctx.prefix != config.DEFAULT_PREFIX:
+                server_prefix_override = f", but on this server it is `{ctx.prefix}`"
+
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Using Bot Commands"
+            embed.description = f"""
+            Each command in Avrae starts with a *prefix*, or a short string of symbols at the start of a message. By \
+            default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only start a command \
+            if a message starts with this prefix.
+            
+            To use a command in Avrae, type the prefix, then the name of the command. For example, to roll a d20, send \
+            a message containing `{ctx.prefix}roll d20`. Try it now!
+            ```
+            {ctx.prefix}roll d20
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('roll') and 'd20' in ctx.message.content:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Great! As you might have guessed, `{ctx.prefix}roll <dice>` is the command to roll some dice. Throughout \
+            the rest of this tutorial and other tutorials, we'll show commands in code blocks like that. 
+            
+            When you see something like `<dice>` or `[dice]`, this is called an *argument*: it means you can put some \
+            input there, like the dice you want to roll. Arguments like `<this>` are required, and arguments like \
+            `[this]` are optional.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.ImportCharacter)
+
+    @state()
+    class ImportCharacter(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Importing a Character"
+            embed.description = f"""
+            Now, let's import a character and get started with Avrae's automated attacks, skill checks, and ability \
+            saves! First, go ahead and make a character on \
+            [D&D Beyond](https://www.dndbeyond.com/?utm_source=avrae&utm_medium=tutorial).
+            
+            Once you're ready, import the character into Avrae with the command `{ctx.prefix}beyond <url>`, using \
+            either the "Sharable Link" on your character sheet or the URL in the address bar of your browser.
+            ```
+            {ctx.prefix}beyond <url>
+            ```
+            Or, if you've already imported a character, switch to them now!
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            try:
+                character = await Character.from_ctx(ctx)
+            except NoCharacter:
+                return
+            if ctx.command in (ctx.bot.get_command('beyond'),
+                               ctx.bot.get_command('dicecloud'),
+                               ctx.bot.get_command('gsheet'),
+                               ctx.bot.get_command('update'),
+                               ctx.bot.get_command('char')) \
+                    and character is not None:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            # should be active from listener, and in cache
+            # eventually this should get replaced by ctx.character
+            character = await Character.from_ctx(ctx)
+
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Nice to meet you, {character.name}! Avrae has no limit on how many characters you can import, but you can \
+            only have one "active" at a time. To switch between active characters, use `{ctx.prefix}character <name>`.
+            
+            Also, if you change your character's character sheet, Avrae will need to be updated to know about those \
+            changes. Whenever you do so, make sure to run `{ctx.prefix}update` to update your active character!
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.ChecksAttacksSaves)
+
+    @state()
+    class ChecksAttacksSaves(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Checks, Saves, and Attacks"
+            embed.description = f"""
+            Finally, let's go over the three most important rolls in D&D: skill checks, saving throws, and attacks. \
+            Now that your character is saved in Avrae, you can easily make these three rolls with simple commands: \
+            `{ctx.prefix}check <skill>`, `{ctx.prefix}save <ability>`, and `{ctx.prefix}attack <action>`. 
+
+            For example, you can make a Stealth check with `{ctx.prefix}check stealth`, a Dexterity save with \
+            `{ctx.prefix}save dex`, and an unarmed attack with `{ctx.prefix}attack unarmed`. Try these now!
+            ```
+            {ctx.prefix}check <skill>
+            {ctx.prefix}save <ability>
+            {ctx.prefix}attack <action>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            check = ctx.bot.get_command('check')
+            save = ctx.bot.get_command('save')
+            attack = ctx.bot.get_command('attack')
+            if ctx.command in (check, save, attack):
+                if ctx.command is check:
+                    state_map.data['has_check'] = True
+                elif ctx.command is save:
+                    state_map.data['has_save'] = True
+                elif ctx.command is attack:
+                    state_map.data['has_attack'] = True
+                await state_map.commit(ctx)
+                embed = TutorialEmbed(self, ctx)
+                embed.title = "Objectives"
+                embed.description = checklist([
+                    (f"Make a skill check with `{ctx.prefix}check <skill>`.", state_map.data.get('has_check')),
+                    (f"Make an ability save with `{ctx.prefix}save <ability>`.", state_map.data.get('has_save')),
+                    (f"Make an attack with `{ctx.prefix}attack <action>`.", state_map.data.get('has_attack'))
+                ])
+                await ctx.send(embed=embed)
+
+            if state_map.data.get('has_check') and state_map.data.get('has_save') and state_map.data.get('has_attack'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            # todo
+            await ctx.trigger_typing()
+            await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/quickstart.py
+++ b/cogsmisc/tutorials/quickstart.py
@@ -26,7 +26,7 @@ class Quickstart(Tutorial):
             embed.title = "Using Bot Commands"
             embed.description = f"""
             Each command in Avrae starts with a *prefix*, or a short string of symbols at the start of a message. By \
-            default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only start a command \
+            default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only run a command \
             if a message starts with this prefix.
             
             To use a command in Avrae, type the prefix, then the name of the command. For example, to roll a d20, send \
@@ -45,11 +45,11 @@ class Quickstart(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
             Great! As you might have guessed, `{ctx.prefix}roll <dice>` is the command to roll some dice. Throughout \
-            the rest of this tutorial and other tutorials, we'll show commands in code blocks like that. 
+            the rest of this tutorial and other tutorials, we'll show commands in code blocks like `this`. 
             
             When you see something like `<dice>` or `[dice]`, this is called an *argument*: it means you can put some \
-            input there, like the dice you want to roll. Arguments like `<this>` are required, and arguments like \
-            `[this]` are optional.
+            input there, like the dice you want to roll. Arguments in brackets like `<this>` are required, and \
+            arguments in brackets like `[this]` are optional.
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -71,7 +71,7 @@ class Quickstart(Tutorial):
             ```
             {ctx.prefix}beyond <url>
             ```
-            Or, if you've already imported a character, switch to them now!
+            Or, if you've already imported a character, switch to them now using `{ctx.prefix}character <name>`!
             """
             await ctx.send(embed=embed)
 
@@ -96,7 +96,8 @@ class Quickstart(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
             Nice to meet you, {character.name}! Avrae has no limit on how many characters you can import, but you can \
-            only have one "active" at a time. To switch between active characters, use `{ctx.prefix}character <name>`.
+            only have one "active" at a time across all servers. To switch between active characters, use \
+            `{ctx.prefix}character <name>`.
             
             Also, if you change your character's character sheet, Avrae will need to be updated to know about those \
             changes. Whenever you do so, make sure to run `{ctx.prefix}update` to update your active character!
@@ -151,6 +152,15 @@ class Quickstart(Tutorial):
                 await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):
-            # todo
             await ctx.trigger_typing()
+            await asyncio.sleep(3)
+            embed = TutorialEmbed(self, ctx, footer=False)
+            embed.description = f"""
+            That's all you need to get started! If you ever need a refresher on one command, you can use \
+            `{ctx.prefix}help <command>` to get the command's help sent to you. Next, you might want to try the \
+            *Playing the Game* tutorial - start this tutorial with `{ctx.prefix}tutorial Playing the Game`.
+
+            Looking for additional resources? Come join us at the [Avrae Development Discord](https://support.avrae.io).
+            """
+            await ctx.send(embed=embed)
             await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/quickstart.py
+++ b/cogsmisc/tutorials/quickstart.py
@@ -25,12 +25,9 @@ class Quickstart(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Using Bot Commands"
             embed.description = f"""
-            Each command in Avrae starts with a *prefix*, or a short string of characters at the start of a message. \
-            By default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only run a \
-            command if a message starts with this prefix.
+            Each command in Avrae starts with a *prefix*, or a short string of characters at the start of a message. By default, this prefix is `{config.DEFAULT_PREFIX}`{server_prefix_override}. Avrae will only run a command if a message starts with this prefix.
             
-            To use a command in Avrae, type the prefix, then the name of the command. For example, to roll a d20, send \
-            a message containing `{ctx.prefix}roll d20`. Try it now!
+            To use a command in Avrae, type the prefix, then the name of the command. For example, to roll a d20, send a message containing `{ctx.prefix}roll d20`. Try it now!
             ```
             {ctx.prefix}roll d20
             ```
@@ -44,12 +41,9 @@ class Quickstart(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            Great! As you might have guessed, `{ctx.prefix}roll <dice>` is the command to roll some dice. Throughout \
-            the rest of this tutorial and other tutorials, we'll show commands in code blocks like `this`. 
+            Great! As you might have guessed, `{ctx.prefix}roll <dice>` is the command to roll some dice. Throughout the rest of this tutorial and other tutorials, we'll show commands in code blocks like `this`. 
             
-            When you see something like `<dice>` or `[dice]`, this is called an *argument*: it means you can put some \
-            input there, like the dice you want to roll. Arguments in brackets like `<this>` are required, and \
-            arguments in brackets like `[this]` are optional.
+            When you see something like `<dice>` or `[dice]`, this is called an *argument*: it means you can put some input there, like the dice you want to roll. Arguments in brackets like `<this>` are required, and arguments in brackets like `[this]` are optional.
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -62,12 +56,9 @@ class Quickstart(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Importing a Character"
             embed.description = f"""
-            Now, let's import a character and get started with Avrae's automated attacks, skill checks, and ability \
-            saves! First, go ahead and make a character on \
-            [D&D Beyond](https://www.dndbeyond.com/?utm_source=avrae&utm_medium=tutorial).
+            Now, let's import a character and get started with Avrae's automated attacks, skill checks, and ability saves! First, go ahead and make a character on [D&D Beyond](https://www.dndbeyond.com/?utm_source=avrae&utm_medium=tutorial).
             
-            Once you're ready, import the character into Avrae with the command `{ctx.prefix}beyond <url>`, using \
-            either the "Sharable Link" on your character sheet or the URL in the address bar of your browser.
+            Once you're ready, import the character into Avrae with the command `{ctx.prefix}beyond <url>`, using either the "Sharable Link" on your character sheet or the URL in the address bar of your browser.
             ```
             {ctx.prefix}beyond <url>
             ```
@@ -95,12 +86,9 @@ class Quickstart(Tutorial):
 
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            Nice to meet you, {character.name}! Avrae has no limit on how many characters you can import, but you can \
-            only have one "active" at a time across all servers. To switch between active characters, use \
-            `{ctx.prefix}character <name>`.
+            Nice to meet you, {character.name}! Avrae has no limit on how many characters you can import, but you can only have one "active" at a time across all servers. To switch between active characters, use `{ctx.prefix}character <name>`.
             
-            Also, if you change your character's character sheet, Avrae will need to be updated to know about those \
-            changes. Whenever you do so, make sure to run `{ctx.prefix}update` to update your active character!
+            Also, if you change your character's character sheet, Avrae will need to be updated to know about those changes. Whenever you do so, make sure to run `{ctx.prefix}update` to update your active character!
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -113,12 +101,9 @@ class Quickstart(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Checks, Saves, and Attacks"
             embed.description = f"""
-            Finally, let's go over the three most important rolls in D&D: skill checks, saving throws, and attacks. \
-            Now that your character is saved in Avrae, you can easily make these three rolls with simple commands: \
-            `{ctx.prefix}check <skill>`, `{ctx.prefix}save <ability>`, and `{ctx.prefix}attack <action>`. 
+            Finally, let's go over the three most important rolls in D&D: skill checks, saving throws, and attacks. Now that your character is saved in Avrae, you can easily make these three rolls with simple commands: `{ctx.prefix}check <skill>`, `{ctx.prefix}save <ability>`, and `{ctx.prefix}attack <action>`. 
 
-            For example, you can make a Stealth check with `{ctx.prefix}check stealth`, a Dexterity save with \
-            `{ctx.prefix}save dex`, and an unarmed attack with `{ctx.prefix}attack "Unarmed Strike"`. Try these now!
+            For example, you can make a Stealth check with `{ctx.prefix}check stealth`, a Dexterity save with `{ctx.prefix}save dex`, and an unarmed attack with `{ctx.prefix}attack "Unarmed Strike"`. Try these now!
             ```
             {ctx.prefix}check <skill>
             {ctx.prefix}save <ability>
@@ -156,9 +141,7 @@ class Quickstart(Tutorial):
             await asyncio.sleep(3)
             embed = TutorialEmbed(self, ctx, footer=False)
             embed.description = f"""
-            That's all you need to get started! If you ever need a refresher on one command, you can use \
-            `{ctx.prefix}help <command>` to get the command's help sent to you. Next, you might want to try the \
-            *Playing the Game* tutorial - start this tutorial with `{ctx.prefix}tutorial Playing the Game`.
+            That's all you need to get started! If you ever need a refresher on one command, you can use `{ctx.prefix}help <command>` to get the command's help sent to you. Next, you might want to try the *Playing the Game* tutorial - start this tutorial with `{ctx.prefix}tutorial Playing the Game`.
 
             Looking for additional resources? Come join us at the [Avrae Development Discord](https://support.avrae.io).
             """

--- a/cogsmisc/tutorials/runningthegame.py
+++ b/cogsmisc/tutorials/runningthegame.py
@@ -1,0 +1,173 @@
+import asyncio
+
+from .models import Tutorial, TutorialEmbed, TutorialState, checklist, state
+
+
+class RunningTheGame(Tutorial):
+    name = "Running the Game (DM)"
+    description = """
+    *5 minutes*
+    Avrae helps Dungeon Masters run the game with a set of commands to act as the monstrous foes your players might face! This tutorial for Dungeon Masters covers how to act as a creature, and some tips and tricks for running the game.
+    """
+
+    @state(first=True)
+    class ChecksAndSaves(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Monster Checks & Saves"
+            embed.description = f"""
+            Avrae is a useful tool, and, as such, even has support for automating rolls done by monsters, inside of and outside of combat. In this tutorial, we will go over some of the basic commands that a DM can use to help run monsters effectively. Even if you're a player, knowing these commands can be useful, in case you ever want to run a game of your own.
+
+            First, let's run a check for a monster. After that, try a save for a monster. These are both similar to how they would be run as a player.
+            
+            As an example, to make a Sleight of Hand check for a Commoner, you would use  `{ctx.prefix}monster_check Commoner "Sleight of Hand"`. To have that same Commoner roll a Dexterity saving throw, you would use `{ctx.prefix}monster_save Commoner Dexterity`. Try it yourself!
+            ```
+            {ctx.prefix}monster_check <name of monster> <skill>
+            {ctx.prefix}monster_save <name of monster> <ability>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            mc = ctx.bot.get_command('mc')
+            ms = ctx.bot.get_command('ms')
+            if ctx.command in (mc, ms):
+                if ctx.command is mc:
+                    state_map.data['has_check'] = True
+                elif ctx.command is ms:
+                    state_map.data['has_save'] = True
+                await state_map.commit(ctx)
+                embed = TutorialEmbed(self, ctx)
+                embed.title = "Objectives"
+                embed.description = checklist([
+                    (f"Make a skill check for a monster with {ctx.prefix}monster_check <name of monster> <skill>.",
+                     state_map.data.get('has_check')),
+                    (f"Make an ability save for a monster with {ctx.prefix}monster_save <name of monster> <ability>.",
+                     state_map.data.get('has_save')),
+                ])
+                await ctx.send(embed=embed)
+
+            if state_map.data.get('has_check') and state_map.data.get('has_save'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Good! Now you know how to do skill checks and ability saves for monsters. These commands work both in and out of combat, too, so feel free to use them as you see fit.
+
+            When using these commands for monsters with multiple words in their name, make sure to surround the monster's name in quotes.
+            
+            As a note, if `{ctx.prefix}monster_check` and `{ctx.prefix}monster_save` seem like a handful to type out, you can also use `{ctx.prefix}mc` and {ctx.prefix}ms`, respectively, to achieve the same effect, so long as you use the proper arguments.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.ListMonsterAttacks)
+
+    @state()
+    class ListMonsterAttacks(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Listing Monster Attacks"
+            embed.description = f"""
+            One of the most common actions that a monster will take in D&D is the Attack action. Here, you will learn how to list off and use these attacks while outside of combat.
+
+            Firstly, to have an effective idea of what attacks a monster can use, you can list them off.
+            
+            For example, doing `{ctx.prefix}monster_attack "Silver Dragon Wyrmling" list` would list off the attacks of a Silver Dragon Wyrmling. Try that!
+            ```
+            {ctx.prefix}monster_attack <monster name> list
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command in (
+                    ctx.bot.get_command('ma'),
+                    ctx.bot.get_command('ma list')
+            ):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Great! Knowing what attacks a monster can do is quintessential to using them.
+            
+            To note, you can also use `{ctx.prefix}ma` instead of `{ctx.prefix}monster_attack`, as shorthand, so long as you use the proper arguments. And, again, if a monster's name is multiple words, surround the monster's name in quotes for the best effect.
+            
+            Now, let's put that knowledge to use.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.UseMonsterAttacks)
+
+    @state()
+    class ListMonsterAttacks(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Using Monster Attacks"
+            embed.description = f"""
+            Using monster attacks is similar to how one would use attacks as a player. To note, these attacks will not deal any damage to players automatically. You may want to consider using the initiative tracker for combats. To view the tutorial for how to run combats as a DM, view the "Initiative (DM)" tutorial once you have finished here.
+            
+            For example, to have the Silver Dragon Wyrmling from before attack with its bite, you would use `{ctx.prefix}monster_attack "Silver Dragon Wyrmling" bite`. Try attacking with a monster now.
+            ```
+            {ctx.prefix}monster_attack <name of monster> <name of attack>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('ma'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Excellent! Having the knowledge of how to use monster attacks outside of initiative is good knowledge to have.
+            
+            Like before, when attacking with a monster (or an attack!) that has multiple words to it, surround that argument in quotes for best effect. You can also use `{ctx.prefix}ma` as shorthand for `{ctx.prefix}monster_attack`, so long as you use the proper arguments to achieve your desired effect.
+            
+            Let's move on to the next part of this tutorial.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.CastMonsterSpells)
+
+    @state()
+    class CastMonsterSpells(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Using Monster Attacks"
+            embed.description = f"""
+            Like with the other aspects of using monster actions, casting their spells is similar to a player.
+            
+            To cast a spell using a monster, you must first ensure that that monster has spells that it can cast. To view the list of spells a monster can cast, view its information using the Lookup function of the bot, which is covered in the D&D Beyond Link section of the tutorial. In case you've forgotten, though, it is as simple as `{ctx.prefix}monster <name of monster>`.
+            
+            Let's use a Lich as an example. To have a Lich cast Blight, you would use `{ctx.prefix}monster_cast Lich Blight`.
+            
+            Once you have found a monster that has spellcasting, try casting one of its spells.
+            ```
+            {ctx.prefix}monster_cast <name of monster> <name of spell>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('mcast'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Superb! Keep in mind that, like with monster attacks, monster spells will not automatically deal damage to your players' characters. To do that, you must be using the initiative tracker, which is covered in the Initiative (DM) section of the tutorial.
+
+            Like with the previous commands, when casting using a monster with multiple words in its name or using a spell with multiple words in its name, you should surround the argument in quotes. Also, you can also use `{ctx.prefix}mcast` as shorthand for `{ctx.prefix}monster_cast`, providing you use all the proper arguments in their proper places.
+            
+            All of the commands covered in this tutorial have in-depth `{ctx.prefix}help` entries for them which list off more in-depth and specific arguments for each command. To view these help entries, use `{ctx.prefix}help monster_check`, `{ctx.prefix}help monster_save`, `{ctx.prefix}help monster_attack`, or `{ctx.prefix}help monster_cast`, respectively.
+            
+            One final note. While it was touched upon before, you should know that, as a DM, you cannot change or alter your players' stats in any way (such as modifying their HP or spell slots) without using the initiative tracker. You can learn more about the initiative tracker and how to use it by viewing the "Initiative (DM)" tutorial.
+            """
+            await ctx.send(embed=embed)
+            await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/runningthegame.py
+++ b/cogsmisc/tutorials/runningthegame.py
@@ -20,10 +20,10 @@ class RunningTheGame(Tutorial):
 
             First, let's run a check for a monster. After that, try a save for a monster. These are both similar to how they would be run as a player.
             
-            As an example, to make a Sleight of Hand check for a Commoner, you would use  `{ctx.prefix}monster_check Commoner "Sleight of Hand"`. To have that same Commoner roll a Dexterity saving throw, you would use `{ctx.prefix}monster_save Commoner Dexterity`. Try it yourself!
+            As an example, to make a Sleight of Hand check for a Commoner, you would use  `{ctx.prefix}moncheck Commoner "Sleight of Hand"`. To have that same Commoner roll a Dexterity saving throw, you would use `{ctx.prefix}monsave Commoner Dexterity`. Try it yourself!
             ```
-            {ctx.prefix}monster_check <name of monster> <skill>
-            {ctx.prefix}monster_save <name of monster> <ability>
+            {ctx.prefix}moncheck <name of monster> <skill>
+            {ctx.prefix}monsave <name of monster> <ability>
             ```
             """
             await ctx.send(embed=embed)
@@ -40,9 +40,9 @@ class RunningTheGame(Tutorial):
                 embed = TutorialEmbed(self, ctx)
                 embed.title = "Objectives"
                 embed.description = checklist([
-                    (f"Make a skill check for a monster with {ctx.prefix}monster_check <name of monster> <skill>.",
+                    (f"Make a skill check for a monster with `{ctx.prefix}moncheck <name of monster> <skill>`.",
                      state_map.data.get('has_check')),
-                    (f"Make an ability save for a monster with {ctx.prefix}monster_save <name of monster> <ability>.",
+                    (f"Make an ability save for a monster with `{ctx.prefix}monsave <name of monster> <ability>`.",
                      state_map.data.get('has_save')),
                 ])
                 await ctx.send(embed=embed)
@@ -57,7 +57,7 @@ class RunningTheGame(Tutorial):
 
             When using these commands for monsters with multiple words in their name, make sure to surround the monster's name in quotes.
             
-            As a note, if `{ctx.prefix}monster_check` and `{ctx.prefix}monster_save` seem like a handful to type out, you can also use `{ctx.prefix}mc` and {ctx.prefix}ms`, respectively, to achieve the same effect, so long as you use the proper arguments.
+            As a note, if `{ctx.prefix}moncheck` and `{ctx.prefix}monsave` seem like a handful to type out, you can also use `{ctx.prefix}mc` and `{ctx.prefix}ms`, respectively, to achieve the same effect, so long as you use the proper arguments.
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -74,9 +74,9 @@ class RunningTheGame(Tutorial):
 
             Firstly, to have an effective idea of what attacks a monster can use, you can list them off.
             
-            For example, doing `{ctx.prefix}monster_attack "Silver Dragon Wyrmling" list` would list off the attacks of a Silver Dragon Wyrmling. Try that!
+            For example, doing `{ctx.prefix}monattack "Silver Dragon Wyrmling" list` would list off the attacks of a Silver Dragon Wyrmling. Try that!
             ```
-            {ctx.prefix}monster_attack <monster name> list
+            {ctx.prefix}monattack <monster name> list
             ```
             """
             await ctx.send(embed=embed)
@@ -93,7 +93,7 @@ class RunningTheGame(Tutorial):
             embed.description = f"""
             Great! Knowing what attacks a monster can do is quintessential to using them.
             
-            To note, you can also use `{ctx.prefix}ma` instead of `{ctx.prefix}monster_attack`, as shorthand, so long as you use the proper arguments. And, again, if a monster's name is multiple words, surround the monster's name in quotes for the best effect.
+            To note, you can also use `{ctx.prefix}ma` instead of `{ctx.prefix}monattack`, as shorthand, so long as you use the proper arguments. And, again, if a monster's name is multiple words, surround the monster's name in quotes for the best effect.
             
             Now, let's put that knowledge to use.
             """
@@ -110,9 +110,9 @@ class RunningTheGame(Tutorial):
             embed.description = f"""
             Using monster attacks is similar to how one would use attacks as a player. To note, these attacks will not deal any damage to players automatically. You may want to consider using the initiative tracker for combats. To view the tutorial for how to run combats as a DM, view the "Initiative (DM)" tutorial once you have finished here.
             
-            For example, to have the Silver Dragon Wyrmling from before attack with its bite, you would use `{ctx.prefix}monster_attack "Silver Dragon Wyrmling" bite`. Try attacking with a monster now.
+            For example, to have the Silver Dragon Wyrmling from before attack with its bite, you would use `{ctx.prefix}monattack "Silver Dragon Wyrmling" bite`. Try attacking with a monster now.
             ```
-            {ctx.prefix}monster_attack <name of monster> <name of attack>
+            {ctx.prefix}monattack <name of monster> <name of attack>
             ```
             """
             await ctx.send(embed=embed)
@@ -126,7 +126,7 @@ class RunningTheGame(Tutorial):
             embed.description = f"""
             Excellent! Having the knowledge of how to use monster attacks outside of initiative is good knowledge to have.
             
-            Like before, when attacking with a monster (or an attack!) that has multiple words to it, surround that argument in quotes for best effect. You can also use `{ctx.prefix}ma` as shorthand for `{ctx.prefix}monster_attack`, so long as you use the proper arguments to achieve your desired effect.
+            Like before, when attacking with a monster (or an attack!) that has multiple words to it, surround that argument in quotes for best effect. You can also use `{ctx.prefix}ma` as shorthand for `{ctx.prefix}monattack`, so long as you use the proper arguments to achieve your desired effect.
             
             Let's move on to the next part of this tutorial.
             """
@@ -145,11 +145,11 @@ class RunningTheGame(Tutorial):
             
             To cast a spell using a monster, you must first ensure that that monster has spells that it can cast. To view the list of spells a monster can cast, view its information using the Lookup function of the bot, which is covered in the D&D Beyond Link section of the tutorial. In case you've forgotten, though, it is as simple as `{ctx.prefix}monster <name of monster>`.
             
-            Let's use a Lich as an example. To have a Lich cast Blight, you would use `{ctx.prefix}monster_cast Lich Blight`.
+            Let's use a Lich as an example. To have a Lich cast Blight, you would use `{ctx.prefix}moncast Lich Blight`.
             
             Once you have found a monster that has spellcasting, try casting one of its spells.
             ```
-            {ctx.prefix}monster_cast <name of monster> <name of spell>
+            {ctx.prefix}moncast <name of monster> <name of spell>
             ```
             """
             await ctx.send(embed=embed)
@@ -163,11 +163,13 @@ class RunningTheGame(Tutorial):
             embed.description = f"""
             Superb! Keep in mind that, like with monster attacks, monster spells will not automatically deal damage to your players' characters. To do that, you must be using the initiative tracker, which is covered in the Initiative (DM) section of the tutorial.
 
-            Like with the previous commands, when casting using a monster with multiple words in its name or using a spell with multiple words in its name, you should surround the argument in quotes. Also, you can also use `{ctx.prefix}mcast` as shorthand for `{ctx.prefix}monster_cast`, providing you use all the proper arguments in their proper places.
+            Like with the previous commands, when casting using a monster with multiple words in its name or using a spell with multiple words in its name, you should surround the argument in quotes. Also, you can also use `{ctx.prefix}mcast` as shorthand for `{ctx.prefix}moncast`, providing you use all the proper arguments in their proper places.
             
-            All of the commands covered in this tutorial have in-depth `{ctx.prefix}help` entries for them which list off more in-depth and specific arguments for each command. To view these help entries, use `{ctx.prefix}help monster_check`, `{ctx.prefix}help monster_save`, `{ctx.prefix}help monster_attack`, or `{ctx.prefix}help monster_cast`, respectively.
+            All of the commands covered in this tutorial have in-depth `{ctx.prefix}help` entries for them which list off more in-depth and specific arguments for each command. To view these help entries, use `{ctx.prefix}help moncheck`, `{ctx.prefix}help monsave`, `{ctx.prefix}help monattack`, or `{ctx.prefix}help moncast`, respectively.
             
             One final note. While it was touched upon before, you should know that, as a DM, you cannot change or alter your players' stats in any way (such as modifying their HP or spell slots) without using the initiative tracker. You can learn more about the initiative tracker and how to use it by viewing the "Initiative (DM)" tutorial.
+            
+            That's it for this tutorial!
             """
             await ctx.send(embed=embed)
             await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/spellcasting.py
+++ b/cogsmisc/tutorials/spellcasting.py
@@ -78,7 +78,7 @@ class Spellcasting(Tutorial):
 
             In order to target a creature with a spell, you must be playing on a character that can cast spells, have the spell that they're trying to cast in their known spells, and have a spell slot of that spell's appropriate level. While you can target creatures outside of initiative using the following command, know that the automation of healing and damage will not play out unless you are in initiative.
             
-            Why don't we first try casting a spell that normally only has one target? For example, Call Lightning. In this specific example, you would use `{ctx.prefix}cast "Call Lightning" -t "Adult Blue Dragon"`. Note the `-t` argument! Try it yourself.
+            Why don't we first try casting a spell that normally only has one target? For example, Chill Touch. In this specific example, you would use `{ctx.prefix}cast "Chill Touch" -t "Adult Blue Dragon"`. Note the `-t` argument! Try it yourself.
             ```
             {ctx.prefix}cast <name of spell> -t <name of target>
             ```

--- a/cogsmisc/tutorials/spellcasting.py
+++ b/cogsmisc/tutorials/spellcasting.py
@@ -1,0 +1,223 @@
+import asyncio
+
+from .models import Tutorial, TutorialEmbed, TutorialState, checklist, state
+
+
+class Spellcasting(Tutorial):
+    name = "Spellcasting"
+    description = """
+    *5 minutes*
+    This tutorial will help you learn how to cast spells outside of combat, and how to manage your spell slots.
+    """
+
+    @state(first=True)
+    class CastingSpells(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Casting Spells"
+            embed.description = f"""
+            Spellcasting is a useful tool in D&D. This tutorial will help you learn how to cast spells outside of \
+            combat. To start, you must first be on a character with the ability to cast spells. You must also have \
+            the ability to cast that spell, such as having it be in your spell list, and have a spell slot of the \
+            appropriate level.
+
+            To have that character, for example, cast the cantrip Ray of Frost, you would use \
+            `{ctx.prefix}cast "Ray of Frost"`. Try casting one of your own spells!
+            ```
+            {ctx.prefix}cast <name of spell>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('cast'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Wonderful! To note, as in the example provided before, when casting a spell with multiple words in its \
+            name, surround the name in quotes for best effect. Now, let's try doing something a little more powerful...
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.UpcastingSpells)
+
+    @state()
+    class UpcastingSpells(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Upcasting Spells"
+            embed.description = f"""
+            Sometimes, a spell just might not have enough "oomph" for the specific situation you need it for. \
+            If said spell supports it, however, you can cast that spell using a higher level slot. \
+            To do so, you must, as before, be on a character with the ability to cast spells, have that spell on \
+            your character's spell list, and have a spell slot of the appropriate level. Not all spells have greater \
+            effects when upcasting, though, so be sure to read a spell's description for an "At Higher Levels" section \
+            to see if it does.
+
+            For example, if your Fighter has thought it would be a good idea to touch lava, you can upcast Cure Wounds \
+            to heal their injuries (but not their pride) by doing `{ctx.prefix}cast "Cure Wounds" -l 4`. The `-l` \
+            argument is the key here, as it denotes that you're trying to cast a spell at a higher `l`evel. Try it now!
+            ```
+            {ctx.prefix}cast <name of spell> -l <slot level>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('cast') and '-l' in ctx.message.content:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Magical! Now that you know how to cast spells, please use your power responsibly. In the next section, \
+            we will talk about how to target a specific creature (or creatures) with your magic.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.Targeting)
+
+    @state()
+    class Targeting(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Targeting"
+            embed.description = f"""
+            When casting most spells, you will have to select a target, or designate multiple targets. Whether friend, \
+            foe, or self, Avrae has got you covered.
+
+            In order to target a creature with a spell, you must be playing on a character that can cast spells, have \
+            the spell that they're trying to cast in their known spells, and have a spell slot of that spell's \
+            appropriate level. While you can target creatures outside of initiative using the following command, know \
+            that the automation of healing and damage will not play out unless you are in initiative.
+            
+            Why don't we first try casting a spell that normally only has one target? For example, Call Lightning. \
+            In this specific example, you would use `{ctx.prefix}cast "Call Lightning" -t "Adult Blue Dragon"`. \
+            Note the `-t` argument! Try it yourself.
+            ```
+            {ctx.prefix}cast <name of spell> -t <name of target>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('cast') and '-t' in ctx.message.content:
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Marvellous! If you're ever looking to target more than one creature with the same spell, you can use \
+            multiple `-t <name of target>` arguments. For example, \
+            `{ctx.prefix}cast "Mass Healing Word" -t "Samric Alestorm" -t "Alanna Holimion" -t "Arwyn Terra"`. \
+            And, as before, the best results happen when you surround arguments with multiple words in quotes.
+
+            Now that you've learned how to cast your spells on your intended targets, let's move on to learning how to \
+            manually gain and lose spell slots.
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.SlotManagement)
+
+    @state()
+    class SlotManagement(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Gaining and Losing Spell Slots"
+            embed.description = f"""
+            Typically, through normal play, spell slots are gained when resting, or lost when casting. However, there \
+            may come a time when you need to manually adjust the amount of spell slots you currently have, such as if \
+            you mistakenly cast a spell. To note, these commands can only be used on characters that have spell slots. \
+            You also cannot go under the minimum or over the maximum amount of spell slots that your character has for \
+            that respective level.
+
+            For example, if you accidentally cast Fireball when you meant to cast Fire Bolt and need that third level \
+            spell slot, you can manually regain it by using `{ctx.prefix}game spellslot 3 +1`. Try to manually lose, \
+            and then regain, a spell slot now!
+            ```
+            {ctx.prefix}game spellslot <level of spell slot> -<number of spell slots>
+            {ctx.prefix}game spellslot <level of spell slot> +<number of spell slots>
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            command = ctx.bot.get_command('game spellslot')
+            if ctx.command is command:
+                if ctx.message.content.endswith('-1'):
+                    state_map.data['has_removed'] = True
+                elif ctx.message.content.endswith('+1'):
+                    state_map.data['has_added'] = True
+                await state_map.commit(ctx)
+
+                embed = TutorialEmbed(self, ctx)
+                embed.title = "Objectives"
+                embed.description = checklist([
+                    (f"Manually lose a spell slot using `{ctx.prefix}game spellslot <level of spell slot> "
+                     f"-<number of spell slots>`.", state_map.data.get('has_removed')),
+                    (f"Manually gain a spell slot using `{ctx.prefix}game spellslot <level of spell slot> "
+                     f"+<number of spell slots>`.", state_map.data.get('has_added')),
+                ])
+                await ctx.send(embed=embed)
+
+            if state_map.data.get('has_added') and state_map.data.get('has_removed'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            Fantastic! While the amount of situations in which you might need to gain or lose a spell slot manually \
+            may be low, it is still good to know how to do so for when that situation arises.
+
+            As a note, you can also use a set value instead of adding or subtracting spell slots, like \
+            `{ctx.prefix}game spellslot 3 3` to manually set the amount of third-level spell slots to 3. Let’s go over \
+            how to take a nice, relaxing long rest to get all of our spell slots back, yes?
+            """
+            await ctx.send(embed=embed)
+            await ctx.trigger_typing()
+            await asyncio.sleep(5)
+            await state_map.transition(ctx, self.tutorial.LongResting)
+
+    @state()
+    class LongResting(TutorialState):
+        async def objective(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.title = "Long Resting"
+            embed.description = f"""
+            After a long day of keeping your Barbarian from knocking themself out, or of making sure those pesky \
+            melee attacks don’t hit your fragile Wizard body, it is good to take a Long Rest to regain all of your \
+            expended power, so you can do it all again tomorrow.
+
+            Simply run the command to Long Rest, and all of your used spell slots will be restored. This also restores \
+            your HP and resets other things that might reset on a Long Rest.
+            ```
+            {ctx.prefix}game longrest
+            ```
+            """
+            await ctx.send(embed=embed)
+
+        async def listener(self, ctx, state_map):
+            if ctx.command is ctx.bot.get_command('game longrest'):
+                await self.transition(ctx, state_map)
+
+        async def transition(self, ctx, state_map):
+            embed = TutorialEmbed(self, ctx)
+            embed.description = f"""
+            And with that, you have successfully completed the Spellcasting tutorial. You are well on your way to \
+            being a master caster. If you ever need to review how to cast a spell, upcast a spell, manually gain/lose \
+            spell slots, or long rest, you can use `{ctx.prefix}help cast` (for casting/upcasting), \
+            `{ctx.prefix}help game spellslot` (for manually setting spell slot count), and `{ctx.prefix}game longrest` \
+            (for long resting).
+
+            And, as a final note, please understand that, on some of the sheet trackers that Avrae supports, there is \
+            a way to differentiate between learned and prepared spells on the sheet; however, Avrae does not keep \
+            track of which of your spells are simply learned, versus those that are prepared. It is best to keep track \
+            of which spells you have prepared manually.
+            """
+            await ctx.send(embed=embed)
+            await state_map.end_tutorial(ctx)

--- a/cogsmisc/tutorials/spellcasting.py
+++ b/cogsmisc/tutorials/spellcasting.py
@@ -16,13 +16,9 @@ class Spellcasting(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Casting Spells"
             embed.description = f"""
-            Spellcasting is a useful tool in D&D. This tutorial will help you learn how to cast spells outside of \
-            combat. To start, you must first be on a character with the ability to cast spells. You must also have \
-            the ability to cast that spell, such as having it be in your spell list, and have a spell slot of the \
-            appropriate level.
+            Spellcasting is a useful tool in D&D. This tutorial will help you learn how to cast spells outside of combat. To start, you must first be on a character with the ability to cast spells. You must also have the ability to cast that spell, such as having it be in your spell list, and have a spell slot of the appropriate level.
 
-            To have that character, for example, cast the cantrip Ray of Frost, you would use \
-            `{ctx.prefix}cast "Ray of Frost"`. Try casting one of your own spells!
+            To have that character, for example, cast the cantrip Ray of Frost, you would use `{ctx.prefix}cast "Ray of Frost"`. Try casting one of your own spells!
             ```
             {ctx.prefix}cast <name of spell>
             ```
@@ -36,8 +32,7 @@ class Spellcasting(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            Wonderful! To note, as in the example provided before, when casting a spell with multiple words in its \
-            name, surround the name in quotes for best effect. Now, let's try doing something a little more powerful...
+            Wonderful! To note, as in the example provided before, when casting a spell with multiple words in its name, surround the name in quotes for best effect. Now, let's try doing something a little more powerful...
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -50,16 +45,9 @@ class Spellcasting(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Upcasting Spells"
             embed.description = f"""
-            Sometimes, a spell just might not have enough "oomph" for the specific situation you need it for. \
-            If said spell supports it, however, you can cast that spell using a higher level slot. \
-            To do so, you must, as before, be on a character with the ability to cast spells, have that spell on \
-            your character's spell list, and have a spell slot of the appropriate level. Not all spells have greater \
-            effects when upcasting, though, so be sure to read a spell's description for an "At Higher Levels" section \
-            to see if it does.
+            Sometimes, a spell just might not have enough "oomph" for the specific situation you need it for. If said spell supports it, however, you can cast that spell using a higher level slot. To do so, you must, as before, be on a character with the ability to cast spells, have that spell on your character's spell list, and have a spell slot of the appropriate level. Not all spells have greater effects when upcasting, though, so be sure to read a spell's description for an "At Higher Levels" section to see if it does.
 
-            For example, if your Fighter has thought it would be a good idea to touch lava, you can upcast Cure Wounds \
-            to heal their injuries (but not their pride) by doing `{ctx.prefix}cast "Cure Wounds" -l 4`. The `-l` \
-            argument is the key here, as it denotes that you're trying to cast a spell at a higher `l`evel. Try it now!
+            For example, if your Fighter has thought it would be a good idea to touch lava, you can upcast Cure Wounds to heal their injuries (but not their pride) by doing `{ctx.prefix}cast "Cure Wounds" -l 4`. The `-l` argument is the key here, as it denotes that you're trying to cast a spell at a higher `l`evel. Try it now!
             ```
             {ctx.prefix}cast <name of spell> -l <slot level>
             ```
@@ -73,8 +61,7 @@ class Spellcasting(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            Magical! Now that you know how to cast spells, please use your power responsibly. In the next section, \
-            we will talk about how to target a specific creature (or creatures) with your magic.
+            Magical! Now that you know how to cast spells, please use your power responsibly. In the next section, we will talk about how to target a specific creature (or creatures) with your magic.
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -87,17 +74,11 @@ class Spellcasting(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Targeting"
             embed.description = f"""
-            When casting most spells, you will have to select a target, or designate multiple targets. Whether friend, \
-            foe, or self, Avrae has got you covered.
+            When casting most spells, you will have to select a target, or designate multiple targets. Whether friend, foe, or self, Avrae has got you covered.
 
-            In order to target a creature with a spell, you must be playing on a character that can cast spells, have \
-            the spell that they're trying to cast in their known spells, and have a spell slot of that spell's \
-            appropriate level. While you can target creatures outside of initiative using the following command, know \
-            that the automation of healing and damage will not play out unless you are in initiative.
+            In order to target a creature with a spell, you must be playing on a character that can cast spells, have the spell that they're trying to cast in their known spells, and have a spell slot of that spell's appropriate level. While you can target creatures outside of initiative using the following command, know that the automation of healing and damage will not play out unless you are in initiative.
             
-            Why don't we first try casting a spell that normally only has one target? For example, Call Lightning. \
-            In this specific example, you would use `{ctx.prefix}cast "Call Lightning" -t "Adult Blue Dragon"`. \
-            Note the `-t` argument! Try it yourself.
+            Why don't we first try casting a spell that normally only has one target? For example, Call Lightning. In this specific example, you would use `{ctx.prefix}cast "Call Lightning" -t "Adult Blue Dragon"`. Note the `-t` argument! Try it yourself.
             ```
             {ctx.prefix}cast <name of spell> -t <name of target>
             ```
@@ -111,13 +92,9 @@ class Spellcasting(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            Marvellous! If you're ever looking to target more than one creature with the same spell, you can use \
-            multiple `-t <name of target>` arguments. For example, \
-            `{ctx.prefix}cast "Mass Healing Word" -t "Samric Alestorm" -t "Alanna Holimion" -t "Arwyn Terra"`. \
-            And, as before, the best results happen when you surround arguments with multiple words in quotes.
+            Marvellous! If you're ever looking to target more than one creature with the same spell, you can use multiple `-t <name of target>` arguments. For example, `{ctx.prefix}cast "Mass Healing Word" -t "Samric Alestorm" -t "Alanna Holimion" -t "Arwyn Terra"`. And, as before, the best results happen when you surround arguments with multiple words in quotes.
 
-            Now that you've learned how to cast your spells on your intended targets, let's move on to learning how to \
-            manually gain and lose spell slots.
+            Now that you've learned how to cast your spells on your intended targets, let's move on to learning how to manually gain and lose spell slots.
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -130,15 +107,9 @@ class Spellcasting(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Gaining and Losing Spell Slots"
             embed.description = f"""
-            Typically, through normal play, spell slots are gained when resting, or lost when casting. However, there \
-            may come a time when you need to manually adjust the amount of spell slots you currently have, such as if \
-            you mistakenly cast a spell. To note, these commands can only be used on characters that have spell slots. \
-            You also cannot go under the minimum or over the maximum amount of spell slots that your character has for \
-            that respective level.
+            Typically, through normal play, spell slots are gained when resting, or lost when casting. However, there may come a time when you need to manually adjust the amount of spell slots you currently have, such as if you mistakenly cast a spell. To note, these commands can only be used on characters that have spell slots. You also cannot go under the minimum or over the maximum amount of spell slots that your character has for that respective level.
 
-            For example, if you accidentally cast Fireball when you meant to cast Fire Bolt and need that third level \
-            spell slot, you can manually regain it by using `{ctx.prefix}game spellslot 3 +1`. Try to manually lose, \
-            and then regain, a spell slot now!
+            For example, if you accidentally cast Fireball when you meant to cast Fire Bolt and need that third level spell slot, you can manually regain it by using `{ctx.prefix}game spellslot 3 +1`. Try to manually lose, and then regain, a spell slot now!
             ```
             {ctx.prefix}game spellslot <level of spell slot> -<number of spell slots>
             {ctx.prefix}game spellslot <level of spell slot> +<number of spell slots>
@@ -171,12 +142,9 @@ class Spellcasting(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            Fantastic! While the amount of situations in which you might need to gain or lose a spell slot manually \
-            may be low, it is still good to know how to do so for when that situation arises.
+            Fantastic! While the amount of situations in which you might need to gain or lose a spell slot manually may be low, it is still good to know how to do so for when that situation arises.
 
-            As a note, you can also use a set value instead of adding or subtracting spell slots, like \
-            `{ctx.prefix}game spellslot 3 3` to manually set the amount of third-level spell slots to 3. Let’s go over \
-            how to take a nice, relaxing long rest to get all of our spell slots back, yes?
+            As a note, you can also use a set value instead of adding or subtracting spell slots, like `{ctx.prefix}game spellslot 3 3` to manually set the amount of third-level spell slots to 3. Let’s go over how to take a nice, relaxing long rest to get all of our spell slots back, yes?
             """
             await ctx.send(embed=embed)
             await ctx.trigger_typing()
@@ -189,12 +157,9 @@ class Spellcasting(Tutorial):
             embed = TutorialEmbed(self, ctx)
             embed.title = "Long Resting"
             embed.description = f"""
-            After a long day of keeping your Barbarian from knocking themself out, or of making sure those pesky \
-            melee attacks don’t hit your fragile Wizard body, it is good to take a Long Rest to regain all of your \
-            expended power, so you can do it all again tomorrow.
+            After a long day of keeping your Barbarian from knocking themself out, or of making sure those pesky melee attacks don’t hit your fragile Wizard body, it is good to take a Long Rest to regain all of your expended power, so you can do it all again tomorrow.
 
-            Simply run the command to Long Rest, and all of your used spell slots will be restored. This also restores \
-            your HP and resets other things that might reset on a Long Rest.
+            Simply run the command to Long Rest, and all of your used spell slots will be restored. This also restores your HP and resets other things that might reset on a Long Rest.
             ```
             {ctx.prefix}game longrest
             ```
@@ -208,16 +173,9 @@ class Spellcasting(Tutorial):
         async def transition(self, ctx, state_map):
             embed = TutorialEmbed(self, ctx)
             embed.description = f"""
-            And with that, you have successfully completed the Spellcasting tutorial. You are well on your way to \
-            being a master caster. If you ever need to review how to cast a spell, upcast a spell, manually gain/lose \
-            spell slots, or long rest, you can use `{ctx.prefix}help cast` (for casting/upcasting), \
-            `{ctx.prefix}help game spellslot` (for manually setting spell slot count), and `{ctx.prefix}game longrest` \
-            (for long resting).
+            And with that, you have successfully completed the Spellcasting tutorial. You are well on your way to being a master caster. If you ever need to review how to cast a spell, upcast a spell, manually gain/lose spell slots, or long rest, you can use `{ctx.prefix}help cast` (for casting/upcasting), `{ctx.prefix}help game spellslot` (for manually setting spell slot count), and `{ctx.prefix}game longrest` (for long resting).
 
-            And, as a final note, please understand that, on some of the sheet trackers that Avrae supports, there is \
-            a way to differentiate between learned and prepared spells on the sheet; however, Avrae does not keep \
-            track of which of your spells are simply learned, versus those that are prepared. It is best to keep track \
-            of which spells you have prepared manually.
+            And, as a final note, please understand that, on some of the sheet trackers that Avrae supports, there is a way to differentiate between learned and prepared spells on the sheet; however, Avrae does not keep track of which of your spells are simply learned, versus those that are prepared. It is best to keep track of which spells you have prepared manually.
             """
             await ctx.send(embed=embed)
             await state_map.end_tutorial(ctx)

--- a/dbot.py
+++ b/dbot.py
@@ -34,7 +34,7 @@ from utils.redisIO import RedisIO
 COGS = (
     "cogs5e.dice", "cogs5e.charGen", "cogs5e.homebrew", "cogs5e.lookup", "cogs5e.pbpUtils",
     "cogs5e.gametrack", "cogs5e.initTracker", "cogs5e.sheetManager", "cogsmisc.customization", "cogsmisc.core",
-    "cogsmisc.publicity", "cogsmisc.stats", "cogsmisc.repl", "cogsmisc.adminUtils"
+    "cogsmisc.publicity", "cogsmisc.stats", "cogsmisc.repl", "cogsmisc.adminUtils", "cogsmisc.tutorials"
 )
 
 

--- a/scripts/ensure_indices.py
+++ b/scripts/ensure_indices.py
@@ -94,6 +94,9 @@ INDICES = {
     "user_permissions": [
         IndexModel('id', unique=True)
     ],
+    "tutorial_map": [
+        IndexModel('user_id', unique=True)
+    ],
 
     # alias workshop
     "workshop_collections": [

--- a/utils/aldclient.py
+++ b/utils/aldclient.py
@@ -1,7 +1,6 @@
 """
 Asyncio wrapper for launchdarkly client to ensure flag evaluation is not a blocking call.
 """
-
 import ldclient
 
 
@@ -14,3 +13,8 @@ class AsyncLaunchDarklyClient(ldclient.LDClient):
 
     async def variation(self, key, user, default):  # run variation evaluation in a separate thread
         return await self.loop.run_in_executor(None, super().variation, key, user, default)
+
+
+def discord_user_to_dict(user):
+    """Converts a Discord user to a user dict for LD."""
+    return {"key": str(user.id), "name": str(user)}

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -2,6 +2,7 @@ import discord.utils
 from discord.ext import commands
 
 from utils import config
+from utils.aldclient import discord_user_to_dict
 
 
 # The permission system of the bot is based on a "just works" basis
@@ -106,7 +107,7 @@ def feature_flag(flag_name, use_ddb_user=False, default=False):
             else:
                 user = ddb_user.to_ld_dict()
         else:
-            user = {"key": str(ctx.author.id), "name": str(ctx.author)}
+            user = discord_user_to_dict(ctx.author)
 
         flag_on = await ctx.bot.ldclient.variation(flag_name, user, default)
         if flag_on:

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -97,6 +97,7 @@ async def search_and_select(ctx, list_to_search: list, query, key, cutoff=5, ret
                             list_filter=None, selectkey=None, search_func=search, return_metadata=False):
     """
     Searches a list for an object matching the key, and prompts user to select on multiple matches.
+
     :param ctx: The context of the search.
     :param list_to_search: The list of objects to search.
     :param query: The value to search for.
@@ -108,8 +109,7 @@ async def search_and_select(ctx, list_to_search: list, query, key, cutoff=5, ret
     :param list_filter: A filter to filter the list to search by.
     :param selectkey: If supplied, each option will display as selectkey(opt) in the select prompt.
     :param search_func: The function to use to search.
-    :param return_metadata Whether to return a metadata object {num_options, chosen_index}.
-    :return:
+    :param return_metadata: Whether to return a metadata object {num_options, chosen_index}.
     """
     if list_filter:
         list_to_search = list(filter(list_filter, list_to_search))


### PR DESCRIPTION
### Summary
Adds the framework for tutorials, as well as the quickstart tutorial.

- `!tutorial` shows the current tutorial objective if the user is in a tutorial, or lists the available tutorials if not
- `!tutorial skip` skips the current objective
- `!tutorial end` ends the current tutorial
- All these commands are behind feature flags
- More tutorials will be added before this is released
- Hi everyone that's watching #github expectantly 👋 

PRing this now to begin tests with staff and test the impact of the listeners.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
