### PR TITLE
Grant access to combatant id

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -7,6 +7,8 @@ from aliasing.api.functions import SimpleRollResult
 from aliasing.api.statblock import AliasStatBlock
 from cogs5e.models.errors import InvalidSaveType
 from cogs5e.models.sheet.statblock import StatBlock
+from cogs5e.models.initiative.combatant import Combatant
+from cogs5e.models.initiative.group import CombatantGroup
 from utils.argparser import ParsedArguments
 
 MAX_METADATA_SIZE = 100000
@@ -46,31 +48,20 @@ class SimpleCombat:
     # public methods
     def get_combatant(self, name):
         """
-        Gets a :class:`~aliasing.api.combat.SimpleCombatant`, fuzzy searching (partial match) on name.
+        Gets a :class:`~aliasing.api.combat.SimpleCombatant`, fuzzy searching (partial match) on name, or searching by ID.
+        When searching by ID, you can retrieve a :class:`~aliasing.api.combat.SimpleGroup`
 
-        :param str name: The name of the combatant to get.
-        :return: The combatant.
-        :rtype: :class:`~aliasing.api.combat.SimpleCombatant`
+        :param str name: The name (or ID) of the combatant to get.
+        :return: The combatant or group.
+        :rtype: :class:`~aliasing.api.combat.SimpleCombatant` or :class:`~aliasing.api.combat.SimpleGroup`
         """
         name = str(name)
         combatant = self._combat.get_combatant(name, False)
         if combatant:
-            return SimpleCombatant(combatant)
-        return None
-
-    def get_combatant_by_id(self, combatant_id):
-        """
-        Gets a :class:`~aliasing.api.combat.SimpleCombatant` by their unique identifier.
-        A :class:`~aliasing.api.combat.SimpleCombatant` identifier is in the format of a UUID4.
-
-        :param str combatant_id: The id of the combatant to get.
-        :return: The combatant, or None
-        :rtype: :class:`~aliasing.api.combat.SimpleCombatant`
-        """
-        combatant_id = str(combatant_id)
-        combatant = self._combat.combatant_by_id(combatant_id)
-        if combatant:
-            return SimpleCombatant(combatant)
+            if isinstance(combatant, CombatantGroup):
+                return SimpleGroup(combatant)
+            elif isinstance(combatant, Combatant):
+                return SimpleCombatant(combatant)
         return None
 
     def get_group(self, name):
@@ -507,6 +498,15 @@ class SimpleGroup:
         :rtype: str
         """
         return self._group.name
+
+    @property
+    def id(self):
+        """
+        The group's unique identifier.
+
+        :rtype: str
+        """
+        return self._group.id
 
     def get_combatant(self, name):
         """

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -48,12 +48,11 @@ class SimpleCombat:
     # public methods
     def get_combatant(self, name):
         """
-        Gets a :class:`~aliasing.api.combat.SimpleCombatant`, fuzzy searching (partial match) on name, or searching by ID.
-        When searching by ID, you can retrieve a :class:`~aliasing.api.combat.SimpleGroup`
+        Gets a combatant by its name or ID.
 
-        :param str name: The name (or ID) of the combatant to get.
-        :return: The combatant or group.
-        :rtype: :class:`~aliasing.api.combat.SimpleCombatant` or :class:`~aliasing.api.combat.SimpleGroup`
+        If a combatant name is passed, returns the first :class:`~aliasing.api.combat.SimpleCombatant` that matches the name via fuzzy searching (partial match) on name. This cannot return groups.
+
+        If a combatant ID is passed, returns the combatant with the given ID, which may be a :class:`~aliasing.api.combat.SimpleCombatant` or :class:`~aliasing.api.combat.SimpleGroup`
         """
         name = str(name)
         combatant = self._combat.get_combatant(name, False)

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -58,6 +58,20 @@ class SimpleCombat:
             return SimpleCombatant(combatant)
         return None
 
+    def get_combatant_by_id(self, combatant_id):
+        """
+        Gets a :class:`~aliasing.api.combat.SimpleCombatant` by their unique identifier.
+
+        :param str combatant_id: The id of the combatant to get.
+        :return: The combatant, or None
+        :rtype: :class:`~aliasing.api.combat.SimpleCombatant`
+        """
+        combatant_id = str(combatant_id)
+        combatant = self._combat.combatant_by_id(combatant_id)
+        if combatant:
+            return SimpleCombatant(combatant)
+        return None
+
     def get_group(self, name):
         """
         Gets a :class:`~aliasing.api.combat.SimpleGroup`, fuzzy searching (partial match) on name.
@@ -160,6 +174,15 @@ class SimpleCombatant(AliasStatBlock):
         # deprecated drac 2.1
         self.resists = self.resistances  # use .resistances instead
         self.level = self._combatant.spellbook.caster_level  # use .spellbook.caster_level or .levels.total_level instead
+
+    @property
+    def id(self):
+        """
+        The combatant's unique identifier.
+
+        :rtype: str
+        """
+        return self._combatant.id
 
     @property
     def note(self):

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -61,6 +61,7 @@ class SimpleCombat:
     def get_combatant_by_id(self, combatant_id):
         """
         Gets a :class:`~aliasing.api.combat.SimpleCombatant` by their unique identifier.
+        A :class:`~aliasing.api.combat.SimpleCombatant` identifier is in the format of a UUID4.
 
         :param str combatant_id: The id of the combatant to get.
         :return: The combatant, or None


### PR DESCRIPTION
# Summary
Adds methods to allow aliasers to access a combatant's id, and get a combatant by their id.

Resolves #1615 

## Changes

+ Added `SimpleCombatant.id`
+ Added `SimpleGroup.id`
+ Changed `SimpleCombat.get_combatant` to document get combatants or groups by ID

# Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
