### PR TITLE
Add slash command check

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -359,7 +359,7 @@ class Customization(commands.Cog):
     async def prefix(self, ctx, prefix: str = None):
         """Sets the bot's prefix for this server.
 
-        You must have Manage Server permissions or a role called "Bot Admin" to use this command. Due to a Discord conflict, a prefix cannot begin with `/`. However, prefixes such as `a/` are still valid.
+        You must have Manage Server permissions or a role called "Bot Admin" to use this command. Due to a possible Discord conflict, a prefix beginning with `/` will require confirmation.
 
         Forgot the prefix? Reset it with "@Avrae#6944 prefix !".
         """
@@ -373,7 +373,9 @@ class Customization(commands.Cog):
 
         # Check for Discord Slash-command conflict
         if prefix.startswith('/'):
-            return await ctx.send(f"Due to a Discord conflict, a prefix cannot begin with /")
+            if not await confirm(ctx, f"Setting a prefix that begins with / may cause issues. "
+                       "Are you sure you want to continue?"):
+                return await ctx.send("Ok, cancelling.")
 
         # insert into cache
         self.bot.prefixes[guild_id] = prefix

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -371,6 +371,10 @@ class Customization(commands.Cog):
         if not checks._role_or_permissions(ctx, lambda r: r.name.lower() == 'bot admin', manage_guild=True):
             return await ctx.send("You do not have permissions to change the guild prefix.")
 
+        # Check for Discord Slash-command conflict
+        if prefix.startswith('/'):
+            return await ctx.send(f"Due to Discord conflict, a prefix cannot begin with /")
+
         # insert into cache
         self.bot.prefixes[guild_id] = prefix
 

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -359,7 +359,7 @@ class Customization(commands.Cog):
     async def prefix(self, ctx, prefix: str = None):
         """Sets the bot's prefix for this server.
 
-        You must have Manage Server permissions or a role called "Bot Admin" to use this command. Due to Discord conflict, a prefix cannot begin with `/`. However, prefixes such as `a/` are still valid.
+        You must have Manage Server permissions or a role called "Bot Admin" to use this command. Due to a Discord conflict, a prefix cannot begin with `/`. However, prefixes such as `a/` are still valid.
 
         Forgot the prefix? Reset it with "@Avrae#6944 prefix !".
         """
@@ -373,7 +373,7 @@ class Customization(commands.Cog):
 
         # Check for Discord Slash-command conflict
         if prefix.startswith('/'):
-            return await ctx.send(f"Due to Discord conflict, a prefix cannot begin with /")
+            return await ctx.send(f"Due to a Discord conflict, a prefix cannot begin with /")
 
         # insert into cache
         self.bot.prefixes[guild_id] = prefix

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -359,7 +359,7 @@ class Customization(commands.Cog):
     async def prefix(self, ctx, prefix: str = None):
         """Sets the bot's prefix for this server.
 
-        You must have Manage Server permissions or a role called "Bot Admin" to use this command.
+        You must have Manage Server permissions or a role called "Bot Admin" to use this command. Due to Discord conflict, a prefix cannot begin with `/`. However, prefixes such as `a/` are still valid.
 
         Forgot the prefix? Reset it with "@Avrae#6944 prefix !".
         """


### PR DESCRIPTION
### Summary
Adds Discord Slash-command conflict checking to prevent Avrae from becoming non-responsive to a prefix.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
