### PR TITLE
Catching empty names for cc's

### DIFF
--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -146,6 +146,8 @@ class CustomCounter:
             raise InvalidArgument("Reset passed but no valid reset value (`max`, `resetto`, `resetby`) passed.")
         if reset_to is not None and reset_by is not None:
             raise InvalidArgument("Both `resetto` and `resetby` arguments found.")
+        if all(i in name for i in ['	', ' ', '']):
+            raise InvalidArgument("The name of the counter can not be empty.")
 
         min_value = None
         if minv is not None:

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -146,7 +146,7 @@ class CustomCounter:
             raise InvalidArgument("Reset passed but no valid reset value (`max`, `resetto`, `resetby`) passed.")
         if reset_to is not None and reset_by is not None:
             raise InvalidArgument("Both `resetto` and `resetby` arguments found.")
-        if all(i in name for i in ['	', ' ', '']):
+        if not name.strip():
             raise InvalidArgument("The name of the counter can not be empty.")
 
         min_value = None


### PR DESCRIPTION
This should not allow the creation of empty names for counters which breaks the `!cc` command later on since the field name can't be empty.

### Summary
See https://discord.com/channels/269275778867396608/795768989729030165/849614250750115861 for context.

I think only the tab, space, and empty character are needed for this check since it seems those are the only ones causing an error later on. I'm not sure if there are any other characters that should be included.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
