### PR TITLE
Add `abs` to draconic evaluator

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -23,7 +23,7 @@ from utils.dice import PersistentRollContext
 DEFAULT_BUILTINS = {
     # builtins
     'floor': floor, 'ceil': ceil, 'round': round, 'len': len, 'max': max, 'min': min, 'enumerate': enumerate,
-    'range': safe_range, 'sqrt': sqrt, 'sum': sum, 'any': any, 'all': all, 'time': time.time,
+    'range': safe_range, 'sqrt': sqrt, 'sum': sum, 'any': any, 'all': all, 'abs': abs, 'time': time.time,
     # ours
     'roll': roll, 'vroll': vroll, 'err': err, 'typeof': typeof,
     # legacy from simpleeval

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -228,6 +228,15 @@ These functions are available in any scripting context, regardless if you have a
 Python Builtins
 """""""""""""""
 
+.. function:: abs(x)
+
+    Takes a number (float or int) and returns the absolute value of that number.
+
+    :param x: The number to find the absolute value of.
+    :type x: float or int
+    :return: The absolute value of x.
+    :rtype: float or int
+
 .. function:: all(iterable)
 
     Return ``True`` if all elements of the *iterable* are true, or if the iterable is empty.


### PR DESCRIPTION
Summary
======

Adds the built-in python function `abs` to the Draconic evaluator in Avrae.

Resolves #1466 (AFR-760)

Checklist
======

PR Type
--------

<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
Other
--------

- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.

![image](https://user-images.githubusercontent.com/16567386/110881322-2c0e7f00-82ae-11eb-94f9-5054941f3fd0.png)

