### PR TITLE
Unify reply text, update test

### DIFF
--- a/cogs5e/gamelog.py
+++ b/cogs5e/gamelog.py
@@ -74,7 +74,7 @@ class GameLog(commands.Cog):
             return await ctx.send("This campaign is already linked to this channel.")
         elif existing_link is not None:
             result = await confirm(
-                ctx, "This campaign is already linked to another channel. Link it to this one instead?")
+                ctx, "This campaign is already linked to another channel. Link it to this one instead? (Reply with yes/no)")
             if not result:
                 return await ctx.send("Ok, canceling.")
 

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -520,7 +520,7 @@ class GameTrack(commands.Cog):
 
         conflict = next((c for c in character.consumables if c.name.lower() == name.lower()), None)
         if conflict:
-            if await confirm(ctx, "Warning: This will overwrite an existing consumable. Continue?"):
+            if await confirm(ctx, "Warning: This will overwrite an existing consumable. Continue? (Reply with yes/no)"):
                 character.consumables.remove(conflict)
             else:
                 return await ctx.send("Overwrite unconfirmed. Aborting.")

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -126,7 +126,7 @@ class SheetManager(commands.Cog):
 
         conflict = next((a for a in character.overrides.attacks if a.name.lower() == attack.name.lower()), None)
         if conflict:
-            if await confirm(ctx, "This will overwrite an attack with the same name. Continue?"):
+            if await confirm(ctx, "This will overwrite an attack with the same name. Continue? (Reply with yes/no)"):
                 character.overrides.attacks.remove(conflict)
             else:
                 return await ctx.send("Okay, aborting.")
@@ -165,7 +165,7 @@ class SheetManager(commands.Cog):
         conflicts = [a for a in character.overrides.attacks if a.name.lower() in [new.name.lower() for new in attacks]]
         if conflicts:
             if await confirm(ctx, f"This will overwrite {len(conflicts)} attacks with the same name "
-                                  f"({', '.join(c.name for c in conflicts)}). Continue?"):
+                                  f"({', '.join(c.name for c in conflicts)}). Continue? (Reply with yes/no)"):
                 for conflict in conflicts:
                     character.overrides.attacks.remove(conflict)
             else:
