### PR TITLE
2021w32

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -14,12 +14,12 @@ from discord.ext import commands
 from aliasing import helpers
 from cogs5e.models.character import Character, CustomCounter
 from cogs5e.models.embeds import EmbedWithCharacter
-from cogs5e.models.errors import ConsumableException, CounterOutOfBounds, InvalidArgument, NoSelectionElements
+from cogs5e.models.errors import ConsumableException, InvalidArgument, NoSelectionElements
 from cogs5e.utils import checkutils, gameutils, targetutils
 from cogs5e.utils.help_constants import *
 from gamedata.lookuputils import get_spell_choices, select_spell_full
 from utils.argparser import argparse
-from utils.functions import confirm, search, search_and_select, try_delete
+from utils.functions import confirm, maybe_mod, search, search_and_select, try_delete
 
 log = logging.getLogger(__name__)
 
@@ -74,17 +74,7 @@ class GameTrack(commands.Cog):
                                 f"{character.spellbook.slots_str(level)}"
         else:
             old_slots = character.spellbook.get_slots(level)
-            try:
-                if value.startswith(('+', '-')):
-                    value = old_slots + int(value)
-                else:
-                    value = int(value)
-            except ValueError:
-                return await ctx.send(f"{value} is not a valid integer.")
-            try:
-                assert 0 <= value <= character.spellbook.get_max_slots(level)
-            except AssertionError:
-                raise CounterOutOfBounds()
+            value = maybe_mod(value, old_slots)
             character.spellbook.set_slots(level, value)
             await character.commit(ctx)
             embed.description = f"__**Remaining Level {level} Spell Slots**__\n" \

--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -1,6 +1,5 @@
 import collections
 import functools
-import itertools
 import logging
 import traceback
 
@@ -1096,12 +1095,14 @@ class InitTracker(commands.Cog):
                 if 'custom' in args:  # single, custom
                     attack = Attack.new(name=atk_name, bonus_calc='0', damage_calc='0')
                 elif is_player:  # single, noncustom, action?
-                    attack = await search_and_select(
-                        ctx, list(itertools.chain(combatant.attacks, combatant.character.actions)), atk_name,
-                        lambda a: a.name, message="Select your action.")
+                    attack = await actionutils.select_action(
+                        ctx, atk_name, attacks=combatant.attacks, actions=combatant.character.actions,
+                        message="Select your action."
+                    )
                 else:  # single, noncustom
-                    attack = await search_and_select(ctx, combatant.attacks, atk_name, lambda a: a.name,
-                                                     message="Select your attack.")
+                    attack = await actionutils.select_action(
+                        ctx, atk_name, attacks=combatant.attacks, message="Select your attack."
+                    )
         except SelectionException:
             return await ctx.send("Attack not found.")
 

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -84,4 +84,4 @@ class IEffect(Effect):
 
     def build_str(self, caster, evaluator):
         super().build_str(caster, evaluator)
-        return self.name
+        return f"Effect: {self.name}"

--- a/cogs5e/models/embeds.py
+++ b/cogs5e/models/embeds.py
@@ -93,24 +93,25 @@ class EmbedPaginator:
             self.close_field()
 
         self._current_field_name = name
+        self._current_field_inline = inline
+        self.extend_field(value)
 
+    def extend_field(self, value):
+        """Add a line of text to the last field in the help embed."""
+        if not value:
+            return
         chunks = chunk_text(value, max_chunk_size=self.EMBED_FIELD_MAX)
+
+        if self._field_count + len(chunks[0]) + 1 > self.EMBED_FIELD_MAX:
+            self.close_field()
+            self._current_field_name = self.CONTINUATION_FIELD_TITLE
+
         for i, chunk in enumerate(chunks):
             self._field_count += len(value) + 1
-            self._current_field_inline = inline
             self._current_field.append(chunk)
             if i < len(chunks) - 1:  # if not last chunk, add the chunk in a new field
                 self.close_field()
                 self._current_field_name = self.CONTINUATION_FIELD_TITLE
-
-    def extend_field(self, value):
-        """Add a line of text to the last field in the help embed."""
-        if self._field_count + len(value) + 1 > self.EMBED_FIELD_MAX:
-            self.close_field()
-            self.add_field(self.CONTINUATION_FIELD_TITLE, value)
-        else:
-            self._field_count += len(value) + 1
-            self._current_field.append(value)
 
     def close_field(self):
         """Terminate the current field and write it to the last embed."""

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -90,7 +90,7 @@ class AttackList:
 
     # utils
     def build_str(self, caster):
