### PR TITLE
Update footer for `!alias list` and variants

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -188,7 +188,7 @@ class CollectableManagementGroup(commands.Group):
         for name, bindings_str in pages[page - 1]:
             ep.add_field(name, bindings_str)
         if total > 25:
-            ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{ctx.command.qualified_name} list <page>")
+            ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{ctx.command.root_parent} list <page>")
 
         if not collections:
             ep.add_description(f"You have no {self.obj_name_pl}. Check out the [Alias Workshop]"

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -188,7 +188,7 @@ class CollectableManagementGroup(commands.Group):
         for name, bindings_str in pages[page - 1]:
             ep.add_field(name, bindings_str)
         if total > 25:
-            ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{ctx.command.qualified_name} <page>")
+            ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{ctx.command.qualified_name} list <page>")
 
         if not collections:
             ep.add_description(f"You have no {self.obj_name_pl}. Check out the [Alias Workshop]"

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -65,10 +65,12 @@ class CollectableManagementGroup(commands.Group):
         self.obj_name = 'alias' if self.is_alias else 'snippet'
         self.obj_copy_command = self.obj_name  # when an item is viewed, we show the non-server version of the command
         self.obj_name_pl = 'aliases' if self.is_alias else 'snippets'
+        self.base_name = self.obj_name
 
         if self.is_server:
             self.obj_name = f'server {self.obj_name}'
             self.obj_name_pl = f'server {self.obj_name_pl}'
+            self.base_name = f'serv{self.base_name}'
             self.owner_from_ctx = lambda ctx: str(ctx.guild.id)
         else:
             self.owner_from_ctx = lambda ctx: str(ctx.author.id)
@@ -188,7 +190,7 @@ class CollectableManagementGroup(commands.Group):
         for name, bindings_str in pages[page - 1]:
             ep.add_field(name, bindings_str)
         if total > 25:
-            ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{ctx.command.root_parent} list <page>")
+            ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{self.base_name} list <page>")
 
         if not collections:
             ep.add_description(f"You have no {self.obj_name_pl}. Check out the [Alias Workshop]"


### PR DESCRIPTION
### Summary
Currently the footer in `!alias` says `!alias <page>` when ran as just `!alias`, but properly says `!alias list <page>` when ran with `!alias list`, and the same for snippets and the server variants of each. This PR changes it to save the base command and display that instead.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
