### PR TITLE
Fix AVR-702 (server collection commands erroring in DMs)

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -309,6 +309,8 @@ async def _alias_before_edit(ctx, name=None):
 
 
 async def _servalias_before_edit(ctx, name=None):
+    if ctx.guild is None:
+        raise commands.NoPrivateMessage()
     if not _can_edit_servaliases(ctx):
         raise NotAllowed("You do not have permission to edit server aliases. Either __Administrator__ "
                          "Discord permissions or a role named \"Server Aliaser\" or \"Dragonspeaker\" "

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -319,6 +319,8 @@ async def _servalias_before_edit(ctx, name=None):
 
 
 async def _servsnippet_before_edit(ctx, _=None):
+    if ctx.guild is None:
+        raise commands.NoPrivateMessage()
     if not _can_edit_servaliases(ctx):
         raise NotAllowed("You do not have permission to edit server snippets. Either __Administrator__ "
                          "Discord permissions or a role named \"Server Aliaser\" or \"Dragonspeaker\" "


### PR DESCRIPTION
Summary
======

Adds checks to `_servalias_before_edit` and `_servsnippet_before_edit` to prevent them from executing in DM Channels.

Fixes #1415 (AVR-702)

Checklist
======
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
PR Type
---------
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

Other
------
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
