### PR TITLE
Let effects override innate resists

### DIFF
--- a/cogs5e/models/initiative/combatant.py
+++ b/cogs5e/models/initiative/combatant.py
@@ -175,7 +175,7 @@ class Combatant(BaseCombatant, StatBlock):
     @property
     def resistances(self):
         out = self._resistances.copy()
-        out.update(Resistances.from_dict({k: self.active_effects(k) for k in RESIST_TYPES}), overwrite=False)
+        out.update(Resistances.from_dict({k: self.active_effects(k) for k in RESIST_TYPES}), overwrite=True)
         return out
 
     def set_resist(self, damage_type: str, resist_type: str):


### PR DESCRIPTION
### Summary
Right now effects on a combatant can't override innate resistances if they are of the same type as an existing resist
Ex: `-neutral necrotic` on a creature with Resistance: necrotic

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