-        return '\n'.join(atk.build_str(caster) for atk in self.attacks)
+        return '\n'.join(atk.build_str(caster) for atk in sorted(self.attacks, key=lambda atk: atk.name))
 
     def __str__(self):
         return '\n'.join(str(atk) for atk in self.attacks)

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -225,8 +225,11 @@ class CustomCounter:
         minv = self.get_min()
         maxv = self.get_max()
 
-        if strict and not minv <= new_value <= maxv:
-            raise CounterOutOfBounds()
+        if strict:
+            if new_value < minv:
+                raise CounterOutOfBounds(f"You do not have enough remaining uses of {self.name}.")
+            elif new_value > maxv:
+                raise CounterOutOfBounds(f"{self.name} cannot be set to {new_value} (max {maxv}).")
 
         new_value = min(max(minv, new_value), maxv)
         self._value = int(new_value)

--- a/cogs5e/models/sheet/spellcasting.py
+++ b/cogs5e/models/sheet/spellcasting.py
@@ -68,8 +68,10 @@ class Spellbook:
         """
         if not 0 < level < 10:
             raise InvalidSpellLevel()
-        if not 0 <= value <= self.get_max_slots(level):
-            raise CounterOutOfBounds()
+        if value < 0:
+            raise CounterOutOfBounds(f"You do not have enough remaining level {level} spell slots.")
+        elif value > (maxv := self.get_max_slots(level)):
+            raise CounterOutOfBounds(f"You may not have this many level {level} spell slots (max {maxv}).")
         self.slots[str(level)] = value
 
     def reset_slots(self):
@@ -98,7 +100,7 @@ class Spellbook:
 
         val = self.get_slots(level) - 1
         if val < 0:
-            raise CounterOutOfBounds("You do not have any spell slots of this level remaining.")
+            raise CounterOutOfBounds(f"You do not have any level {level} spell slots remaining.")
 
         self.set_slots(level, val)
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -83,8 +83,7 @@ class SheetManager(commands.Cog):
 
         caster, targets, combat = await targetutils.maybe_combat(ctx, char, args)
         # we select from caster attacks b/c a combat effect could add some
-        attack_or_action = await search_and_select(
-            ctx, list(itertools.chain(caster.attacks, char.actions)), atk_name, lambda a: a.name)
+        attack_or_action = await actionutils.select_action(ctx, atk_name, attacks=caster.attacks, actions=char.actions)
 
         if isinstance(attack_or_action, Attack):
             result = await actionutils.run_attack(ctx, embed, args, caster, attack_or_action, targets, combat)

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -290,7 +290,10 @@ class BeyondSheetParser(SheetLoaderABC):
         for d_action in character_actions:
             if d_action['typeId'] == '1120657896' and d_action['id'] == '1':  # Unarmed Strike - already in attacks
                 continue
-            g_actions = compendium.lookup_actions_for_entity(int(d_action['typeId']), int(d_action['id']))
+            try:
+                g_actions = compendium.lookup_actions_for_entity(int(d_action['typeId']), int(d_action['id']))
+            except (TypeError, ValueError):  # weird null typeid/uuid id action, maybe artificer infused item?
+                continue
             if g_actions:  # save a reference to each gamedata action by UID
                 for g_action in g_actions:
                     actions.append(Action(

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -299,6 +299,9 @@ class BeyondSheetParser(SheetLoaderABC):
             # Unarmed Strike - already in attacks
             if d_action['typeId'] == '1120657896' and d_action['id'] == '1':
                 continue
+            # display as attack override - fall back to attack system
+            if d_action['isCustomized'] and d_action['displayAsAttack']:
+                continue
 
             # gamedata for limiteduse
             try:

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -188,6 +188,8 @@ async def send_action_list(destination, caster, attacks=None, actions=None, embe
             # count these for extra display
             if action.uid is None:
                 non_automated_count += 1
+        if not action_texts:
+            return
         action_text = '\n'.join(action_texts)
         embeds.add_fields_from_long_text(embed, field_name=title, text=action_text)
 

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -150,7 +150,8 @@ async def send_action_list(destination, caster, attacks=None, actions=None, embe
     # since the sheet displays the description regardless of entitlements, we do here too
     def add_action_field(title, action_source):
         action_texts = (f"**{action.name}**: {action.build_str(caster=caster, automation_only=not verbose)}"
-                        for action in action_source)
+                        for action
+                        in sorted(action_source, key=lambda action: action.name))
         action_text = '\n'.join(action_texts)
         embeds.add_fields_from_long_text(embed, field_name=title, text=action_text)
 

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -446,6 +446,6 @@ class MonsterCastableSpellbook(MonsterSpellbook):
             if self.daily[daily_key] > 0:
                 self.daily[daily_key] -= 1
             else:
-                raise CounterOutOfBounds("You do not have any remaining casts of this spell.")
+                raise CounterOutOfBounds(f"You do not have any remaining casts of {spell.name}.")
         else:
             self.use_slot(level)

--- a/tests/bot_test.py
+++ b/tests/bot_test.py
@@ -26,11 +26,3 @@ async def test_nonexistant_commands(avrae, dhttp):
     avrae.message("hello world")
     avrae.message("spam spam spam!roll 1d20")
     assert dhttp.queue_empty()  # avrae has not responded to anything
-
-
-async def test_help(avrae, dhttp):  # simple test just to make sure help works
-    avrae.message("!help")
-    await dhttp.drain()
-
-    avrae.message("!help -here")
-    await dhttp.receive_message(embed=discord.Embed())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ import re
 from fnmatch import fnmatchcase
 from queue import Queue
 
+import discord
 import pytest
 from discord import DiscordException, Embed
 from discord.ext import commands
@@ -72,6 +73,21 @@ def compare_embeds(request_embed, embed, *, regex: bool = True):
         assert request_embed == embed
 
 
+def embed_assertations(embed):
+    """Checks to ensure that the embed is valid."""
+    assert len(embed) <= 6000
+    assert len(embed.title) <= 256
+    assert len(embed.description) <= 4096
+    assert len(embed.fields) <= 25
+    for field in embed.fields:
+        assert 0 < len(field.name) <= 256
+        assert 0 < len(field.value) <= 1024
+    if embed.footer:
+        assert len(embed.footer.text) <= 2048
+    if embed.author:
+        assert len(embed.author.name) <= 256
+
+
 def message_content_check(request: Request, content: str = None, *, regex: bool = True, embed: Embed = None):
     match = None
     if content:
@@ -81,7 +97,10 @@ def message_content_check(request: Request, content: str = None, *, regex: bool 
         else:
             assert request.data.get('content') == content
     if embed:
-        compare_embeds(request.data.get('embed'), embed.to_dict(), regex=regex)
+        embed_data = request.data.get('embed')
+        assert embed_data is not None
+        embed_assertations(discord.Embed.from_dict(embed_data))
+        compare_embeds(embed_data, embed.to_dict(), regex=regex)
     return match
 
 

--- a/tests/utiltests/help_test.py
+++ b/tests/utiltests/help_test.py
@@ -1,0 +1,30 @@
+import discord
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_help(avrae, dhttp):
+    avrae.message("!help")
+    await dhttp.drain()
+
+    avrae.message("!help -here")
+    await dhttp.receive_message(embed=discord.Embed())
+
+
+async def test_help_commands(avrae, dhttp):
+    for command in avrae.walk_commands():
+        avrae.message(f"!help {command.qualified_name}")
+        await dhttp.drain()
+
+        avrae.message(f"!help {command.qualified_name} -here")
+        await dhttp.receive_message(embed=discord.Embed())
+
+
+async def test_help_modules(avrae, dhttp):
+    for cog in avrae.cogs.keys():
+        avrae.message(f"!help {cog}")
+        await dhttp.drain()
+
+        avrae.message(f"!help {cog} -here")
+        await dhttp.receive_message(embed=discord.Embed())


### PR DESCRIPTION
### Summary
- Fixes an error when importing artificers from DDB
- Fixes the help embed, again, but this time with tests
- Sorts the output of `!action list` alphabetically
- IEffect strs now start with `Effect:`
- Only display runnable actions by default in `!action list`, with help in footer
- Only import actions from DDB if it is not (set to display as attack and customized)
- Improves the display of counter out of bound errors

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
