### PR TITLE
Ignore crit state on children of Save Automation

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -88,7 +88,7 @@ class Attack(Effect):
         did_crit = False
         to_hit_roll = None
 
-        # Disable critical damage state for children #1556
+        # Disable critical damage state for children (#1556)
         original = autoctx.in_save
         autoctx.in_save = False
 
@@ -175,7 +175,7 @@ class Attack(Effect):
             autoctx.queue("**To Hit**: Automatic miss!")
             children = self.on_miss(autoctx)
 
-        autoctx.in_save = original  # Restore proper crit state #1556
+        autoctx.in_save = original  # Restore proper crit state (#1556)
 
         return AttackResult(
             attack_bonus=attack_bonus, ac=ac, to_hit_roll=to_hit_roll, adv=adv, did_hit=did_hit, did_crit=did_crit,

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -136,6 +136,10 @@ class Attack(Effect):
             autoctx.metavars['lastAttackRollTotal'] = to_hit_roll.total  # 1362
             autoctx.metavars['lastAttackNaturalRoll'] = d20_value  # 1495
 
+            # Disable critical damage state for children #1556
+            original = autoctx.in_save
+            autoctx.in_save = False
+
             # output
             if not hide:  # not hidden
                 autoctx.queue(f"**{to_hit_message}**: {to_hit_roll.result}")
@@ -170,6 +174,8 @@ class Attack(Effect):
             did_hit = False
             autoctx.queue(f"**To Hit**: Automatic miss!")
             children = self.on_miss(autoctx)
+
+        autoctx.in_save = original  # Restore proper crit state #1556
 
         return AttackResult(
             attack_bonus=attack_bonus, ac=ac, to_hit_roll=to_hit_roll, adv=adv, did_hit=did_hit, did_crit=did_crit,

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -163,7 +163,7 @@ class Attack(Effect):
             else:
                 children = self.on_hit(autoctx)
         elif hit:
-            autoctx.queue(f"**To Hit**: Automatic hit!")
+            autoctx.queue("**To Hit**: Automatic hit!")
             # nocrit and crit cancel out
             if crit and not nocrit:
                 did_crit = True
@@ -172,7 +172,7 @@ class Attack(Effect):
                 children = self.on_hit(autoctx)
         else:
             did_hit = False
-            autoctx.queue(f"**To Hit**: Automatic miss!")
+            autoctx.queue("**To Hit**: Automatic miss!")
             children = self.on_miss(autoctx)
 
         autoctx.in_save = original  # Restore proper crit state #1556

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -88,6 +88,10 @@ class Attack(Effect):
         did_crit = False
         to_hit_roll = None
 
+        # Disable critical damage state for children #1556
+        original = autoctx.in_save
+        autoctx.in_save = False
+
         # roll attack against autoctx.target
         if not (hit or miss):
             # reroll before kh/kl (#1199)
@@ -135,10 +139,6 @@ class Attack(Effect):
 
             autoctx.metavars['lastAttackRollTotal'] = to_hit_roll.total  # 1362
             autoctx.metavars['lastAttackNaturalRoll'] = d20_value  # 1495
-
-            # Disable critical damage state for children #1556
-            original = autoctx.in_save
-            autoctx.in_save = False
 
             # output
             if not hide:  # not hidden

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -87,7 +87,7 @@ class Damage(Effect):
 
         # crit
         # nocrit (#1216)
-        in_crit = (autoctx.in_crit or crit_arg ) and not (nocrit or autoctx.in_save)
+        in_crit = (autoctx.in_crit or crit_arg) and not (nocrit or autoctx.in_save)
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:
             dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -87,7 +87,7 @@ class Damage(Effect):
 
         # crit
         # nocrit (#1216)
-        in_crit = (autoctx.in_crit or crit_arg) and not nocrit
+        in_crit = (autoctx.in_crit or crit_arg ) and not nocrit and not autoctx.in_save
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:
             dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -10,11 +10,10 @@ from ..results import DamageResult
 
 
 class Damage(Effect):
-    def __init__(self, damage: str, overheal: bool = False, higher: dict = None, cantripScale: bool = None, nocrtical: bool = None, **kwargs):
+    def __init__(self, damage: str, overheal: bool = False, higher: dict = None, cantripScale: bool = None, **kwargs):
         super(Damage, self).__init__("damage", **kwargs)
         self.damage = damage
         self.overheal = overheal
-        self.nocritical = nocrtical
         # common
         self.higher = higher
         self.cantripScale = cantripScale
@@ -22,7 +21,7 @@ class Damage(Effect):
     def to_dict(self):
         out = super(Damage, self).to_dict()
         out.update({
-            "damage": self.damage, "overheal": self.overheal, "nocritical": self.nocritical
+            "damage": self.damage, "overheal": self.overheal
         })
         if self.higher is not None:
             out['higher'] = self.higher
@@ -42,7 +41,7 @@ class Damage(Effect):
         d_args = args.get('d', [], ephem=True)
         c_args = args.get('c', [], ephem=True)
         crit_arg = args.last('crit', None, bool, ephem=True)
-        nocrit = args.last('nocrit', default=False, type_=bool, ephem=True) or self.nocritical
+        nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
         max_arg = args.last('max', None, bool, ephem=True)
         magic_arg = args.last('magical', None, bool, ephem=True)
         silvered_arg = args.last('silvered', None, bool, ephem=True)
@@ -88,7 +87,7 @@ class Damage(Effect):
 
         # crit
         # nocrit (#1216)
-        in_crit = (autoctx.in_crit or crit_arg) and not nocrit 
+        in_crit = (autoctx.in_crit or crit_arg) and not nocrit
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:
             dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -10,10 +10,11 @@ from ..results import DamageResult
 
 
 class Damage(Effect):
-    def __init__(self, damage: str, overheal: bool = False, higher: dict = None, cantripScale: bool = None, **kwargs):
+    def __init__(self, damage: str, overheal: bool = False, higher: dict = None, cantripScale: bool = None, nocrtical: bool = None, **kwargs):
         super(Damage, self).__init__("damage", **kwargs)
         self.damage = damage
         self.overheal = overheal
+        self.nocritical = nocrtical
         # common
         self.higher = higher
         self.cantripScale = cantripScale
@@ -21,7 +22,7 @@ class Damage(Effect):
     def to_dict(self):
         out = super(Damage, self).to_dict()
         out.update({
-            "damage": self.damage, "overheal": self.overheal
+            "damage": self.damage, "overheal": self.overheal, "nocritical": self.nocritical
         })
         if self.higher is not None:
             out['higher'] = self.higher
@@ -41,7 +42,7 @@ class Damage(Effect):
         d_args = args.get('d', [], ephem=True)
         c_args = args.get('c', [], ephem=True)
         crit_arg = args.last('crit', None, bool, ephem=True)
-        nocrit = args.last('nocrit', default=False, type_=bool, ephem=True)
+        nocrit = args.last('nocrit', default=False, type_=bool, ephem=True) or self.nocritical
         max_arg = args.last('max', None, bool, ephem=True)
         magic_arg = args.last('magical', None, bool, ephem=True)
         silvered_arg = args.last('silvered', None, bool, ephem=True)
@@ -87,7 +88,7 @@ class Damage(Effect):
 
         # crit
         # nocrit (#1216)
-        in_crit = (autoctx.in_crit or crit_arg) and not nocrit
+        in_crit = (autoctx.in_crit or crit_arg) and not nocrit 
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:
             dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -87,6 +87,7 @@ class Damage(Effect):
 
         # crit
         # nocrit (#1216)
+        # Disable critical damage in saves (#1556)
         in_crit = (autoctx.in_crit or crit_arg) and not (nocrit or autoctx.in_save)
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -87,7 +87,7 @@ class Damage(Effect):
 
         # crit
         # nocrit (#1216)
-        in_crit = (autoctx.in_crit or crit_arg ) and not nocrit and not autoctx.in_save
+        in_crit = (autoctx.in_crit or crit_arg ) and not (nocrit or autoctx.in_save)
         roll_for = "Damage" if not in_crit else "Damage (CRIT!)"
         if in_crit:
             dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -101,15 +101,14 @@ class Save(Effect):
             is_success = False
 
         # Disable critical damage state for children #1556
-        old_no_crit = autoctx.args.last('nocrit', default=False, type_=bool)
-        autoctx.args.update({'nocrit': True})
+        autoctx.in_save = True
 
         if is_success:
             children = self.on_success(autoctx)
         else:
             children = self.on_fail(autoctx)
-        
-        autoctx.args.update({'nocrit': old_no_crit})  # Restore proper crit state #1556
+
+        autoctx.in_save = False  # Restore proper crit state #1556
 
         return SaveResult(dc=dc, ability=save_skill, save_roll=save_roll, adv=adv, did_save=is_success,
                           children=children)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -97,7 +97,7 @@ class Save(Effect):
                     autoctx.add_pm(str(autoctx.ctx.author.id), out)
                     autoctx.queue(f"**{save_blurb}**: 1d20...{success_str}")
         else:
-            autoctx.meta_queue('{} Save'.format(stat.upper()))
+            autoctx.meta_queue(f'{stat.upper()} Save')
             is_success = False
 
         # Disable critical damage state for children (#1556)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -101,6 +101,7 @@ class Save(Effect):
             is_success = False
 
         # Disable critical damage state for children #1556
+        original = autoctx.in_save
         autoctx.in_save = True
 
         if is_success:
@@ -108,7 +109,7 @@ class Save(Effect):
         else:
             children = self.on_fail(autoctx)
 
-        autoctx.in_save = False  # Restore proper crit state #1556
+        autoctx.in_save = original  # Restore proper crit state #1556
 
         return SaveResult(dc=dc, ability=save_skill, save_roll=save_roll, adv=adv, did_save=is_success,
                           children=children)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -101,15 +101,15 @@ class Save(Effect):
             is_success = False
 
         # Disable critical damage state for children #1556
-        old_in_crit = autoctx.in_crit
-        autoctx.in_crit = False
+        old_no_crit = autoctx.args.last('nocrit', default=False, type_=bool)
+        autoctx.args.update({'nocrit': True})
 
         if is_success:
             children = self.on_success(autoctx)
         else:
             children = self.on_fail(autoctx)
         
-        autoctx.in_crit = old_in_crit  # Restore proper crit state #1556
+        autoctx.args.update({'nocrit': old_no_crit})  # Restore proper crit state #1556
 
         return SaveResult(dc=dc, ability=save_skill, save_roll=save_roll, adv=adv, did_save=is_success,
                           children=children)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -100,7 +100,7 @@ class Save(Effect):
             autoctx.meta_queue('{} Save'.format(stat.upper()))
             is_success = False
 
-        # Disable critical damage state for children #1556
+        # Disable critical damage state for children (#1556)
         original = autoctx.in_save
         autoctx.in_save = True
 
@@ -109,7 +109,7 @@ class Save(Effect):
         else:
             children = self.on_fail(autoctx)
 
-        autoctx.in_save = original  # Restore proper crit state #1556
+        autoctx.in_save = original  # Restore proper crit state (#1556)
 
         return SaveResult(dc=dc, ability=save_skill, save_roll=save_roll, adv=adv, did_save=is_success,
                           children=children)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -69,8 +69,9 @@ class Save(Effect):
         autoctx.metavars['lastSaveDC'] = dc
 
         autoctx.meta_queue(f"**DC**: {dc}")
+        stat = save_skill[:3]
         if not autoctx.target.is_simple:
-            save_blurb = f'{save_skill[:3].upper()} Save'
+            save_blurb = f'{stat.upper()} Save'
             if auto_pass:
                 is_success = True
                 autoctx.queue(f"**{save_blurb}:** Automatic success!")
@@ -96,13 +97,20 @@ class Save(Effect):
                     autoctx.add_pm(str(autoctx.ctx.author.id), out)
                     autoctx.queue(f"**{save_blurb}**: 1d20...{success_str}")
         else:
-            autoctx.meta_queue('{} Save'.format(save_skill[:3].upper()))
+            autoctx.meta_queue('{} Save'.format(stat.upper()))
             is_success = False
+
+        # Disable critical damage state for children #1556
+        old_in_crit = autoctx.in_crit
+        autoctx.in_crit = False
 
         if is_success:
             children = self.on_success(autoctx)
         else:
             children = self.on_fail(autoctx)
+        
+        autoctx.in_crit = old_in_crit  # Restore proper crit state #1556
+
         return SaveResult(dc=dc, ability=save_skill, save_roll=save_roll, adv=adv, did_save=is_success,
                           children=children)
 

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -35,6 +35,7 @@ class AutomationContext:
         }
         self.target = None
         self.in_crit = False
+        self.in_save = False
 
         self.caster_needs_commit = False
 


### PR DESCRIPTION
### Summary
~~Adds handling for nocritical that pairs with underlying nocrit.~~
Ignores crit state for children of Save automation, restoring it afterwards. Allowing a damage's dice to not be doubled on critical. Mostly intended for saves as part of attacks. (Snake poison, etc)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
