### PR TITLE
Fix automatic hit on crit arg

### DIFF
--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -317,14 +317,14 @@ class Attack(Effect):
                 ac = ac or autoctx.target.ac
 
             # assign hit values
-            if d20_value >= criton or to_hit_roll.crit == d20.CritType.CRIT: # critical hit
+            if d20_value >= criton or to_hit_roll.crit == d20.CritType.CRIT:  # critical hit
                 did_crit = True and not nocrit  # if nocrit, will evaluate to false
             # AVR-764 crit on crit arg and if we do not have a critical failure
-            elif crit and not to_hit_roll.crit == d20.CritType.FAIL: # crit arg
+            elif crit and not to_hit_roll.crit == d20.CritType.FAIL:  # crit arg
                 did_crit = True and not nocrit
-            elif to_hit_roll.crit == d20.CritType.FAIL: # crit fail
+            elif to_hit_roll.crit == d20.CritType.FAIL:  # crit fail
                 did_hit = False
-            elif ac and to_hit_roll.total < ac: # miss
+            elif ac and to_hit_roll.total < ac:  # miss
                 did_hit = False
 
             autoctx.metavars['lastAttackRollTotal'] = to_hit_roll.total  # 1362

--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -317,11 +317,14 @@ class Attack(Effect):
                 ac = ac or autoctx.target.ac
 
             # assign hit values
-            if d20_value >= criton or to_hit_roll.crit == d20.CritType.CRIT or (crit and not nocrit):  # crit
-                did_crit = True if not nocrit else False
-            elif to_hit_roll.crit == d20.CritType.FAIL:  # crit fail
+            if d20_value >= criton or to_hit_roll.crit == d20.CritType.CRIT: # critical hit
+                did_crit = True and not nocrit  # if nocrit, will evaluate to false
+            # AVR-764 crit on crit arg and if we do not have a critical failure
+            elif crit and not to_hit_roll.crit == d20.CritType.FAIL: # crit arg
+                did_crit = True and not nocrit
+            elif to_hit_roll.crit == d20.CritType.FAIL: # crit fail
                 did_hit = False
-            elif ac and to_hit_roll.total < ac:  # miss
+            elif ac and to_hit_roll.total < ac: # miss
                 did_hit = False
 
             autoctx.metavars['lastAttackRollTotal'] = to_hit_roll.total  # 1362


### PR DESCRIPTION
Summary
======

Previously, the `crit` arg would auto-hit the target, even on a natural one (crit fail)
This change fixes that bug

Resolves AVR-764 (Not in GitHub yet)

Checklist
=======
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
PR Type
--------

<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
Other
-------

- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
