### PR TITLE
Return group.name instead of group_id

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -139,7 +139,7 @@ class SimpleCombatant(AliasStatBlock):
 
         :rtype: str or None
         """
-        return self._combatant.group
+        return self._combatant.get_group_name()
 
     @property
     def race(self):

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -139,7 +139,8 @@ class SimpleCombatant(AliasStatBlock):
 
         :rtype: str or None
         """
-        return self._combatant.get_group_name()
+        group = self._combatant.get_group()
+        return group.name if group else None
 
     @property
     def race(self):

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -279,7 +279,7 @@ class Combat:
         :param strict: Whether group name must be a full case insensitive match.
         :return: The combatant group.
         """
-        if name: # catch no group without having to loop
+        if name:  # catch no group without having to loop
             if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
                 return self._combatant_id_map[name]
             if strict:

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -279,17 +279,16 @@ class Combat:
         :param strict: Whether group name must be a full case insensitive match.
         :return: The combatant group.
         """
-        if name:  # catch no group without having to loop
-            if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
-                return self._combatant_id_map[name]
-            if strict:
-                grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
-            else:
-                grp = next((g for g in self.get_groups() if name.lower() in g.name.lower()), None)
+        if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
+            return self._combatant_id_map[name]
+        if strict:
+            grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
+        else:
+            grp = next((g for g in self.get_groups() if name.lower() in g.name.lower()), None)
 
-            if grp is None and create is not None:
-                grp = CombatantGroup.new(self, name, init=create, ctx=self.ctx)
-                self.add_combatant(grp)
+        if grp is None and create is not None:
+            grp = CombatantGroup.new(self, name, init=create, ctx=self.ctx)
+            self.add_combatant(grp)
 
         return grp
 

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -279,16 +279,17 @@ class Combat:
         :param strict: Whether group name must be a full case insensitive match.
         :return: The combatant group.
         """
-        if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
-            return self._combatant_id_map[name]
-        if strict:
-            grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
-        else:
-            grp = next((g for g in self.get_groups() if name.lower() in g.name.lower()), None)
+        if name: # catch no group without having to loop
+            if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
+                return self._combatant_id_map[name]
+            if strict:
+                grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
+            else:
+                grp = next((g for g in self.get_groups() if name.lower() in g.name.lower()), None)
 
-        if grp is None and create is not None:
-            grp = CombatantGroup.new(self, name, init=create, ctx=self.ctx)
-            self.add_combatant(grp)
+            if grp is None and create is not None:
+                grp = CombatantGroup.new(self, name, init=create, ctx=self.ctx)
+                self.add_combatant(grp)
 
         return grp
 

--- a/cogs5e/models/initiative/combatant.py
+++ b/cogs5e/models/initiative/combatant.py
@@ -251,9 +251,8 @@ class Combatant(BaseCombatant, StatBlock):
                 self.combat.goto_turn(self, True)
             return c_group
 
-    def get_group_name(self):
-        group = self.combat.get_group(self._group_id)
-        return group.name if group else None
+    def get_group(self):
+        return self.combat.get_group(self._group_id) if self._group_id else None
 
     # effects
     def add_effect(self, effect):

--- a/cogs5e/models/initiative/combatant.py
+++ b/cogs5e/models/initiative/combatant.py
@@ -252,7 +252,8 @@ class Combatant(BaseCombatant, StatBlock):
             return c_group
 
     def get_group_name(self):
-        return self.combat.get_group(self._group_id).name if self._group_id else None
+        group = self.combat.get_group(self._group_id)
+        return group.name if group else None
 
     # effects
     def add_effect(self, effect):

--- a/cogs5e/models/initiative/combatant.py
+++ b/cogs5e/models/initiative/combatant.py
@@ -251,6 +251,9 @@ class Combatant(BaseCombatant, StatBlock):
                 self.combat.goto_turn(self, True)
             return c_group
 
+    def get_group_name(self):
+        return self.combat.get_group(self._group_id).name if self._group_id else None
+
     # effects
     def add_effect(self, effect):
         # handle name conflict


### PR DESCRIPTION
### Summary
SimpleCombatant.group is returning Id instead of Name. Now returns the name or none as per spec.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
