### PR TITLE
Adds ability to set strict setting for combatant/group matching

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -547,10 +547,10 @@ class SimpleGroup:
         name = str(name)
         combatant = None
 
-        if strict or strict is None:
-            combatant = next((c for c in self.get_combatants() if name.lower() == c.name.lower()), None)
+        if strict is not False:
+            combatant = next((c for c in self.combatants if name.lower() == c.name.lower()), None)
         if not combatant and not strict:
-            combatant = next((c for c in self.get_combatants() if name.lower() in c.name.lower()), None)
+            combatant = next((c for c in self.combatants if name.lower() in c.name.lower()), None)
         return combatant
 
     def set_init(self, init: int):

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -44,16 +44,20 @@ class SimpleCombat:
         return cls(combat, None)
 
     # public methods
-    def get_combatant(self, name):
+    def get_combatant(self, name, strict=None):
         """
         Gets a combatant by its name or ID.
 
-        If a combatant name is passed, returns the first :class:`~aliasing.api.combat.SimpleCombatant` that matches the name via fuzzy searching (partial match) on name. This cannot return groups.
-
-        If a combatant ID is passed, returns the combatant with the given ID, which may be a :class:`~aliasing.api.combat.SimpleCombatant` or :class:`~aliasing.api.combat.SimpleGroup`
+        :param str name: The name or id of the combatant or group to get.
+        :param strict: Whether combatant name must be a full case insensitive match.
+                       None  - strict and then partial match. Default.
+                       False - only partial match
+                       True  - only strict match
+        :return: The combatant or group or None.
+        :rtype: :class:`~aliasing.api.combat.SimpleCombatant` or `~aliasing.api.combat.SimpleGroup`
         """
         name = str(name)
-        combatant = self._combat.get_combatant(name, False)
+        combatant = self._combat.get_combatant(name, strict)
         if combatant:
             if combatant.type == init.CombatantType.GROUP:
                 return SimpleGroup(combatant)
@@ -61,16 +65,20 @@ class SimpleCombat:
                 return SimpleCombatant(combatant)
         return None
 
-    def get_group(self, name):
+    def get_group(self, name, strict=None):
         """
-        Gets a :class:`~aliasing.api.combat.SimpleGroup`, fuzzy searching (partial match) on name.
+        Gets a :class:`~aliasing.api.combat.SimpleGroup` that matches on name.
 
         :param str name: The name of the group to get.
-        :return: The group.
+        :param strict: Whether combatant name must be a full case insensitive match.
+                       None  - strict and then partial match. Default.
+                       False - only partial match
+                       True  - only strict match
+        :return: The group or None.
         :rtype: :class:`~aliasing.api.combat.SimpleGroup`
         """
         name = str(name)
-        group = self._combat.get_group(name, strict=False)
+        group = self._combat.get_group(name, strict)
         if group:
             return SimpleGroup(group)
         return None
@@ -524,19 +532,24 @@ class SimpleGroup:
         """
         return self._group.id
 
-    def get_combatant(self, name):
+    def get_combatant(self, name, strict=None):
         """
-        Gets a :class:`~aliasing.api.combat.SimpleCombatant`, fuzzy searching (partial match) on name.
+       Gets a :class:`~aliasing.api.combat.SimpleCombatant` from the group.
 
         :param str name: The name of the combatant to get.
