### PR TITLE
Allow for `-critdice` to overwite the csetting

### DIFF
--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -594,8 +594,8 @@ class Damage(Effect):
         hide = args.last('h', type_=bool)
 
         # character-specific arguments
-        if autoctx.character:
-            critdice = autoctx.character.get_setting('critdice') or critdice
+        if autoctx.character and critdice == 0:
+            critdice = autoctx.character.get_setting('critdice')
 
         # combat-specific arguments
         if not autoctx.target.is_simple:

--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -594,7 +594,7 @@ class Damage(Effect):
         hide = args.last('h', type_=bool)
 
         # character-specific arguments
-        if autoctx.character and critdice == 0:
+        if autoctx.character and 'critdice' not in args:
             critdice = autoctx.character.get_setting('critdice')
 
         # combat-specific arguments


### PR DESCRIPTION
### Summary
This implements AFR-790, allowing the `-critdice` argument in attacks to overwrite the critdice csettings.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
