### PR TITLE
adding the avr args for damage

### DIFF
--- a/cogs5e/models/automation/effects.py
+++ b/cogs5e/models/automation/effects.py
@@ -569,6 +569,7 @@ class Damage(Effect):
         crit_arg = args.last('crit', None, bool, ephem=True)
         nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
         max_arg = args.last('max', None, bool, ephem=True)
+        avr_arg = args.last('avr', None, bool, ephem=True)
         magic_arg = args.last('magical', None, bool, ephem=True)
         mi_arg = args.last('mi', None, int)
         dtype_args = args.get('dtype', [], ephem=True)
@@ -631,6 +632,9 @@ class Damage(Effect):
         # max
         if max_arg:
             dice_ast = d20.utils.tree_map(max_mapper, dice_ast)
+        
+        if avr_arg:
+            dice_ast = d20.utils.tree_map(avr_mapper, dice_ast)
 
         # evaluate damage
         dmgroll = roll(dice_ast)


### PR DESCRIPTION
Added support for the `avr` argument in the damage class, which makes the damage deal average damage using the avr_mapper function.

### Summary
Here goes a short summary about what the PR is about.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