-        :return: The combatant.
+        :param strict: Whether combatant name must be a full case insensitive match.
+                       None  - strict and then partial match. Default.
+                       False - only partial match
+                       True  - only strict match
+        :return: The combatant or None.
         :rtype: :class:`~aliasing.api.combat.SimpleCombatant`
         """
         name = str(name)
-        combatant = next((c for c in self.combatants if name.lower() in c.name.lower()), None)
-        if combatant:
-            return combatant
-        return None
+        if strict or strict is None:
+            combatant = next((c for c in self.get_combatants() if name.lower() == c.name.lower()), None)
+        if not combatant and not strict:
+            combatant = next((c for c in self.get_combatants() if name.lower() in c.name.lower()), None)
+        return combatant
 
     def set_init(self, init: int):
         """

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -545,6 +545,8 @@ class SimpleGroup:
         :rtype: :class:`~aliasing.api.combat.SimpleCombatant`
         """
         name = str(name)
+        combatant = None
+
         if strict or strict is None:
             combatant = next((c for c in self.get_combatants() if name.lower() == c.name.lower()), None)
         if not combatant and not strict:

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -265,30 +265,43 @@ class Combat:
         """Gets a combatant by their ID."""
         return self._combatant_id_map.get(combatant_id)
 
-    def get_combatant(self, name, strict=True):
-        """Gets a combatant by their name or ID."""
+    def get_combatant(self, name, strict=None):
+        """Gets a combatant by their name or ID.
+
+        :param name: The name or id of the combatant.
+        :param strict: Whether combatant name must be a full case insensitive match.
+                       None  - strict and then partial match
+                       False - only partial match
+                       True  - only strict match
+        :return: The combatant or None.
+        """
         if name in self._combatant_id_map:
             return self._combatant_id_map[name]
-        if strict:
-            return next((c for c in self.get_combatants() if c.name.lower() == name.lower()), None)
-        else:
-            return next((c for c in self.get_combatants() if name.lower() in c.name.lower()), None)
+        if strict or strict is None:
+            combatant = next((c for c in self.get_combatants() if name.lower() == c.name.lower()), None)
+        if not combatant and not strict:
+            combatant = next((c for c in self.get_combatants() if name.lower() in c.name.lower()), None)
+        return combatant
 
-    def get_group(self, name, create=None, strict=True):
+    def get_group(self, name, create=None, strict=None):
         """
         Gets a combatant group by its name or ID.
 
         :rtype: CombatantGroup
         :param name: The name of the combatant group.
         :param create: The initiative to create a group at if a group is not found.
-        :param strict: Whether group name must be a full case insensitive match.
+        :param strict: Whether combatant name must be a full case insensitive match.
+                       None  - strict and then partial match
+                       False - only partial match
+                       True  - only strict match
         :return: The combatant group.
         """
         if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
             return self._combatant_id_map[name]
-        if strict:
+
+        if strict or strict is None:
             grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
-        else:
+        if not grp and not strict:
             grp = next((g for g in self.get_groups() if name.lower() in g.name.lower()), None)
 
         if grp is None and create is not None:

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -277,6 +277,8 @@ class Combat:
         """
         if name in self._combatant_id_map:
             return self._combatant_id_map[name]
+
+        combatant = None
         if strict or strict is None:
             combatant = next((c for c in self.get_combatants() if name.lower() == c.name.lower()), None)
         if not combatant and not strict:
@@ -299,6 +301,7 @@ class Combat:
         if name in self._combatant_id_map and isinstance(self._combatant_id_map[name], CombatantGroup):
             return self._combatant_id_map[name]
 
+        grp = None
         if strict or strict is None:
             grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
         if not grp and not strict:

--- a/cogs5e/models/initiative/combat.py
+++ b/cogs5e/models/initiative/combat.py
@@ -279,7 +279,7 @@ class Combat:
             return self._combatant_id_map[name]
 
         combatant = None
-        if strict or strict is None:
+        if strict is not False:
             combatant = next((c for c in self.get_combatants() if name.lower() == c.name.lower()), None)
         if not combatant and not strict:
             combatant = next((c for c in self.get_combatants() if name.lower() in c.name.lower()), None)
@@ -302,7 +302,7 @@ class Combat:
             return self._combatant_id_map[name]
 
         grp = None
-        if strict or strict is None:
+        if strict is not False:
             grp = next((g for g in self.get_groups() if g.name.lower() == name.lower()), None)
         if not grp and not strict:
             grp = next((g for g in self.get_groups() if name.lower() in g.name.lower()), None)


### PR DESCRIPTION
### Summary
Adds the ability to specify the strictness of matching for `get_combatant` and `get_group`.
None  - strict and then partial match
False - only partial match
True  - only strict match

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
