### PR TITLE
Modifications to allow for changing monster's statistics when they are added to combat.

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -238,9 +238,9 @@ class InitTracker(commands.Cog):
         
         # Check for custom stats
         cust={}
-        for i in args:
-            if i in STAT_ABBREVIATIONS:
-                cust[i]=args.last(i, type_=int)
+        for stat in (('pro',)+STAT_ABBREVIATIONS):
+            if (stat_arg := args.last(stat, type_=int)):
+                cust[stat]= (max(max(stat_arg,100),0))
         
         if args.get("myskills"):
             char: Character = await Character.from_ctx(ctx)

--- a/cogs5e/models/initiative/combatant.py
+++ b/cogs5e/models/initiative/combatant.py
@@ -466,12 +466,17 @@ class MonsterCombatant(Combatant):
         self._monster_id = monster_id
 
     @classmethod
-    def from_monster(cls, monster, ctx, combat, name, controller_id, init, private, hp=None, ac=None):
+    def from_monster(cls, monster, ctx, combat, name, controller_id, init, private, stats=None, skills=None, saves=None, hp=None, ac=None):
         monster_name = monster.name
         creature_type = monster.creature_type
         hp = int(monster.hp) if not hp else int(hp)
         ac = int(monster.ac) if not ac else int(ac)
         id = create_combatant_id()
+        
+        # make sure stats are set
+        stats=(stats if stats else monster.stats)
+        skills=(skills if skills else monster.skills)
+        saves=(saves if saves else monster.saves)
 
         # copy spellbook
         spellbook = None
@@ -480,11 +485,11 @@ class MonsterCombatant(Combatant):
 
         # copy resistances (#1134)
         resistances = monster.resistances.copy()
-
+                
         return cls(ctx, combat, id, name, controller_id, private, init,
                    # statblock info
-                   stats=monster.stats, levels=monster.levels, attacks=monster.attacks,
-                   skills=monster.skills, saves=monster.saves, resistances=resistances,
+                   stats=stats, levels=monster.levels, attacks=monster.attacks,
+                   skills=skills, saves=saves, resistances=resistances,
                    spellbook=spellbook, ac=ac, max_hp=hp,
                    # monster specific
                    monster_name=monster_name, monster_id=monster.entity_id, creature_type=creature_type)

--- a/cogs5e/models/sheet/base.py
+++ b/cogs5e/models/sheet/base.py
@@ -1,4 +1,4 @@
-from utils.constants import SAVE_NAMES, SKILL_MAP, SKILL_NAMES, STAT_ABBREVIATIONS, STAT_NAMES, ABILITY_NAMES
+from utils.constants import SAVE_NAMES, SKILL_MAP, SKILL_NAMES, STAT_ABBREVIATIONS, STAT_NAMES
 from utils.functions import camel_to_title, verbose_stat
 
 
@@ -60,7 +60,8 @@ class BaseStats:
                f"**CHA**: {self.charisma} ({(self.charisma - 10) // 2:+})"
 
     def __getitem__(self, item):  # little bit hacky, but works
-        if item not in ABILITY_NAMES:
+        abils=('pro',)+STAT_ABBREVIATIONS
+        if item not in abils:
             raise ValueError(f"{item} is not a stat.")
         return getattr(self, item)
 

--- a/cogs5e/models/sheet/spellcasting.py
+++ b/cogs5e/models/sheet/spellcasting.py
@@ -118,7 +118,7 @@ class Spellbook:
     def cast(self, spell, level):
         """
         Uses the resources to cast *spell* at *level*.
-
+ABILITY
         :type spell: :class:`~cogs5e.models.spell.Spell`
         :type level: int
         """

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -345,20 +345,6 @@ def xp_by_cr(cr):
             '16': 15000, '17': 18000, '18': 20000, '19': 22000, '20': 25000, '21': 33000, '22': 41000, '23': 50000,
             '24': 62000, '25': 75000, '26': 90000, '27': 105000, '28': 120000, '29': 135000, '30': 155000}.get(cr, 0)
 
-
-def _calc_prof(stats, saves, skills):
-    """HACK: Calculates proficiency bonus from save/skill proficiencies."""
-    prof = None
-    for skill_name, skill in itertools.chain(saves, skills):
-        if skill.prof == 1:
-            prof = skill.value - stats.get_mod(SKILL_MAP[skill_name])
-            break
-
-    if prof is not None:
-        return prof
-    return 0
-
-
 def floatify_cr(cr: str) -> float:
     return {'1/8': 0.125, '1/4': 0.25, '1/2': 0.5}.get(cr) or float(cr)
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -3,13 +3,11 @@ RESIST_TYPES = ('resist', 'immune', 'vuln', 'neutral')
 DAMAGE_TYPES = ('acid', 'bludgeoning', 'cold', 'fire', 'force', 'lightning', 'necrotic', 'piercing', 'poison',
                 'psychic', 'radiant', 'slashing', 'thunder')
 
-ABILITY_NAMES = ('prof_bonus','strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma')
-
 STAT_NAMES = ('strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma')
 
-STAT_ABBREVIATIONS = ('pro','str', 'dex', 'con', 'int', 'wis', 'cha')
+STAT_ABBREVIATIONS = ('str', 'dex', 'con', 'int', 'wis', 'cha')
 
-STAT_ABBR_MAP = {'pro': 'Proficiency Bonus','str': 'Strength', 'dex': 'Dexterity', 'con': 'Constitution',
+STAT_ABBR_MAP = {'str': 'Strength', 'dex': 'Dexterity', 'con': 'Constitution',
                  'int': 'Intelligence', 'wis': 'Wisdom', 'cha': 'Charisma'}
 
 SKILL_NAMES = ('acrobatics', 'animalHandling', 'arcana', 'athletics', 'deception', 'history', 'initiative', 'insight',


### PR DESCRIPTION
### Summary
Modified MonsterCombatant to pass through custom arguments.
Modified BaseStats, Skills, and Saves, adding a function to each to allow them to be intercepted, then passed through, as well as adding better support for the prof_bonus modifier in normal code.
Added the ABILITY_NAMES constant which mimics STAT_NAMES except with 'prof_bonus' included, as well as adding "Proficiency Bonus" to STAT_ABBR_MAP.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
