### PR TITLE
2021w10

### DIFF
--- a/cogs5e/gamelog.py
+++ b/cogs5e/gamelog.py
@@ -159,20 +159,20 @@ class GameLog(commands.Cog):
         """
         Sends a typing indicator to the linked channel to indicate that something is about to happen.
         """
-        await gctx.channel.trigger_typing()
+        await gctx.trigger_typing()
 
     async def dice_roll(self, gctx):
         """
         Sends a message with the result of the roll, similar to `!r`.
         """
-        await gctx.channel.trigger_typing()
+        await gctx.trigger_typing()
 
         roll_request = ddb.dice.RollRequest.from_dict(gctx.event.data)
         if not roll_request.rolls:  # do nothing if there are no rolls actually made
             return
         elif len(roll_request.rolls) > 1:  # if there are multiple rolls in the same event, just use the default handler
             await self.dice_roll_roll(gctx, roll_request,
-                                      comment_getter=lambda rr: f"{roll_request.action}: {rr.roll_type.value.title()}")
+                                      comment_getter=gamelogutils.default_comment_getter(roll_request))
             return
         first_roll = roll_request.rolls[0]
 
@@ -201,7 +201,10 @@ class GameLog(commands.Cog):
         :type comment_getter: Callable[[ddb.dice.RollRequestRoll], str]
         """
         if comment_getter is None:
-            comment_getter = lambda _: comment
+            if comment is None:
+                comment_getter = gamelogutils.default_comment_getter(roll_request)
+            else:
+                comment_getter = lambda _: comment
 
         results = []
         for rr in roll_request.rolls:
@@ -214,7 +217,7 @@ class GameLog(commands.Cog):
 
         out = f"<@!{gctx.discord_user_id}> **rolled from** {constants.DDB_LOGO_EMOJI}:\n{final_results}"
         # the user knows they rolled - don't need to ping them in discord
-        await gctx.channel.send(out, allowed_mentions=discord.AllowedMentions.none())
+        await gctx.send(out, allowed_mentions=discord.AllowedMentions.none())
 
     async def _dice_roll_embed_common(self, gctx, roll_request, title_fmt: str, **fmt_kwargs):
         """
@@ -226,7 +229,7 @@ class GameLog(commands.Cog):
         caster = await gctx.get_statblock()
         if caster is None:
             await self.dice_roll_roll(gctx, roll_request,
-                                      comment_getter=lambda rr: f"{roll_request.action}: {rr.roll_type.value.title()}")
+                                      comment_getter=gamelogutils.default_comment_getter(roll_request))
             return
 
         # only listen to the first roll
@@ -237,7 +240,7 @@ class GameLog(commands.Cog):
         embed.title = title_fmt.format(name=caster.get_title_name(), **fmt_kwargs)
         embed.description = str(the_roll.to_d20())
         embed.set_footer(text=f"Rolled in {gctx.campaign.campaign_name}", icon_url=constants.DDB_LOGO_ICON)
-        await gctx.channel.send(embed=embed)
+        await gctx.send(embed=embed)
 
     async def dice_roll_check(self, gctx, roll_request):
         """Check: Display like ``!c``. Requires character - if not imported falls back to default roll."""
@@ -288,7 +291,7 @@ class GameLog(commands.Cog):
             # or if the action is unknown (we assume basic to hit/damage then)
             embed = gamelogutils.embed_for_basic_attack(gctx, roll_request.action, caster, attack_roll)
 
-        message = await gctx.channel.send(embed=embed)
+        message = await gctx.send(embed=embed)
         if pend_damage:
             await gamelogutils.PendingAttack.create(gctx, roll_request, gctx.event, message.id)
 
@@ -321,13 +324,13 @@ class GameLog(commands.Cog):
 
         # either update the old message or post a new one
         if pending is not None:
-            partial = discord.PartialMessage(channel=gctx.channel, id=pending.message_id)
+            partial = discord.PartialMessage(channel=await gctx.destination_channel(), id=pending.message_id)
             try:
                 await partial.edit(embed=embed)
             except discord.NotFound:  # original message was deleted
-                await gctx.channel.send(embed=embed)
+                await gctx.send(embed=embed)
         else:
