### PR TITLE
Large Bot Sharding: Concurrent Startup

### DIFF
--- a/utils/clustering.py
+++ b/utils/clustering.py
@@ -18,6 +18,7 @@ else:
     figure out which task died, and take over for it
 """
 import asyncio
+import datetime
 import json
 import logging
 import uuid
@@ -25,6 +26,7 @@ from contextlib import asynccontextmanager
 from math import ceil
 
 import aiohttp
+import discord.http
 
 from utils import config
 
@@ -55,21 +57,34 @@ async def _coordinate_shards(bot):
     coordinator_exists = await bot.rdb.exists(cluster_coordination_key)
     my_task_arn, my_family, my_ecs_cluster_name = await _get_ecs_metadata()
 
+    # poll discord - how many shards, max concurrency?
+    try:
+        data = await bot.http.request(discord.http.Route('GET', '/gateway/bot'))
+    except discord.HTTPException as e:
+        raise discord.GatewayNotFound() from e
+    recommended_shards = data['shards']
+    session_start_limit = data['session_start_limit']
+    bot.launch_max_concurrency = session_start_limit['max_concurrency']
+
+    # alert if remaining starts < 25% total
+    if session_start_limit['remaining'] < (session_start_limit['total'] * 0.25):
+        log.critical(f"Remaining IDENTIFY quota low! Remaining: {session_start_limit['remaining']}")
+        reset_at = datetime.datetime.now() + datetime.timedelta(milliseconds=session_start_limit['reset_after'])
+        log.info(f"Resets at: {reset_at}")
+
     # get the total number of shards running on this acct
     if coordinator_exists:
         # get the canonical number of shards
         bot.shard_count = int(await bot.rdb.hget(cluster_coordination_key, "num_shards"))
     else:
-        if config.NUM_SHARDS is None:
-            # how many shards does Discord want?
-            recommended_shards, _ = await bot.http.get_bot_gateway()
-        else:
+        if config.NUM_SHARDS is not None:
             recommended_shards = config.NUM_SHARDS
         # create the task coordinator
         await bot.rdb.hset(cluster_coordination_key, "num_shards", recommended_shards)
         bot.shard_count = recommended_shards
         log.info(f"Created task coordinator {cluster_coordination_key} with num_shards={bot.shard_count}!")
-    log.debug(f"SHARD_COUNT={bot.shard_count}")
+    log.info(f"Session start limits: {session_start_limit}")
+    log.debug(f"SHARD_COUNT={bot.shard_count}; MAX_CONCURRENCY={bot.launch_max_concurrency}")
 
     # claim unclaimed shards, or take over a dead task
     num_existing_clusters = await bot.rdb.hlen(cluster_coordination_key) - 1
@@ -152,7 +167,7 @@ async def coordination_lock(rdb):
     while not await rdb.setnx(cluster_lock_key, lock_value):
         await asyncio.sleep(1)
         i += 1
-        log.info(f"Waiting for lock... ({i}s)")
+        log.debug(f"Waiting for lock... ({i}s)")
 
     log.info("Acquired lock, coordinating shards!")
     try:
@@ -164,3 +179,14 @@ async def coordination_lock(rdb):
             await rdb.delete(cluster_lock_key)
         else:
             log.warning("Lock value is not what we set, ignoring value!")
+
+
+# lock: each shard reserves the bucket for 5s by doing a SET NX EX with the currently launching shard id
+async def wait_bucket_available(shard_id, bucket_id, rdb):
+    cluster_lock_key = f"shards.{config.GIT_COMMIT_SHA}.lock:{bucket_id}"
+    i = 0
+    while not await rdb.set(cluster_lock_key, shard_id, ex=5, nx=True):
+        await asyncio.sleep(0.2)
+        i += 0.2
+        log.debug(f"Waiting for shard lock... ({i}s)")
+    log.info(f"Bucket {bucket_id} is available, launching shard ID {shard_id}")

--- a/utils/redisIO.py
+++ b/utils/redisIO.py
@@ -24,8 +24,11 @@ class RedisIO:
         encoded_data = await self._db.get(key)
         return encoded_data.decode() if encoded_data is not None else default
 
-    async def set(self, key, value, **kwargs):
-        return await self._db.set(key, value, **kwargs)
+    async def set(self, key, value, *, ex=0, nx=False):
+        exist = None
+        if nx:
+            exist = self._db.SET_IF_NOT_EXIST
+        return await self._db.set(key, value, expire=ex, exist=exist)
 
     async def incr(self, key):
         return await self._db.incr(key)
@@ -190,5 +193,6 @@ def deserialize_ps_msg(message: str):
     if t not in PS_DESER_MAP:
         raise TypeError(f"{t} is not a valid pubsub message type.")
     return PS_DESER_MAP[t].from_dict(data)
+
 
 pslogger = logging.getLogger("rdb.pubsub")


### PR DESCRIPTION
### Summary
Adds support for launching multiple shards concurrently (see https://discord.com/developers/docs/topics/gateway#session-start-limit-object). Note that `max_concurrency` actually refers to the number of concurrent IDENTIFY buckets, calculated by `shard_id % max_concurrency`.

The strategy here is to lock each of these buckets for 5 seconds in Redis each time a shard launches.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] **If code changes were made then they have been tested.**
- [ ] I have updated the documentation to reflect the changes.
