### PR TITLE
Allow manipulating the current round through automation

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -127,7 +127,7 @@ class SimpleCombat:
         """
         if not isinstance(round_num, int):
             raise ValueError("Round_num must be an integer.")
-        self._combat._round_num = round_num
+        self._combat.round_num = round_num
 
     def end_round(self):
         """

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -118,6 +118,22 @@ class SimpleCombat:
         """
         return self._combat._metadata.pop(str(k), None)
 
+    def set_round(self, round_num: int):
+        """
+        Sets the current round.
+
+        :param int round_num: the new round number
+        """
+        if not isinstance(round_num, int):
+            raise ValueError("Round_num must be an integer.")
+        self._combat._round_num = round_num
+
+    def end_round(self):
+        """
+        Moves initiative to just before the next round (no active combatant or group).
+        """
+        self._combat.end_round()
+
     # private functions
     def func_set_character(self, character):
         me = next((c for c in self._combat.get_combatants() if getattr(c, 'character_id', None) == character.upstream),

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -121,6 +121,7 @@ class SimpleCombat:
     def set_round(self, round_num: int):
         """
         Sets the current round.
+        Setting the round will not tick any events with durations.
 
         :param int round_num: the new round number
         """
@@ -131,6 +132,7 @@ class SimpleCombat:
     def end_round(self):
         """
         Moves initiative to just before the next round (no active combatant or group).
+        Ending the round will not tick any events with durations.
         """
         self._combat.end_round()
 

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -319,8 +319,7 @@ class Combat:
         self.sort_combatants()
 
         # reset current turn
-        self._turn = 0
-        self._current_index = None
+        self.end_round()
 
         order = []
         for combatant, init_roll in sorted(rolls.items(), key=lambda r: (r[1].total, int(r[0].init_skill)),

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -331,6 +331,13 @@ class Combat:
 
         return order
 
+    def end_round(self):
+        """
+        Moves initiative to just before the next round (no active combatant or group).
+        """
+        self._turn = 0
+        self._current_index = None
+
     async def select_combatant(self, name, choice_message=None, select_group=False):
         """
         Opens a prompt for a user to select the combatant they were searching for.


### PR DESCRIPTION
### Summary
This change allows alias users to reset the current round and move initiative to its initial state, allowing plug-ins for the `!init reroll -restart True` command that handle initiative differently.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