@@ -184,7 +184,7 @@ class SheetManager(commands.Cog):
         """
         character: Character = await Character.from_ctx(ctx)
         attack = await search_and_select(ctx, character.overrides.attacks, name, lambda a: a.name)
-        if not (await confirm(ctx, f"Are you sure you want to delete {attack.name}?")):
+        if not (await confirm(ctx, f"Are you sure you want to delete {attack.name}? (Reply with yes/no)")):
             return await ctx.send("Okay, aborting delete.")
         character.overrides.attacks.remove(attack)
         await character.commit(ctx)
@@ -511,7 +511,7 @@ class SheetManager(commands.Cog):
         conflict = await self.bot.mdb.characters.find_one({"owner": str(ctx.author.id), "upstream": _id})
         if conflict:
             return await confirm(ctx,
-                                 f"Warning: This will overwrite a character with the same ID. Do you wish to continue (reply yes/no)?\n"
+                                 f"Warning: This will overwrite a character with the same ID. Do you wish to continue (Reply with yes/no)?\n"
                                  f"If you only wanted to update your character, run `{ctx.prefix}update` instead.")
         return True
 

--- a/cogsmisc/adminUtils.py
+++ b/cogsmisc/adminUtils.py
@@ -229,7 +229,7 @@ class AdminUtils(commands.Cog):
     @checks.is_owner()
     async def admin_restart_shard(self, ctx, shard_id: int):
         """Forces a shard to disconnect from the Discord API and reconnect."""
-        if not await confirm(ctx, f"Are you sure you want to restart shard {shard_id}?"):
+        if not await confirm(ctx, f"Are you sure you want to restart shard {shard_id}? (Reply with yes/no)"):
             return await ctx.send("ok, not restarting")
         resp = await self.pscall("restart_shard", kwargs={"shard_id": shard_id}, expected_replies=1)
         await self._send_replies(ctx, resp)
@@ -239,7 +239,7 @@ class AdminUtils(commands.Cog):
     async def admin_kill_cluster(self, ctx, cluster_id: int):
         """Forces a cluster to restart by killing it."""
         num_shards = len(self.bot.shard_ids) if self.bot.shard_ids is not None else 1
-        if not await confirm(ctx, f"Are you absolutely sure you want to kill cluster {cluster_id}?\n"
+        if not await confirm(ctx, f"Are you absolutely sure you want to kill cluster {cluster_id}? (Reply with yes/no)\n"
                                   f"**This will terminate approximately {num_shards} shards, which "
                                   f"will take at least {num_shards * 5} seconds to restart, and "
                                   f"impact about {len(self.bot.guilds)} servers.**"):

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -311,7 +311,7 @@ class CollectableManagementGroup(commands.Group):
         # confirm mass change
         changes = '\n'.join([f"`{old}` ({collection}) -> `{new}`" for old, new, collection in rename_tris])
         response = await confirm(ctx, f"This will rename {len(rename_tris)} {self.obj_name_pl}. "
-                                      f"Do you want to continue?\n"
+                                      f"Do you want to continue? (Reply with yes/no)\n"
                                       f"{changes}")
         if not response:
             return await ctx.send("Ok, aborting.")
@@ -402,14 +402,14 @@ async def _snippet_before_edit(ctx, name=None, delete=False):
         return
     name = name.lower()
     if name in SPECIAL_ARGS or name.startswith('-'):
-        confirmation = f"**Warning:** Creating a snippet named `{name}` will prevent you from using the built-in `{name}` argument in Avrae commands.\nAre you sure you want to create this snippet? (yes/no)"
+        confirmation = f"**Warning:** Creating a snippet named `{name}` will prevent you from using the built-in `{name}` argument in Avrae commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
     # roll string checking
     try:
         d20.parse(name)
     except d20.RollSyntaxError:
         pass
     else:
-        confirmation = f"**Warning:** Creating a snippet named `{name}` might cause hidden problems if you try to use the same roll in other commands.\nAre you sure you want to create this snippet? (yes/no)"
+        confirmation = f"**Warning:** Creating a snippet named `{name}` might cause hidden problems if you try to use the same roll in other commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
 
     if confirmation is not None:
         if not await confirm(ctx, confirmation):
@@ -453,8 +453,8 @@ class Customization(commands.Cog):
 
         # Check for Discord Slash-command conflict
         if prefix.startswith('/'):
-            if not await confirm(ctx, f"Setting a prefix that begins with / may cause issues. "
-                                      "Are you sure you want to continue?"):
+            if not await confirm(ctx, "Setting a prefix that begins with / may cause issues. "
+                                      "Are you sure you want to continue? (Reply with yes/no)"):
                 return await ctx.send("Ok, cancelling.")
 
         # insert into cache
@@ -869,7 +869,7 @@ class Customization(commands.Cog):
         elif gvar['owner'] != str(ctx.author.id):
             return await ctx.send("You are not the owner of this variable.")
         else:
-            if await confirm(ctx, f"Are you sure you want to delete `{name}`?"):
+            if await confirm(ctx, f"Are you sure you want to delete `{name}`? (Reply with yes/no)"):
                 await self.bot.mdb.gvars.delete_one({"key": name})
             else:
                 return await ctx.send("Ok, cancelling.")

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -91,7 +91,7 @@ class Tutorials(commands.Cog):
             return await ctx.send(f"The tutorial you were running no longer exists. "
                                   f"Please run `{ctx.prefix}tutorial end` to start a new tutorial!")
         # confirm
-        result = await confirm(ctx, "Are you sure you want to skip the current tutorial objective?")
+        result = await confirm(ctx, "Are you sure you want to skip the current tutorial objective? (Reply with yes/no)")
         if not result:
             return await ctx.send("Ok, aborting.")
         # run tutorial state transition
@@ -106,7 +106,7 @@ class Tutorials(commands.Cog):
         if user_state is None:
             return await ctx.send("You are not currently running a tutorial.")
         # confirm
-        result = await confirm(ctx, "Are you sure you want to end the current tutorial?")
+        result = await confirm(ctx, "Are you sure you want to end the current tutorial? (Reply with yes/no)")
         if not result:
             return await ctx.send("Ok, aborting.")
         # delete tutorial state map

--- a/cogsmisc/tutorials/init_dm.py
+++ b/cogsmisc/tutorials/init_dm.py
@@ -348,7 +348,7 @@ class DMInitiative(Tutorial):
                 if orkira is None:
                     addback = await confirm(ctx,
                                             "Uh oh, it looks like Orkira isn't in the fight anymore. "
-                                            "Would you like me to add her back?")
+                                            "Would you like me to add her back? (Reply with yes/no)")
                     if addback:
                         orkira = await add_orkira(ctx, the_combat)
                         await ctx.send("Ok. I've added her back to the fight - try again!")

--- a/tests/cogsmisc/customization_test.py
+++ b/tests/cogsmisc/customization_test.py
@@ -14,22 +14,22 @@ async def test_snippet_before_edit(avrae, dhttp):
 
     avrae.message("!snippet 2d6 adv")
     await dhttp.receive_message("**Warning:** Creating a snippet named `2d6` might cause hidden problems "
-                                "if you try to use the same roll in other commands.\nAre you sure you want "
-                                "to create this snippet? (Reply with yes/no)", regex=False)
+                                "if you try to use the same roll in other commands.\nAre you sure you want to "
+                                "create this snippet? (Reply with yes/no)", regex=False)
     avrae.message("no")
     await dhttp.receive_message("Ok, cancelling.", regex=False)
 
     avrae.message("!snippet adv adv")
     await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using "
                                 "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
-                                " create this snippet? (Reply with yes/no)", regex=False)
+                                "create this snippet? (Reply with yes/no)", regex=False)
     avrae.message("yes")
     await dhttp.receive_message("Snippet `adv` added.```py\n!snippet adv adv\n```", regex=False)
 
     avrae.message("!snippet adv adv")
     await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using "
                                 "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
-                                " create this snippet? (Reply with yes/no)", regex=False)
+                                "create this snippet? (Reply with yes/no)", regex=False)
     avrae.message("no")
     await dhttp.receive_message("Ok, cancelling.", regex=False)
 

--- a/tests/cogsmisc/customization_test.py
+++ b/tests/cogsmisc/customization_test.py
@@ -1,4 +1,4 @@
-import discord
+import discord  # noqa: F401 Is used in file
 import pytest
 
 
@@ -7,70 +7,83 @@ pytestmark = pytest.mark.asyncio
 
 async def test_snippet_before_edit(avrae, dhttp):
     dhttp.clear()
-    
+
     # Snippet tests
-    avrae.message('!snippet test adv')
-    await dhttp.receive_message("Snippet `test` added.```py\n!snippet test adv\n```", regex = False)
+    avrae.message("!snippet test adv")
+    await dhttp.receive_message("Snippet `test` added.```py\n!snippet test adv\n```", regex=False)
 
-    avrae.message('!snippet 2d6 adv')
-    await dhttp.receive_message('**Warning:** Creating a snippet named `2d6` might cause hidden problems if you try to use the same roll in other commands.\nAre you sure you want to create this snippet? (yes/no)', regex = False)
-    avrae.message('no')
-    await dhttp.receive_message('Ok, cancelling.', regex = False)
-    
-    avrae.message('!snippet adv adv')
-    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using the built-in `adv` argument in Avrae commands.\nAre you sure you want to create this snippet? (yes/no)", regex = False)
-    avrae.message('yes')
-    await dhttp.receive_message("Snippet `adv` added.```py\n!snippet adv adv\n```", regex = False)
+    avrae.message("!snippet 2d6 adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `2d6` might cause hidden problems "
+                                "if you try to use the same roll in other commands.\nAre you sure you want "
+                                "to create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("no")
+    await dhttp.receive_message("Ok, cancelling.", regex=False)
 
-    avrae.message('!snippet adv adv')
-    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using the built-in `adv` argument in Avrae commands.\nAre you sure you want to create this snippet? (yes/no)", regex = False)
-    avrae.message('no')
-    await dhttp.receive_message('Ok, cancelling.', regex = False)
+    avrae.message("!snippet adv adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using "
+                                "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+                                " create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("yes")
+    await dhttp.receive_message("Snippet `adv` added.```py\n!snippet adv adv\n```", regex=False)
 
-    avrae.message('!snippet str adv')
-    await dhttp.receive_message("**Warning:** Creating a snippet named `str` will prevent you from using the built-in `str` argument in Avrae commands.\nAre you sure you want to create this snippet? (yes/no)", regex = False)
-    avrae.message('no')
-    await dhttp.receive_message('Ok, cancelling.', regex = False)
+    avrae.message("!snippet adv adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using "
+                                "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+                                " create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("no")
+    await dhttp.receive_message("Ok, cancelling.", regex=False)
 
-    avrae.message('!snippet 10 adv')
-    await dhttp.receive_message('**Warning:** Creating a snippet named `10` might cause hidden problems if you try to use the same roll in other commands.\nAre you sure you want to create this snippet? (yes/no)', regex = False)
-    avrae.message('no')
-    await dhttp.receive_message('Ok, cancelling.', regex = False)
+    avrae.message("!snippet str adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `str` will prevent you from using "
+                                "the built-in `str` argument in Avrae commands.\nAre you sure you want to "
+                                "create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("no")
+    await dhttp.receive_message("Ok, cancelling.", regex=False)
 
-    avrae.message('!snippet remove test')
-    await dhttp.receive_message('Snippet test removed.', regex = False)
+    avrae.message("!snippet 10 adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `10` might cause hidden problems if "
+                                "you try to use the same roll in other commands.\nAre you sure you want to "
+                                "create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("no")
+    await dhttp.receive_message("Ok, cancelling.", regex=False)
 
-    avrae.message('!snippet remove adv')
-    await dhttp.receive_message('Snippet adv removed.', regex = False)
+    avrae.message("!snippet remove test")
+    await dhttp.receive_message("Snippet test removed.", regex=False)
 
-    avrae.message('!serversnippet adv adv')
-    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using the built-in `adv` argument in Avrae commands.\nAre you sure you want to create this snippet? (yes/no)", regex = False)
-    avrae.message('yes')
-    await dhttp.receive_message("Server snippet `adv` added.```py\n!snippet adv adv\n```", regex = False)
+    avrae.message("!snippet remove adv")
+    await dhttp.receive_message("Snippet adv removed.", regex=False)
+
+    avrae.message("!serversnippet adv adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using "
+                                "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+                                "create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("yes")
+    await dhttp.receive_message("Server snippet `adv` added.```py\n!snippet adv adv\n```", regex=False)
 
     # alias tests
-    avrae.message('!alias tester echo test')
-    await dhttp.receive_message('Alias `tester` added.```py\n!alias tester echo test\n```', regex = False)
+    avrae.message("!alias tester echo test")
+    await dhttp.receive_message("Alias `tester` added.```py\n!alias tester echo test\n```", regex=False)
 
-    avrae.message('!alias test echo test')
-    await dhttp.receive_message('`test` is already a builtin command. Try another name.', regex = False)
+    avrae.message("!alias test echo test")
+    await dhttp.receive_message("`test` is already a builtin command. Try another name.", regex=False)
 
-    avrae.message('!servalias tester echo test')
-    await dhttp.receive_message('Server alias `tester` added.```py\n!alias tester echo test\n```', regex = False)
+    avrae.message("!servalias tester echo test")
+    await dhttp.receive_message("Server alias `tester` added.```py\n!alias tester echo test\n```", regex=False)
 
-    avrae.message('!servalias test echo test')
-    await dhttp.receive_message('`test` is already a builtin command. Try another name.', regex = False)
+    avrae.message("!servalias test echo test")
+    await dhttp.receive_message("`test` is already a builtin command. Try another name.", regex=False)
 
     # testing the bugfix for renaming
-    avrae.message('!snippet do adv')
-    await dhttp.receive_message("Snippet `do` added.```py\n!snippet do adv\n```", regex = False)
-    avrae.message('!snippet rename do adv')
-    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using the built-in `adv` argument in Avrae commands.\nAre you sure you want to create this snippet? (yes/no)", regex = False)
-    avrae.message('yes')
-    await dhttp.receive_message("Okay, renamed the snippet do to adv.", regex = False)
+    avrae.message("!snippet do adv")
+    await dhttp.receive_message("Snippet `do` added.```py\n!snippet do adv\n```", regex=False)
+    avrae.message("!snippet rename do adv")
+    await dhttp.receive_message("**Warning:** Creating a snippet named `adv` will prevent you from using "
+                                "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+                                "create this snippet? (Reply with yes/no)", regex=False)
+    avrae.message("yes")
+    await dhttp.receive_message("Okay, renamed the snippet do to adv.", regex=False)
 
-    avrae.message('!alias tester echo not a test')
-    await dhttp.receive_message("Alias `tester` added.```py\n!alias tester echo not a test\n```", regex = False)
-    avrae.message('!alias rename tester test')
-    await dhttp.receive_message('`test` is already a builtin command. Try another name.', regex = False)
-    
+    avrae.message("!alias tester echo not a test")
+    await dhttp.receive_message("Alias `tester` added.```py\n!alias tester echo not a test\n```", regex=False)
+    avrae.message("!alias rename tester test")
+    await dhttp.receive_message("`test` is already a builtin command. Try another name.", regex=False)


### PR DESCRIPTION
### Summary
Updates all instances of confirm() without custom reply to use the default reply text `(Reply with yes/no)`
Updates snippet/alias test to match new format

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
