### PR TITLE
full_str does not take the counter name in context

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -442,10 +442,10 @@ class AliasCustomCounter:
 
         Example:
 
-        >>> full_str('Bardic Inspiration')
+        >>> full_str()
         "◉◉◉◉\\n"
         "**Resets On**: Long Rest"
-        >>> full_str('Bardic Inspiration', True)
+        >>> full_str(True)
         "**Bardic Inspiration**\\n"
         "◉◉◉◉\\n"
         "**Resets On**: Long Rest"


### PR DESCRIPTION
### Summary
Fixes the other issues with full_str example display: does not take the counter name in context

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