-            await gctx.channel.send(embed=embed)
+            await gctx.send(embed=embed)
 
     # ==== game log send methods ====
     # to access, get the cog from the handler function that is making the checks and call these

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -603,14 +603,14 @@ async def send_ddb_ctas(ctx, character):
         ld_dict = {"key": str(ctx.author.id), "anonymous": True}
     gamelog_flag = await ctx.bot.ldclient.variation('cog.gamelog.cta.enabled', ld_dict, False)
 
-    # has the user seen this cta within the last 24h?
+    # has the user seen this cta within the last 7d?
     if await ctx.bot.rdb.get(f"cog.sheetmanager.cta.seen.{ctx.author.id}"):
         return
 
     embed = EmbedWithCharacter(character)
     embed.title = "Heads up!"
     embed.description = "There's a couple of things you can do to make your experience even better!"
-    embed.set_footer(text="You won't see this message again today.")
+    embed.set_footer(text="You won't see this message again this week.")
 
     # link ddb user
     if ddb_user is None:
@@ -636,7 +636,7 @@ async def send_ddb_ctas(ctx, character):
     if not embed.fields:
         return
     await ctx.send(embed=embed)
-    await ctx.bot.rdb.setex(f"cog.sheetmanager.cta.seen.{ctx.author.id}", str(time.time()), 60 * 60 * 24)
+    await ctx.bot.rdb.setex(f"cog.sheetmanager.cta.seen.{ctx.author.id}", str(time.time()), 60 * 60 * 24 * 7)
 
 
 def setup(bot):

--- a/cogs5e/utils/gamelogutils.py
+++ b/cogs5e/utils/gamelogutils.py
@@ -45,6 +45,21 @@ async def action_from_roll_request(gctx, caster, roll_request):
 
 
 # ---- display helpers ----
+def default_comment_getter(roll_request):
+    """
+    Given a RollRequest, return a function mapping RollRequestRolls to comments (strs).
+
+    :type roll_request: ddb.dice.RollRequest
+    :rtype: typing.Callable[[ddb.dice.RollRequestRoll], typing.Optional[str]]
+    """
+    if roll_request.action != 'custom':
+        if roll_request.context and roll_request.context.name:
+            return lambda rr: f"{roll_request.context.name}: {roll_request.action}: {rr.roll_type.value.title()}"
+        return lambda rr: f"{roll_request.action}: {rr.roll_type.value.title()}"
+    else:
+        return lambda _: None
+
+
 def embed_for_caster(caster):
     if isinstance(caster, Character):
         return EmbedWithCharacter(character=caster, name=False)

--- a/ddb/dice/tree.py
+++ b/ddb/dice/tree.py
@@ -69,21 +69,24 @@ class RollRequest:
 
 
 class RollContext:
-    def __init__(self, entity_id: str = None, entity_type: str = None):
+    def __init__(self, entity_id: str = None, entity_type: str = None, name: str = None, avatar_url: str = None):
         self.entity_id = entity_id
         self.entity_type = entity_type
+        self.name = name
+        self.avatar_url = avatar_url
 
     @classmethod
     def from_dict(cls, d):
-        return cls(d.get('entityId'), d.get('entityType'))
+        return cls(d.get('entityId'), d.get('entityType'), d.get('name'), d.get('avatarUrl'))
 
     def to_dict(self):
-        return {"entityId": self.entity_id, "entityType": self.entity_type}
+        return {"entityId": self.entity_id, "entityType": self.entity_type, "name": self.name,
+                "avatarUrl": self.avatar_url}
 
     @classmethod
     def from_character(cls, character):
         """Returns a context associated with a DDB character."""
-        return cls(character.upstream_id, 'character')
+        return cls(character.upstream_id, 'character', character.name, character.image)
 
 
 class RollRequestRoll:

--- a/ddb/gamelog/client.py
+++ b/ddb/gamelog/client.py
@@ -130,6 +130,10 @@ class GameLogClient:
         if event.source == AVRAE_EVENT_SOURCE:
             return
 
+        # check: is the event intended for the whole campaign? (Private messages not supported, yet)
+        if event.message_scope != 'gameId':
+            return
+
         # check: is this campaign linked to a channel?
         try:
             campaign = await CampaignLink.from_id(self.bot.mdb, event.game_id)

--- a/ddb/gamelog/context.py
+++ b/ddb/gamelog/context.py
@@ -2,6 +2,7 @@ import logging
 
 from cogs5e.models.character import Character
 from cogs5e.models.errors import NoCharacter
+from gamedata.compendium import compendium
 from utils.functions import get_guild_member, user_from_id
 
 _sentinel = object()
