### PR TITLE
Display is mangled for AliasCounter.full_str

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -443,11 +443,11 @@ class AliasCustomCounter:
         Example:
 
         >>> full_str('Bardic Inspiration')
-        "◉◉◉◉\n"
+        "◉◉◉◉\\n"
         "**Resets On**: Long Rest"
         >>> full_str('Bardic Inspiration', True)
-        "**Bardic Inspiration**\n"
-        "◉◉◉◉\n"
+        "**Bardic Inspiration**\\n"
+        "◉◉◉◉\\n"
         "**Resets On**: Long Rest"
         """
         out = self._cc.full_str()


### PR DESCRIPTION
### Summary
The `\n` in the code ouput on the documentation is mangling for AliasCounter.full_str
This displays correctly, uncertain if is correct output though

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
