### PR TITLE
Add magical arg to effects

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -924,6 +924,7 @@ class InitTracker(commands.Cog):
         -immune <damage type> - Gives the combatant immunity to the given damage type.
         -vuln <damage type> - Gives the combatant vulnerability to the given damage type.`-custom` - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add damage and to hit.
         -neutral <damage type> - Removes the combatant's immunity, resistance, or vulnerability to the given damage type.
+        magical - Makes all damage from the combatant magical
         __General__
         -ac <ac> - modifies ac temporarily; adds if starts with +/- or sets otherwise.
         -sb <save bonus> - Adds a bonus to all saving throws.

--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -629,7 +629,7 @@ class Damage(Effect):
 
         # magic arg (#853), magical effect (#1063)
         magical_effect = autoctx.combatant and autoctx.combatant.active_effects('magical')
-        always = {'magical'} if any([magical_effect, autoctx.is_spell, magic_arg]) else None
+        always = {'magical'} if (magical_effect or autoctx.is_spell or magic_arg) else None
         # dtype transforms/overrides (#876)
         transforms = {}
         for dtype in dtype_args:

--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -627,8 +627,9 @@ class Damage(Effect):
         # evaluate damage
         dmgroll = roll(dice_ast)
 
-        # magic arg (#853)
-        always = {'magical'} if (autoctx.is_spell or magic_arg) else None
+        # magic arg (#853), magical effect (#1063)
+        magical_effect = autoctx.combatant and autoctx.combatant.active_effects('magical')
+        always = {'magical'} if any([magical_effect, autoctx.is_spell, magic_arg]) else None
         # dtype transforms/overrides (#876)
         transforms = {}
         for dtype in dtype_args:

--- a/cogs5e/models/initiative/effect.py
+++ b/cogs5e/models/initiative/effect.py
@@ -287,4 +287,5 @@ SPECIAL_ARGS = {  # 2-tuple of effect, str
     'resist': (parse_resist_arg, parse_resist_str)
 }
 VALID_ARGS = {'b': 'Attack Bonus', 'd': 'Damage Bonus', 'ac': 'AC', 'resist': 'Resistance', 'immune': 'Immunity',
-              'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus'}
+              'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus',
+              'magical': 'Magical Damage'}


### PR DESCRIPTION
Summary
======

Adds an argument to `!init effect` (`magical`) that changes all damage to magical.

Resolves #1063 (AFR-540)

Checklist
======

<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
PR Type
--------
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

Other
-------
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
