### PR TITLE
Add a message telling users to look closely at their linked discord account when running `!ddb`

### DIFF
--- a/cogsmisc/core.py
+++ b/cogsmisc/core.py
@@ -134,11 +134,14 @@ class Core(commands.Cog):
                 "D&D Beyond in Avrae for free - you can link your accounts " \
                 "[here](https://www.dndbeyond.com/account)."
             embed.add_field(name="Having trouble?",
-                            value=(f"Sometimes on the first attempt to link, Discord links to a placeholder account. "
-                                   f"If you've connected, but this command says you haven't, compare the numbers at "
-                                   f"the end of your Discord tag (For `{ctx.author.name}#{ctx.author.discriminator}`, "
-                                   f"check for the `{ctx.author.discriminator}`) on Discord and on D&D Beyond. If they "
-                                   f"do not match, unlink the account, and try again."))
+                            value=(f"On occasion, the first time you link your Discord and D&D Beyond accounts, "
+                                   f"Discord may use a temporary account that differs from your actual account. "
+                                   f"If your accounts appear linked, but this command says they are not, compare "
+                                   f"the numbers at the end of your Discord username to the numbers displayed in "
+                                   f"the [D&D Beyond Account Settings](https://www.dndbeyond.com/account). For "
+                                   f"this account, `{ctx.author!s}`, they should be `{ctx.author.discriminator}`. "
+                                   f"If they do not match, unlink the account, and try again."))
+
             embed.set_footer(text="Already linked your account? It may take up to 15 minutes for Avrae to recognize "
                                   "the link.")
             return await ctx.send(embed=embed)


### PR DESCRIPTION
### Summary
One of most common issues when linking your D&D Beyond accounts with Avrae is that Discord will actually link a 'proxy' account. Unfortunately, this is not at all obvious to the end user, and to them it feels as though the accounts should be linked, but aren't. There is currently no wording in the `!ddb` command or on the D&D Beyond website (where you link) that this is even a possibility, which has lead to some very confused users asked what was going on. This PR adds a message to the `!ddb` command when your accounts are not detect as linked.

Resolves AFR-881

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
