### PR TITLE
Remove errant apostrophe in `!help init effect`

### DIFF
--- a/cogs5e/initTracker.py
+++ b/cogs5e/initTracker.py
@@ -909,7 +909,7 @@ class InitTracker(commands.Cog):
         -dur <duration> - Sets the duration of the effect, in rounds.
         conc - Makes the effect require concentration. Will end any other concentration effects.
         end - Makes the effect duration tick on the end of turn, rather than the beginning.
-        -t <target> - Specifies more combatant's to target, chainable (e.g., "-t or1 -t or2").
+        -t <target> - Specifies more combatants to target, chainable (e.g., "-t or1 -t or2").
         -parent <"[combatant]|[effect]"> - Sets a parent effect from a specified combatant.
         __Attacks__
         adv/dis - Give advantage or disadvantage to all attack rolls.


### PR DESCRIPTION
### Summary
This removes the errant apostrophe in `!help init effect`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
