### PR TITLE
Hide character portraits when -h is passed

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -79,7 +79,9 @@ class SheetManager(commands.Cog):
         caster, targets, combat = await targetutils.maybe_combat(ctx, char, args)
         attack = await search_and_select(ctx, caster.attacks, atk_name, lambda a: a.name)
 
-        embed = EmbedWithCharacter(char, name=False)
+        hide = args.last('h', type_=bool)
+
+        embed = EmbedWithCharacter(char, name=False, image=not hide)
         result = await attackutils.run_attack(ctx, embed, args, caster, attack, targets, combat)
 
         await ctx.send(embed=embed)
@@ -195,11 +197,13 @@ class SheetManager(commands.Cog):
 
         char: Character = await Character.from_ctx(ctx)
 
-        embed = EmbedWithCharacter(char, name=False)
-
         args = await self.new_arg_stuff(args, ctx, char)
-        checkutils.update_csetting_args(char, args)
 
+        hide = args.last('h', type_=bool)
+
+        embed = EmbedWithCharacter(char, name=False, image=not hide)
+
+        checkutils.update_csetting_args(char, args)
         caster, _, _ = await targetutils.maybe_combat(ctx, char, args)
 
         result = checkutils.run_save(skill, caster, args, embed)
@@ -217,11 +221,12 @@ class SheetManager(commands.Cog):
     async def check(self, ctx, check, *args):
         char: Character = await Character.from_ctx(ctx)
         skill_key = await search_and_select(ctx, SKILL_NAMES, check, lambda s: s)
-
-        embed = EmbedWithCharacter(char, False)
-        skill = char.skills[skill_key]
-
         args = await self.new_arg_stuff(args, ctx, char)
+
+        hide = args.last('h', type_=bool)
+
+        embed = EmbedWithCharacter(char, name=False, image=not hide)
+        skill = char.skills[skill_key]
 
         checkutils.update_csetting_args(char, args, skill)
         result = checkutils.run_check(skill_key, char, args, embed)


### PR DESCRIPTION
### Summary
Makes character portraits hidden when `-h` is passed for `!attack`, `!check`, and `!save`

Resolves #1351 (AFR-677)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
