### PR TITLE
Add Simple Pagination to Custom Counters

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -250,24 +250,31 @@ class AliasCharacter(AliasStatBlock):
         if name in self._character.cvars:
             del self._character.cvars[name]
 
-    def cc_full_str(self, name):
+    def cc_full_str(self, name: str, include_name: bool = False):
         """
         Returns a string representing a full custom counter.
 
         :param str name: The name of the custom counter to get.
+        :param bool include_name: If the name of the counter should be included. Defaults to False.
         :returns: A string representing all components of the counter.
         :rtype: str
         :raises: :exc:`ConsumableException` if the counter does not exist.
+        
+
+        :returns: A string representing all components of the counter.
+        :rtype: str
 
         Example:
 
-        >>> cc_full_str('Bardic Inspiration')
-        Bardic Inspiration
+        >>> full_str()
         ◉◉◉◉
         Resets On: Long Rest
         """
         counter = self._get_consumable(name)
-        return f"""**{counter.name}**\n{counter.full_str()}"""
+        out = counter.full_str()
+        if include_name:
+            out = f'**{counter.name}**\n' + out
+        return out
 
     # --- other properties ---
     @property
@@ -451,21 +458,24 @@ class AliasCustomCounter:
         """
         return self._cc.reset()
 
-    def full_str(self):
+    def full_str(self, include_name: bool = False):
         """
         Returns a string representing the full custom counter.
 
+        :param bool include_name: If the name of the counter should be included. Defaults to False.
         :returns: A string representing all components of the counter.
         :rtype: str
 
         Example:
 
         >>> full_str()
-        Bardic Inspiration
         ◉◉◉◉
         Resets On: Long Rest
         """
-        return f"""**{self.name}**\n{self._cc.full_str()}"""
+        out = self._cc.full_str()
+        if include_name:
+            out = f'**{self.name}**\n' + out
+        return out
 
     def __str__(self):
         return str(self._cc)

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -259,14 +259,14 @@ class AliasCharacter(AliasStatBlock):
         :returns: A string representing all components of the counter.
         :rtype: str
         :raises: :exc:`ConsumableException` if the counter does not exist.
-        
-
-        :returns: A string representing all components of the counter.
-        :rtype: str
 
         Example:
 
-        >>> full_str()
+        >>> cc_full_str('Bardic Inspiration')
+        ◉◉◉◉
+        Resets On: Long Rest
+        >>> cc_full_str('Bardic Inspiration', True)
+        Bardic Inspiration
         ◉◉◉◉
         Resets On: Long Rest
         """
@@ -468,7 +468,11 @@ class AliasCustomCounter:
 
         Example:
 
-        >>> full_str()
+        >>> full_str('Bardic Inspiration')
+        ◉◉◉◉
+        Resets On: Long Rest
+        >>> full_str('Bardic Inspiration', True)
+        Bardic Inspiration
         ◉◉◉◉
         Resets On: Long Rest
         """

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -250,7 +250,7 @@ class AliasCharacter(AliasStatBlock):
         if name in self._character.cvars:
             del self._character.cvars[name]
 
-    def full_str(self, name):
+    def cc_full_str(self, name):
         """
         Returns the full counter string in the following format:
             Title

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -250,32 +250,6 @@ class AliasCharacter(AliasStatBlock):
         if name in self._character.cvars:
             del self._character.cvars[name]
 
-    def cc_full_str(self, name: str, include_name: bool = False):
-        """
-        Returns a string representing a full custom counter.
-
-        :param str name: The name of the custom counter to get.
-        :param bool include_name: If the name of the counter should be included. Defaults to False.
-        :returns: A string representing all components of the counter.
-        :rtype: str
-        :raises: :exc:`ConsumableException` if the counter does not exist.
-
-        Example:
-
-        >>> cc_full_str('Bardic Inspiration')
-        ◉◉◉◉
-        Resets On: Long Rest
-        >>> cc_full_str('Bardic Inspiration', True)
-        Bardic Inspiration
-        ◉◉◉◉
-        Resets On: Long Rest
-        """
-        counter = self._get_consumable(name)
-        out = counter.full_str()
-        if include_name:
-            out = f'**{counter.name}**\n' + out
-        return out
-
     # --- other properties ---
     @property
     def owner(self):

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -250,6 +250,20 @@ class AliasCharacter(AliasStatBlock):
         if name in self._character.cvars:
             del self._character.cvars[name]
 
+    def full_str(self, name):
+        """
+        Returns the full counter string in the following format:
+            Title
+            Current Value (bubble|numeric)
+            Reset On (long|short)
+            Resets To
+            On Reset
+
+        :return str
+        """
+        counter = self._get_consumable(name)
+        return f"""**{counter.name}**\n{counter.full_str()}"""
+
     # --- other properties ---
     @property
     def owner(self):
