### PR TITLE
Adds (s)adv/(s)dis to effect

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -921,6 +921,7 @@ class InitTracker(commands.Cog):
         -t <target> - Specifies more combatant's to target, chainable (e.g., "-t or1 -t or2").
         -parent <"[combatant]|[effect]"> - Sets a parent effect from a specified combatant.
         __Attacks__
+        adv/dis - Give advantage or disadvantage to the attack roll(s).
         -b <bonus> - Adds a bonus to hit.
         -d <damage> - Adds additional damage.
         -attack <"[hit]|[damage]|[description]"> - Adds an attack to the combatant. The effect name will be the name of the attack. No [hit] will autohit (e.g., -attack "|1d6[fire]|")
@@ -935,6 +936,7 @@ class InitTracker(commands.Cog):
         -ac <ac> - modifies ac temporarily; adds if starts with +/- or sets otherwise.
         -sb <save bonus> - Adds a bonus to all saving throws.
         -cb <check bonus> - Adds a bonus to all ability checks.
+        -sadv/sdis <ability> - Gives advantage/disadvantage on saving throws for the provided ability.
         -desc <description> - Adds a description of the effect."""
         combat = await Combat.from_ctx(ctx)
         args = argparse(args)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -936,8 +936,7 @@ class InitTracker(commands.Cog):
         -ac <ac> - modifies ac temporarily; adds if starts with +/- or sets otherwise.
         -sb <save bonus> - Adds a bonus to all saving throws.
         -cb <check bonus> - Adds a bonus to all ability checks.
-        sadv/sdis - Gives advantage/disadvantage on all saving throws.
-        -sadv/sdis <ability> - Gives advantage/disadvantage on saving throws for the provided ability.
+        -sadv/sdis <ability> - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
         -desc <description> - Adds a description of the effect."""
         combat = await Combat.from_ctx(ctx)
         args = argparse(args)

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -921,7 +921,7 @@ class InitTracker(commands.Cog):
         -t <target> - Specifies more combatant's to target, chainable (e.g., "-t or1 -t or2").
         -parent <"[combatant]|[effect]"> - Sets a parent effect from a specified combatant.
         __Attacks__
-        adv/dis - Give advantage or disadvantage to the attack roll(s).
+        adv/dis - Give advantage or disadvantage to all attack rolls.
         -b <bonus> - Adds a bonus to hit.
         -d <damage> - Adds additional damage.
         -attack <"[hit]|[damage]|[description]"> - Adds an attack to the combatant. The effect name will be the name of the attack. No [hit] will autohit (e.g., -attack "|1d6[fire]|")
@@ -936,6 +936,7 @@ class InitTracker(commands.Cog):
         -ac <ac> - modifies ac temporarily; adds if starts with +/- or sets otherwise.
         -sb <save bonus> - Adds a bonus to all saving throws.
         -cb <check bonus> - Adds a bonus to all ability checks.
