### PR TITLE
Add methods to manage Group initiative

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -488,6 +488,7 @@ class SimpleGroup:
         self._group = group
         self.type = "group"
         self.combatants = [SimpleCombatant(c) for c in self._group.get_combatants()]
+        self.init = self._group.init
 
     @property
     def name(self):
@@ -520,6 +521,17 @@ class SimpleGroup:
         if combatant:
             return combatant
         return None
+
+    def set_init(self, init: int):
+        """
+        Sets the group's initiative roll.
+
+        :param int init: The new initiative.
+        """
+        if not isinstance(init, int):
+            raise ValueError("Initiative must be an integer.")
+        self._group.init = init
+        self._group.combat.sort_combatants()
 
     def __str__(self):
         return str(self._group)

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -982,6 +982,12 @@ SimpleGroup
 
         :type: str
 
+    .. attribute:: init
+
+        What the group rolled for initiative.
+
+        :type: int
+
 SimpleEffect
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
### Summary
Aliases can currently read and set the initiative of SimpleCombatants, but there is no functionality to set the same for SimpleGroups. This PR aims to add feature parity by adding an `init` getter and setter to the API.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