@@ -431,6 +445,19 @@ class AliasCustomCounter:
         :return CustomCounterResetResult: (new_value: int, old_value: int, target_value: int, delta: str)
         """
         return self._cc.reset()
+
+    def full_str(self):
+        """
+        Returns the full counter string in the following format:
+            Title
+            Current Value (bubble|numeric)
+            Reset On (long|short)
+            Resets To
+            On Reset
+
+        :return str
+        """
+        return f"""**{self.name}**\n{self._cc.full_str()}"""
 
     def __str__(self):
         return str(self._cc)

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -252,14 +252,19 @@ class AliasCharacter(AliasStatBlock):
 
     def cc_full_str(self, name):
         """
-        Returns the full counter string in the following format:
-            Title
-            Current Value (bubble|numeric)
-            Reset On (long|short)
-            Resets To
-            On Reset
+        Returns a string representing a full custom counter.
 
-        :return str
+        :param str name: The name of the custom counter to get.
+        :returns: A string representing all components of the counter.
+        :rtype: str
+        :raises: :exc:`ConsumableException` if the counter does not exist.
+
+        Example:
+
+        >>> cc_full_str('Bardic Inspiration')
+        Bardic Inspiration
+        ◉◉◉◉
+        Resets On: Long Rest
         """
         counter = self._get_consumable(name)
         return f"""**{counter.name}**\n{counter.full_str()}"""
@@ -448,14 +453,17 @@ class AliasCustomCounter:
 
     def full_str(self):
         """
-        Returns the full counter string in the following format:
-            Title
-            Current Value (bubble|numeric)
-            Reset On (long|short)
-            Resets To
-            On Reset
+        Returns a string representing the full custom counter.
 
-        :return str
+        :returns: A string representing all components of the counter.
+        :rtype: str
+
+        Example:
+
+        >>> full_str()
+        Bardic Inspiration
+        ◉◉◉◉
+        Resets On: Long Rest
         """
         return f"""**{self.name}**\n{self._cc.full_str()}"""
 

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -469,12 +469,12 @@ class AliasCustomCounter:
         Example:
 
         >>> full_str('Bardic Inspiration')
-        ◉◉◉◉
-        Resets On: Long Rest
+        "◉◉◉◉\n"
+        "**Resets On**: Long Rest"
         >>> full_str('Bardic Inspiration', True)
-        Bardic Inspiration
-        ◉◉◉◉
-        Resets On: Long Rest
+        "**Bardic Inspiration**\n"
+        "◉◉◉◉\n"
+        "**Resets On**: Long Rest"
         """
         out = self._cc.full_str()
         if include_name:

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -555,7 +555,7 @@ class GameTrack(commands.Cog):
 
     @customcounter.command(name='summary', aliases=['list'])
     async def customcounter_summary(self, ctx, page: int = 0):
-        """Prints a summary of all custom counters."""
+        """Prints a summary of all custom counters. Will use paging if more than 25."""
         character: Character = await Character.from_ctx(ctx)
         embed = EmbedWithCharacter(character)
         # Check that we're not over the field limit

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -554,12 +554,29 @@ class GameTrack(commands.Cog):
         await ctx.send(f"Deleted counter {counter.name}.")
 
     @customcounter.command(name='summary', aliases=['list'])
-    async def customcounter_summary(self, ctx):
+    async def customcounter_summary(self, ctx, page: int = 0):
         """Prints a summary of all custom counters."""
         character: Character = await Character.from_ctx(ctx)
         embed = EmbedWithCharacter(character)
-        for counter in character.consumables:
-            embed.add_field(name=counter.name, value=counter.full_str())
+        # Check that we're not over the field limit
+        total = len(character.consumables)
+        if total > 25:
+            page = max(0, page-1)
+            maxpage = total // 25
+            start = min(page*25, total-25)
+            end = max(start+25, total)
+            # Build the current page
+            embed.description = f"""**Custom Counters**
+            There are too many counters to display.
+            Use `cc list <page #>` to display other pages.
+            
+            Displaying page [{page+1}/{maxpage+1}]
+            """
+            for counter in character.consumables[start:end]:
+                embed.add_field(name=counter.name, value=counter.full_str())
+        else:
+            for counter in character.consumables:
+                embed.add_field(name=counter.name, value=counter.full_str())
         await ctx.send(embed=embed)
 
     @customcounter.command(name='reset')

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -555,7 +555,10 @@ class GameTrack(commands.Cog):
 
     @customcounter.command(name='summary', aliases=['list'])
     async def customcounter_summary(self, ctx, page: int = 0):
-        """Prints a summary of all custom counters. Will use paging if more than 25."""
+        """
+        Prints a summary of all custom counters.
+        Use `!cc list <page>` to view pages if you have more than 25 counters.
+        """
         character: Character = await Character.from_ctx(ctx)
         embed = EmbedWithCharacter(character)
         # Check that we're not over the field limit

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -569,12 +569,8 @@ class GameTrack(commands.Cog):
             start = min(page*25, total-25)
             end = max(start+25, total)
             # Build the current page