+        sadv/sdis - Gives advantage/disadvantage on all saving throws.
         -sadv/sdis <ability> - Gives advantage/disadvantage on saving throws for the provided ability.
         -desc <description> - Adds a description of the effect."""
         combat = await Combat.from_ctx(ctx)

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -34,13 +34,7 @@ class Attack(Effect):
                                   "of a Target effect.")
 
         # arguments
-        args = autoctx.args
-        # adv/dis (#1552)
-        for check_arg in ['adv','dis']:
-            if autoctx.combatant.active_effects(check_arg):
-                args.update({check_arg: True})  # Because adv() only checks last() just forcibly add them
-
-        adv = args.adv(ea=True, ephem=True)
+        args = autoctx.args       
         crit = args.last('crit', None, bool, ephem=True) and 1
         nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
         hit = args.last('hit', None, bool, ephem=True) and 1
@@ -67,6 +61,12 @@ class Attack(Effect):
                 b = f"{b}+{effect_b}"
             elif effect_b:
                 b = effect_b
+            # adv/dis (#1552)
+            for check_arg in ['adv','dis']:
+                if autoctx.combatant.active_effects(check_arg):
+                    args.update({check_arg: True})  # Because adv() only checks last() just forcibly add them
+        # Check adv after effects
+        adv = args.adv(ea=True, ephem=True)
 
         attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
 

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -54,13 +54,22 @@ class Attack(Effect):
             if 'criton' not in args:
                 criton = autoctx.character.get_setting('criton', 20)
 
-        # check for combatant IEffect bonus (#224)
+        # check for combatant IEffects
         if autoctx.combatant:
+            # bonus (#224)
             effect_b = '+'.join(autoctx.combatant.active_effects('b'))
             if effect_b and b:
                 b = f"{b}+{effect_b}"
             elif effect_b:
                 b = effect_b
+
+         # adv/dis (#TODO)
+         # Only apply if we don't already have any advantage changes
+            if not adv:
+                if autoctx.combatant.active_effects('adv'):
+                    adv += 1
+                if  autoctx.combatant.active_effects('dis'):
+                    adv -= 1
 
         attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
 

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -61,12 +61,13 @@ class Attack(Effect):
                 b = f"{b}+{effect_b}"
             elif effect_b:
                 b = effect_b
-
-        # Combine args/ieffect advantages - adv/dis (#1552)
-        adv = reconcile_adv(
-            adv= args.last('adv', type_=bool, ephem=True) or autoctx.combatant.active_effects('adv'),
-            dis= args.last('dis', type_=bool, ephem=True) or autoctx.combatant.active_effects('dis'),
-            ea= args.last('ea', type_=bool, ephem=True) or autoctx.combatant.active_effects('ea'))
+            # Combine args/ieffect advantages - adv/dis (#1552)
+            adv = reconcile_adv(
+                adv= args.last('adv', type_=bool, ephem=True) or autoctx.combatant.active_effects('adv'),
+                dis= args.last('dis', type_=bool, ephem=True) or autoctx.combatant.active_effects('dis'),
+                ea= args.last('ea', type_=bool, ephem=True) or autoctx.combatant.active_effects('ea'))
+        else:
+            adv = args.adv(ea=True, ephem=True)
 
         attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
 

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -64,9 +64,9 @@ class Attack(Effect):
 
         # Combine args/ieffect advantages - adv/dis (#1552)
         adv = reconcile_adv(
-            adv= args.last('adv', bool, ephem=True) or autoctx.combatant.active_effects('adv'),
-            dis= args.last('dis', bool, ephem=True) or autoctx.combatant.active_effects('dis'),
-            dis= args.last('ea', bool, ephem=True) or autoctx.combatant.active_effects('ea'))
+            adv= args.last('adv', type_=bool, ephem=True) or autoctx.combatant.active_effects('adv'),
+            dis= args.last('dis', type_=bool, ephem=True) or autoctx.combatant.active_effects('dis'),
+            ea= args.last('ea', type_=bool, ephem=True) or autoctx.combatant.active_effects('ea'))
 
         attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
 

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -34,7 +34,7 @@ class Attack(Effect):
                                   "of a Target effect.")
 
         # arguments
-        args = autoctx.args       
+        args = autoctx.args
         crit = args.last('crit', None, bool, ephem=True) and 1
         nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
         hit = args.last('hit', None, bool, ephem=True) and 1

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -63,7 +63,7 @@ class Attack(Effect):
             elif effect_b:
                 b = effect_b
 
-         # adv/dis (#TODO)
+         # adv/dis (#1552)
          # Only apply if we don't already have any advantage changes
             if not adv:
                 if autoctx.combatant.active_effects('adv'):

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -3,7 +3,7 @@ import d20
 from . import Effect
 from ..errors import AutomationException, NoAttackBonus, TargetException
 from ..results import AttackResult
-
+from utils.functions import reconcile_adv
 
 class Attack(Effect):
     def __init__(self, hit: list, miss: list, attackBonus: str = None, **kwargs):
@@ -61,12 +61,12 @@ class Attack(Effect):
                 b = f"{b}+{effect_b}"
             elif effect_b:
                 b = effect_b
-            # adv/dis (#1552)
-            for check_arg in ['adv','dis']:
-                if autoctx.combatant.active_effects(check_arg):
-                    args.update({check_arg: True})  # Because adv() only checks last() just forcibly add them
-        # Check adv after effects
-        adv = args.adv(ea=True, ephem=True)
+
+        # Combine args/ieffect advantages - adv/dis (#1552)
+        adv = reconcile_adv(
+            adv= args.last('adv', bool, ephem=True) or autoctx.combatant.active_effects('adv'),
+            dis= args.last('dis', bool, ephem=True) or autoctx.combatant.active_effects('dis'),
+            dis= args.last('ea', bool, ephem=True) or autoctx.combatant.active_effects('ea'))
 
         attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
 

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -35,6 +35,11 @@ class Attack(Effect):
 
         # arguments
         args = autoctx.args
+        # adv/dis (#1552)
+        for check_arg in ['adv','dis']:
+            if autoctx.combatant.active_effects(check_arg):
+                args.update({check_arg: True})  # Because adv() only checks last() just forcibly add them
+
         adv = args.adv(ea=True, ephem=True)
         crit = args.last('crit', None, bool, ephem=True) and 1
         nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
@@ -62,14 +67,6 @@ class Attack(Effect):
                 b = f"{b}+{effect_b}"
             elif effect_b:
                 b = effect_b
-
-         # adv/dis (#1552)
-         # Only apply if we don't already have any advantage changes
-            if not adv:
-                if autoctx.combatant.active_effects('adv'):
-                    adv += 1
-                if  autoctx.combatant.active_effects('dis'):
-                    adv -= 1
 
         attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
 

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -1,9 +1,10 @@
 import d20
 
+from utils.functions import reconcile_adv
 from . import Effect
 from ..errors import AutomationException, NoAttackBonus, TargetException
 from ..results import AttackResult
-from utils.functions import reconcile_adv
+
 
 class Attack(Effect):
     def __init__(self, hit: list, miss: list, attackBonus: str = None, **kwargs):
@@ -64,9 +65,10 @@ class Attack(Effect):
                 b = effect_b
             # Combine args/ieffect advantages - adv/dis (#1552)
             adv = reconcile_adv(
-                adv= args.last('adv', type_=bool, ephem=True) or autoctx.combatant.active_effects('adv'),
-                dis= args.last('dis', type_=bool, ephem=True) or autoctx.combatant.active_effects('dis'),
-                ea= args.last('ea', type_=bool, ephem=True) or autoctx.combatant.active_effects('ea'))
+                adv=args.last('adv', type_=bool, ephem=True) or autoctx.combatant.active_effects('adv'),
+                dis=args.last('dis', type_=bool, ephem=True) or autoctx.combatant.active_effects('dis'),
+                ea=args.last('ea', type_=bool, ephem=True) or autoctx.combatant.active_effects('ea')
+            )
         else:
             adv = args.adv(ea=True, ephem=True)
 

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -36,20 +36,13 @@ class Save(Effect):
             raise TargetException("Tried to make a save without a target! Make sure all Save effects are inside "
                                   "of a Target effect.")
 
+        # ==== args ====
         save = autoctx.args.last('save') or self.stat
         auto_pass = autoctx.args.last('pass', type_=bool, ephem=True)
         auto_fail = autoctx.args.last('fail', type_=bool, ephem=True)
         hide = autoctx.args.last('h', type_=bool)
 
-        # check for combatant IEffects
-        if autoctx.combatant:
-            # Combine args/ieffect advantages - adv/dis (#1552)
-            adv = reconcile_adv(
-                adv= autoctx.args.last('sadv', bool, ephem=True) or autoctx.combatant.active_effects('adv'),
-                dis= autoctx.args.last('sdis', bool, ephem=True) or autoctx.combatant.active_effects('dis'))
-        else:
-            adv = autoctx.args.adv(custom={'adv': 'sadv', 'dis': 'sdis'})
-
+        # ==== dc ====
         dc_override = None
         if self.dc:
             try:
@@ -68,16 +61,31 @@ class Save(Effect):
             save_skill = next(s for s in ('strengthSave', 'dexteritySave', 'constitutionSave',
                                           'intelligenceSave', 'wisdomSave', 'charismaSave') if
                               save.lower() in s.lower())
+            stat = save_skill[:3]
         except StopIteration:
             raise InvalidSaveType()
 
+        # ==== ieffects ====
+        if autoctx.combatant:
+            # Combine args/ieffect advantages - adv/dis (#1552)
+            sadv_effects = autoctx.combatant.active_effects('sadv')
+            sdis_effects = autoctx.combatant.active_effects('sdis')
+            sadv = True in sadv_effects or stat in sadv_effects
+            sdis = True in sdis_effects or stat in sdis_effects
+            adv = reconcile_adv(
+                adv=autoctx.args.last('sadv', bool, ephem=True) or sadv,
+                dis=autoctx.args.last('sdis', bool, ephem=True) or sdis
+            )
+        else:
+            adv = autoctx.args.adv(custom={'adv': 'sadv', 'dis': 'sdis'})
+
+        # ==== execution ====
         save_roll = None
         autoctx.metavars['lastSaveRollTotal'] = 0
         autoctx.metavars['lastSaveNaturalRoll'] = 0  # 1495
         autoctx.metavars['lastSaveDC'] = dc
-
         autoctx.meta_queue(f"**DC**: {dc}")
-        stat = save_skill[:3]
+
         if not autoctx.target.is_simple:
             save_blurb = f'{stat.upper()} Save'
             if auto_pass:

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -66,15 +66,15 @@ class Save(Effect):
             raise InvalidSaveType()
 
         # ==== ieffects ====
-        if autoctx.combatant:
+        if autoctx.target.combatant:
             # Combine args/ieffect advantages - adv/dis (#1552)
-            sadv_effects = autoctx.combatant.active_effects('sadv')
-            sdis_effects = autoctx.combatant.active_effects('sdis')
-            sadv = True in sadv_effects or stat in sadv_effects
-            sdis = True in sdis_effects or stat in sdis_effects
+            sadv_effects = autoctx.target.combatant.active_effects('sadv')
+            sdis_effects = autoctx.target.combatant.active_effects('sdis')
+            sadv = 'all' in sadv_effects or stat in sadv_effects
+            sdis = 'all' in sdis_effects or stat in sdis_effects
             adv = reconcile_adv(
-                adv=autoctx.args.last('sadv', bool, ephem=True) or sadv,
-                dis=autoctx.args.last('sdis', bool, ephem=True) or sdis
+                adv=autoctx.args.last('sadv', type_=bool, ephem=True) or sadv,
+                dis=autoctx.args.last('sdis', type_=bool, ephem=True) or sdis
             )
         else:
             adv = autoctx.args.adv(custom={'adv': 'sadv', 'dis': 'sdis'})

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -40,6 +40,13 @@ class Save(Effect):
         auto_pass = autoctx.args.last('pass', type_=bool, ephem=True)
         auto_fail = autoctx.args.last('fail', type_=bool, ephem=True)
         hide = autoctx.args.last('h', type_=bool)
+
+        # combatant i effect
+        if autoctx.target.combatant:
+            for check_arg in ['sadv','sdis']:
+                if save in autoctx.target.combatant.active_effects(check_arg):
+                    autoctx.args.update({check_arg: True})  # Because adv() only checks last() just forcibly add them
+
         adv = autoctx.args.adv(custom={'adv': 'sadv', 'dis': 'sdis'})
 
         dc_override = None

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -41,10 +41,14 @@ class Save(Effect):
         auto_fail = autoctx.args.last('fail', type_=bool, ephem=True)
         hide = autoctx.args.last('h', type_=bool)
 
-        # Combine args/ieffect advantages - adv/dis (#1552)
-        adv = reconcile_adv(
-            adv= autoctx.args.last('sadv', bool, ephem=True) or autoctx.combatant.active_effects('adv'),
-            dis= autoctx.args.last('sdis', bool, ephem=True) or autoctx.combatant.active_effects('dis'))
+        # check for combatant IEffects
+        if autoctx.combatant:
+            # Combine args/ieffect advantages - adv/dis (#1552)
+            adv = reconcile_adv(
+                adv= autoctx.args.last('sadv', bool, ephem=True) or autoctx.combatant.active_effects('adv'),
+                dis= autoctx.args.last('sdis', bool, ephem=True) or autoctx.combatant.active_effects('dis'))
+        else:
+            adv = autoctx.args.adv(custom={'adv': 'sadv', 'dis': 'sdis'})
 
         dc_override = None
         if self.dc:

--- a/cogs5e/models/initiative/effect.py
+++ b/cogs5e/models/initiative/effect.py
@@ -1,8 +1,8 @@
-from utils.constants import STAT_ABBREVIATIONS
-from utils.functions import verbose_stat
 from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.resistance import Resistance
 from utils.argparser import argparse
+from utils.constants import STAT_ABBREVIATIONS
+from utils.functions import verbose_stat
 from .utils import CombatantType, create_effect_id
 
 
@@ -289,8 +289,6 @@ def parse_stat_choice(arg, _):
     return arg
 
 
-
-
 LIST_ARGS = ('resist', 'immune', 'vuln', 'neutral')
 SPECIAL_ARGS = {  # 2-tuple of effect, str
     'attack': (parse_attack_arg, parse_attack_str),
@@ -298,7 +296,11 @@ SPECIAL_ARGS = {  # 2-tuple of effect, str
     'sadv': (parse_stat_choice, verbose_stat),
     'sdis': (parse_stat_choice, verbose_stat)
 }
-VALID_ARGS = {'b': 'Attack Bonus', 'd': 'Damage Bonus', 'ac': 'AC', 'resist': 'Resistance', 'immune': 'Immunity',
-              'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus', 'cb': 'Check Bonus',
-              'magical': 'Magical Damage', 'silvered': 'Silvered Damage', 'adv': 'Attack Advantage', 'dis': 'Attack Disadvantage',
-              'sadv': 'Save Advantage', 'sdis': 'Save Disadvantage'}
+VALID_ARGS = {
+    'b': 'Attack Bonus', 'd': 'Damage Bonus', 'ac': 'AC', 'resist': 'Resistance', 'immune': 'Immunity',
+    'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus',
+    'cb': 'Check Bonus',
+    'magical': 'Magical Damage', 'silvered': 'Silvered Damage', 'adv': 'Attack Advantage',
+    'dis': 'Attack Disadvantage',
+    'sadv': 'Save Advantage', 'sdis': 'Save Disadvantage'
+}

--- a/cogs5e/models/initiative/effect.py
+++ b/cogs5e/models/initiative/effect.py
@@ -261,6 +261,7 @@ class Effect:
         self.combatant.remove_effect(self)
 
 
+# ---- attack ieffect ----
 def parse_attack_arg(arg, name):
     data = arg.split('|')
     if not len(data) == 3:
@@ -275,6 +276,7 @@ def parse_attack_str(atk):
         return f"{atk['attackBonus']}|{atk['damage']}"
 
 
+# ---- resistance ieffect ----
 def parse_resist_arg(arg, _):
     return [Resistance.from_dict(r).to_dict() for r in arg]
 
@@ -283,18 +285,27 @@ def parse_resist_str(resist_list):
     return ', '.join([str(Resistance.from_dict(r)) for r in resist_list])
 
 
-def parse_stat_choice(arg, _):
-    if arg not in STAT_ABBREVIATIONS:
-        raise InvalidArgument(f"{arg} is not a valid stat")
-    return arg
+# ---- sadv/sdis ieffect ----
+def parse_stat_choice(args, _):
+    for arg in args:
+        if arg not in STAT_ABBREVIATIONS and arg != 'all':
+            raise InvalidArgument(f"{arg} is not a valid stat")
+    return args
 
 
-LIST_ARGS = ('resist', 'immune', 'vuln', 'neutral')
+def parse_stat_str(stat_list):
+    if 'all' in stat_list:
+        return 'All'
+    return ', '.join(verbose_stat(s) for s in stat_list)
+
+
+# ==== effect defs ====
+LIST_ARGS = ('resist', 'immune', 'vuln', 'neutral', 'sadv', 'sdis')
 SPECIAL_ARGS = {  # 2-tuple of effect, str
     'attack': (parse_attack_arg, parse_attack_str),
     'resist': (parse_resist_arg, parse_resist_str),
-    'sadv': (parse_stat_choice, verbose_stat),
-    'sdis': (parse_stat_choice, verbose_stat)
+    'sadv': (parse_stat_choice, parse_stat_str),
+    'sdis': (parse_stat_choice, parse_stat_str)
 }
 VALID_ARGS = {
     'b': 'Attack Bonus', 'd': 'Damage Bonus', 'ac': 'AC', 'resist': 'Resistance', 'immune': 'Immunity',

--- a/cogs5e/models/initiative/effect.py
+++ b/cogs5e/models/initiative/effect.py
@@ -289,8 +289,6 @@ def parse_stat_choice(arg, _):
     return arg
 
 
-def parse_stat_choice_str(stat):
-    return verbose_stat(stat)
 
 
 LIST_ARGS = ('resist', 'immune', 'vuln', 'neutral')

--- a/cogs5e/models/initiative/effect.py
+++ b/cogs5e/models/initiative/effect.py
@@ -1,3 +1,5 @@
+from utils.constants import STAT_ABBREVIATIONS
+from utils.functions import verbose_stat
 from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.resistance import Resistance
 from utils.argparser import argparse
@@ -281,11 +283,24 @@ def parse_resist_str(resist_list):
     return ', '.join([str(Resistance.from_dict(r)) for r in resist_list])
 
 
+def parse_stat_choice(arg, _):
+    if not arg in STAT_ABBREVIATIONS:
+        raise InvalidArgument(f"{arg} is not a valid stat")
+    return arg
+
+
+def parse_stat_choice_str(stat):
+    return verbose_stat(stat)
+
+
 LIST_ARGS = ('resist', 'immune', 'vuln', 'neutral')
 SPECIAL_ARGS = {  # 2-tuple of effect, str
     'attack': (parse_attack_arg, parse_attack_str),
-    'resist': (parse_resist_arg, parse_resist_str)
+    'resist': (parse_resist_arg, parse_resist_str),
+    'sadv': (parse_stat_choice, parse_stat_choice_str),
+    'sdis': (parse_stat_choice, parse_stat_choice_str)
 }
 VALID_ARGS = {'b': 'Attack Bonus', 'd': 'Damage Bonus', 'ac': 'AC', 'resist': 'Resistance', 'immune': 'Immunity',
               'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus', 'cb': 'Check Bonus',
-              'magical': 'Magical Damage', 'silvered': 'Silvered Damage'}
+              'magical': 'Magical Damage', 'silvered': 'Silvered Damage', 'adv': 'Attack Advantage', 'dis': 'Attack Disadvantage',
+              'sadv': 'Save Advantage', 'sdis': 'Save Disadvantage'}

--- a/cogs5e/models/initiative/effect.py
+++ b/cogs5e/models/initiative/effect.py
@@ -284,7 +284,7 @@ def parse_resist_str(resist_list):
 
 
 def parse_stat_choice(arg, _):
-    if not arg in STAT_ABBREVIATIONS:
+    if arg not in STAT_ABBREVIATIONS:
         raise InvalidArgument(f"{arg} is not a valid stat")
     return arg
 
@@ -297,8 +297,8 @@ LIST_ARGS = ('resist', 'immune', 'vuln', 'neutral')
 SPECIAL_ARGS = {  # 2-tuple of effect, str
     'attack': (parse_attack_arg, parse_attack_str),
     'resist': (parse_resist_arg, parse_resist_str),
-    'sadv': (parse_stat_choice, parse_stat_choice_str),
-    'sdis': (parse_stat_choice, parse_stat_choice_str)
+    'sadv': (parse_stat_choice, verbose_stat),
+    'sdis': (parse_stat_choice, verbose_stat)
 }
 VALID_ARGS = {'b': 'Attack Bonus', 'd': 'Damage Bonus', 'ac': 'AC', 'resist': 'Resistance', 'immune': 'Immunity',
               'vuln': 'Vulnerability', 'neutral': 'Neutral', 'attack': 'Attack', 'sb': 'Save Bonus', 'cb': 'Check Bonus',

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -103,6 +103,10 @@ def run_save(save_key, caster, args, embed):
     else:
         embed.title = f'{caster.get_title_name()} makes {a_or_an(save_name)}!'
 
+    # ieffect -sb
+    if isinstance(caster, init.Combatant):
+        args['b'] = args.get('b') + 
+
     result = _run_common(save, stat, caster, args, embed, rr_format="Save {}")
     return SaveResult(rolls=result.rolls, skill=save, skill_name=stat_name, skill_roll_result=result)
 

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -86,7 +86,8 @@ def run_save(save_key, caster, args, embed):
     else:
         try:
             save = caster.saves.get(save_key)
-            stat_name = verbose_stat(save_key[:3]).title()
+            stat = save_key[:3]
+            stat_name = verbose_stat(stat).title()
             save_name = f"{stat_name} Save"
         except ValueError:
             raise InvalidArgument('That\'s not a valid save.')
@@ -100,18 +101,15 @@ def run_save(save_key, caster, args, embed):
         embed.title = f"An unknown creature makes {a_or_an(save_name)}!"
     else:
         embed.title = f'{caster.get_title_name()} makes {a_or_an(save_name)}!'
-    
+
     # ieffect handling
     if isinstance(caster, init.Combatant):
         # -sb
         args['b'] = args.get('b') + caster.active_effects('sb')
         # -sadv/sdis
-        if not args.adv(boolwise=False, ephem=True):
-            adv = 0
-            if save_key[:3] in caster.active_effects('sadv'):
-                args['adv'] = True
-            if save_key[:3] in caster.active_effects('sdis'):
-                args['dis'] = True
+        for check_arg in ['adv','dis']:
+            if stat in caster.active_effects(check_arg):
+                args[check_arg] = True # Because adv() only checks last() just forcibly add them
 
     result = _run_common(save, args, embed, rr_format="Save {}")
     return SaveResult(rolls=result.rolls, skill=save, skill_name=stat_name, skill_roll_result=result)

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -100,10 +100,18 @@ def run_save(save_key, caster, args, embed):
         embed.title = f"An unknown creature makes {a_or_an(save_name)}!"
     else:
         embed.title = f'{caster.get_title_name()} makes {a_or_an(save_name)}!'
-
-    # ieffect -sb
+    
+    # ieffect handling
     if isinstance(caster, init.Combatant):
+        # -sb
         args['b'] = args.get('b') + caster.active_effects('sb')
+        # -sadv/sdis
+        if not args.adv(boolwise=False, ephem=True):
+            adv = 0
+            if save_key[:3] in caster.active_effects('sadv'):
+                args['adv'] = True
+            if save_key[:3] in caster.active_effects('sdis'):
+                args['dis'] = True
 
     result = _run_common(save, args, embed, rr_format="Save {}")
     return SaveResult(rolls=result.rolls, skill=save, skill_name=stat_name, skill_roll_result=result)

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -105,7 +105,7 @@ def run_save(save_key, caster, args, embed):
 
     # ieffect -sb
     if isinstance(caster, init.Combatant):
-        args['b'] = args.get('b') + 
+        args['b'] = args.get('b') + caster.active_effects('sb')
 
     result = _run_common(save, stat, caster, args, embed, rr_format="Save {}")
     return SaveResult(rolls=result.rolls, skill=save, skill_name=stat_name, skill_roll_result=result)

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -109,9 +109,9 @@ def run_save(save_key, caster, args, embed):
         # -sadv/sdis
         sadv_effects = caster.active_effects('sadv')
         sdis_effects = caster.active_effects('sdis')
-        if True in sadv_effects or stat in sadv_effects:
+        if 'all' in sadv_effects or stat in sadv_effects:
             args['adv'] = True  # Because adv() only checks last() just forcibly add them
-        if True in sdis_effects or stat in sdis_effects:
+        if 'all' in sdis_effects or stat in sdis_effects:
             args['dis'] = True
 
     result = _run_common(save, args, embed, rr_format="Save {}")

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -305,7 +305,7 @@ class ParsedArguments:
     def __setitem__(self, key, value):
         """
         :type key: str
-        :type value: str or list[str]
+        :type value: str or bool or list[str or bool]
         """
         if not isinstance(value, (collections.UserList, list)):
             value = [value]

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -469,4 +469,4 @@ def reconcile_adv(adv=False, dis=False, ea=False):
         result += -1
     if ea and not dis:
         return 2
-    return {-1: False, 0: None, 1: True}.get(result)
+    return result

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -450,3 +450,23 @@ async def get_guild_member(guild, member_id):
     if result:
         return result[0]
     return None
+
+
+def reconcile_adv(adv=False, dis=False, ea=False):
+    """
+    Reconciles sets of advantage passed in
+
+    :param adv: Combined advantage
+    :param dis: Combined disadvantage
+    :param ea:  Combined elven accuracy
+    :rtype: int
+    :return: The combined advantage result
+    """
+    result = 0
+    if adv:
+        result += 1
+    if dis:
+        result += -1
+    if ea and not dis:
+        return 2
+    return {-1: False, 0: None, 1: True}.get(result)


### PR DESCRIPTION
Resolves #432
### Summary
Adds `adv/dis` and `sadv/sdis <ability>` to `!i effect`. Both only activate if no other advantage args were passed in before the effects are resolved.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