@@ -78,3 +79,15 @@ class GameLogEventContext:
         except NoCharacter:
             self._character = None
         return self._character
+
+    async def get_monster(self):
+        """
+        Gets the Monster associated with the event. Returns None if the event is not associated with a monster.
+
+        :rtype: gamedata.monster.Monster or None
+        """
+        return compendium.lookup_by_entitlement('monster', self.event.entity_id)
+
+    async def get_statblock(self):
+        """:rtype: cogs5e.models.sheet.statblock.StatBlock or None"""
+        return (await self.get_character()) or (await self.get_monster())

--- a/ddb/gamelog/context.py
+++ b/ddb/gamelog/context.py
@@ -86,7 +86,9 @@ class GameLogEventContext:
 
         :rtype: gamedata.monster.Monster or None
         """
-        return compendium.lookup_by_entitlement('monster', self.event.entity_id)
+        if not self.event.entity_id:
+            return None
+        return compendium.lookup_by_entitlement('monster', int(self.event.entity_id))
 
     async def get_statblock(self):
         """:rtype: cogs5e.models.sheet.statblock.StatBlock or None"""

--- a/ddb/gamelog/errors.py
+++ b/ddb/gamelog/errors.py
@@ -34,3 +34,9 @@ class CampaignAlreadyLinked(CampaignLinkException):
 
     def __init__(self, msg='This campaign has already been linked to a different channel.'):
         super().__init__(msg)
+
+
+# ==== event handling ====
+class IgnoreEvent(GameLogException):
+    """We should just stop processing this event. Do not display any error."""
+    pass

--- a/ddb/gamelog/event.py
+++ b/ddb/gamelog/event.py
@@ -19,8 +19,8 @@ class GameLogEvent:
         self.event_type = kwargs['eventType']  # type: str
         self.source = kwargs['source']  # type: str
         self.data = kwargs['data']
-        self.entity_id = kwargs['entityId']  # type: str
-        self.entity_type = kwargs['entityType']  # type: str
+        self.entity_id = kwargs.get('entityId')  # type: str or None
+        self.entity_type = kwargs.get('entityType')  # type: str or None
         self.message_scope = kwargs['messageScope']  # type: str
         self.message_target = kwargs['messageTarget']  # type: str
 

--- a/ddb/gamelog/event.py
+++ b/ddb/gamelog/event.py
@@ -21,13 +21,13 @@ class GameLogEvent:
         self.data = kwargs['data']
         self.entity_id = kwargs['entityId']  # type: str
         self.entity_type = kwargs['entityType']  # type: str
+        self.message_scope = kwargs['messageScope']  # type: str
+        self.message_target = kwargs['messageTarget']  # type: str
 
         # other stuff
         self.id = kwargs['id']  # type: str
         self.date_time = kwargs['dateTime']  # type: str
         self.persist = kwargs['persist']  # type: bool
-        self.message_scope = kwargs['messageScope']  # type: str
-        self.message_target = kwargs['messageTarget']  # type: str
         self.connection_id = kwargs.get('connectionId')
 
         # raw event for easy serialization

--- a/ddb/utils.py
+++ b/ddb/utils.py
@@ -1,3 +1,6 @@
+from utils.functions import get_guild_member, user_from_id
+
+
 async def ddb_id_to_discord_id(mdb, ddb_user_id):
     """
     Translates a DDB user ID to a Discord user ID.
@@ -9,3 +12,20 @@ async def ddb_id_to_discord_id(mdb, ddb_user_id):
     if result is not None:
         return result['discord_id']
     return None
+
+
+async def ddb_id_to_discord_user(ctx, ddb_user_id, guild=None):
+    """
+    Translates a DDB user ID to a Discord user.
+
+    :rtype: discord.User or None
+    """
+    discord_id = await ddb_id_to_discord_id(ctx.bot.mdb, ddb_user_id)
+    if discord_id is None:
+        return None
+
+    if guild is not None:
+        # optimization: we can use get_guild_member rather than user_from_id because we're operating in a guild
+        return await get_guild_member(guild, discord_id)
+    else:
+        return await user_from_id(ctx, discord_id)


### PR DESCRIPTION
### Summary
- Increases the cooldown on the Game Log CTA to 7d to reduce spamminess
- Private rolls from the game log are now PMed to the roller
- Game Log monster rolls now display the correct monster
- Misc Game Log roll comment improvements

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