-            embed.description = f"""**Custom Counters**
-            There are too many counters to display.
-            Use `cc list <page #>` to display other pages.
-
-            Displaying page [{page+1}/{maxpage+1}]
-            """
+            embed.description = "**Custom Counters**"
+            embed.set_footer(text=f"Page [{page+1}/{maxpage+1}] | {ctx.prefix}cc list <page>")
             for counter in character.consumables[start:end]:
                 embed.add_field(name=counter.name, value=counter.full_str())
         else:

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -560,8 +560,8 @@ class GameTrack(commands.Cog):
         embed = EmbedWithCharacter(character)
         # Check that we're not over the field limit
         total = len(character.consumables)
-        if total > 25:
-            page = max(0, page-1)
+        if total > 25:  # Discord Field limit
+            page = max(0, page-1)  # Humans count from 1
             maxpage = total // 25
             start = min(page*25, total-25)
             end = max(start+25, total)

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -569,7 +569,7 @@ class GameTrack(commands.Cog):
             embed.description = f"""**Custom Counters**
             There are too many counters to display.
             Use `cc list <page #>` to display other pages.
-            
+
             Displaying page [{page+1}/{maxpage+1}]
             """
             for counter in character.consumables[start:end]:

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -434,7 +434,7 @@ class GameTrack(commands.Cog):
         `mod` - Add *modifier* counter value
         `set` - Sets the counter value to *modifier*
 
-        *Ex:* 
+        *Ex:*
         `!cc Test 1`
         `!cc Test -2*2d4`
         `!cc Test set 1d4`
@@ -462,21 +462,19 @@ class GameTrack(commands.Cog):
             m = modifier.split(' ')
             operator = m[0]
             modifier = m[-1]
-        
+
         roll_text = ''
         try:
             result = int(modifier)
         except ValueError:
-            try: # if we're not a number, are we dice
+            try:  # if we're not a number, are we dice
                 roll_result = d20.roll(str(modifier))
                 result = roll_result.total
                 roll_text = f"\nRoll: {roll_result}"
             except d20.RollSyntaxError:
                 raise InvalidArgument(f"Could not modify counter: {modifier} cannot be interpreted as a number or dice string.")
 
-        change = ''
         old_value = counter.value
-        
         result_embed = EmbedWithCharacter(character)
         if not operator or operator == 'mod':
             new_value = counter.value + result
@@ -515,7 +513,7 @@ class GameTrack(commands.Cog):
         `-type <bubble|default>` - Whether the counter displays bubbles to show remaining uses or numbers. Default - numbers.
         `-resetto <value>` - The value to reset the counter to. Default - maximum.
         `-resetby <value>` - Rather than resetting to a certain value, modify the counter by this much per reset. Supports dice.
-        """
+        """  # noqa: E501
         character: Character = await Character.from_ctx(ctx)
 
         conflict = next((c for c in character.consumables if c.name.lower() == name.lower()), None)
@@ -542,7 +540,7 @@ class GameTrack(commands.Cog):
         except InvalidArgument as e:
             return await ctx.send(f"Failed to create counter: {e}")
         else:
-            await ctx.send(f"Custom counter created.")
+            await ctx.send("Custom counter created.")
 
     @customcounter.command(name='delete', aliases=['remove'])
     async def customcounter_delete(self, ctx, name):
@@ -560,7 +558,7 @@ class GameTrack(commands.Cog):
         Use `!cc list <page>` to view pages if you have more than 25 counters.
         """
         character: Character = await Character.from_ctx(ctx)
-        embed = EmbedWithCharacter(character)
+        embed = EmbedWithCharacter(character, title="Custom Counters")
         # Check that we're not over the field limit
         total = len(character.consumables)
         if total > 25:  # Discord Field limit
@@ -569,7 +567,6 @@ class GameTrack(commands.Cog):
             start = min(page*25, total-25)
             end = max(start+25, total)
             # Build the current page
-            embed.description = "**Custom Counters**"
             embed.set_footer(text=f"Page [{page+1}/{maxpage+1}] | {ctx.prefix}cc list <page>")
             for counter in character.consumables[start:end]:
                 embed.add_field(name=counter.name, value=counter.full_str())
@@ -611,7 +608,7 @@ class GameTrack(commands.Cog):
     Casts a spell.
     __**Valid Arguments**__
     {VALID_SPELLCASTING_ARGS}
-    
+
     {VALID_AUTOMATION_ARGS}
     """)
     async def cast(self, ctx, spell_name, *, args=''):


### PR DESCRIPTION
### Summary
Resolves #AFR-746
Add Simple Pagination to Custom Counters. Now doesn't prevent seeing past the 25th counter.
Adds `full_str()` accessibility to AliasCounter
Sometimes you have to do something dumb, before you can smart.
Special thanks to Derixyleth

Release Note: Adds Paging for Custom Counters, no longer preventing you from seeing past the 25th counter. Also adds a full_str() command to AliasCounter for showing the complete counter info.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
