### PR TITLE
Pact/Prepared Improvements

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -88,7 +88,7 @@ class GameTrack(commands.Cog):
         # footer - pact vs non pact
         if character.spellbook.max_pact_slots is not None:
             embed.set_footer(text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used\n"
-                                  f"{constants.FILLED_DIAMOND} / {constants.EMPTY_DIAMOND} = Pact Slot")
+                                  f"{constants.FILLED_BUBBLE_ALT} / {constants.EMPTY_BUBBLE_ALT} = Pact Slot")
         else:
             embed.set_footer(text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used")
 

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -18,6 +18,7 @@ from cogs5e.models.errors import ConsumableException, InvalidArgument, NoSelecti
 from cogs5e.utils import checkutils, gameutils, targetutils
 from cogs5e.utils.help_constants import *
 from gamedata.lookuputils import get_spell_choices, select_spell_full
+from utils import constants
 from utils.argparser import argparse
 from utils.functions import confirm, maybe_mod, search, search_and_select, try_delete
 
@@ -70,7 +71,7 @@ class GameTrack(commands.Cog):
                 return await ctx.send("Invalid spell level.")
         character: Character = await Character.from_ctx(ctx)
         embed = EmbedWithCharacter(character)
-        embed.set_footer(text="\u25c9 = Available / \u3007 = Used")
+
         if level is None and value is None:  # show remaining
             embed.description = f"__**Remaining Spell Slots**__\n{character.spellbook.slots_str()}"
         elif value is None:
@@ -83,6 +84,14 @@ class GameTrack(commands.Cog):
             await character.commit(ctx)
             embed.description = f"__**Remaining Level {level} Spell Slots**__\n" \
                                 f"{character.spellbook.slots_str(level)} ({(value - old_slots):+})"
+
+        # footer - pact vs non pact
+        if character.spellbook.max_pact_slots is not None:
+            embed.set_footer(text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used\n"
+                                  f"{constants.FILLED_DIAMOND} / {constants.EMPTY_DIAMOND} = Pact Slot")
+        else:
+            embed.set_footer(text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used")
+
         await ctx.send(embed=embed)
 
     async def _rest(self, ctx, rest_type, *args):

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -535,8 +535,12 @@ class Character(StatBlock):
             level: min(v, self.spellbook.get_max_slots(level))
             for level, v in old_character.spellbook.slots.items()
         }
-        if old_character.spellbook.num_pact_slots is not None:
-            self.spellbook.num_pact_slots = min(self.spellbook.max_pact_slots, old_character.spellbook.num_pact_slots)
+        if self.spellbook.num_pact_slots is not None:
+            self.spellbook.num_pact_slots = min(
+                old_character.spellbook.num_pact_slots or 0,  # pact slots before update
+                self.spellbook.max_pact_slots,  # cannot have more then max
+                self.spellbook.get_slots(self.spellbook.pact_slot_level)  # cannot gain slots out of nowhere
+            )
 
         if (self.owner, self.upstream) in Character._cache:
             Character._cache[self.owner, self.upstream] = self

--- a/cogs5e/models/sheet/spellcasting.py
+++ b/cogs5e/models/sheet/spellcasting.py
@@ -1,4 +1,5 @@
 from cogs5e.models.errors import CounterOutOfBounds, InvalidSpellLevel
+from utils import constants
 from utils.functions import bubble_format
 
 
@@ -40,26 +41,42 @@ class Spellbook:
         return any(spell_name.lower() == s.name.lower() for s in self.spells)
 
     # ===== display helpers =====
+    def _slots_str_minimal(self, level: int):
+        """Returns the slot level string if there are slots of this level, otherwise empty string."""
+        assert 0 < level < 10
+        _max = self.get_max_slots(level)
+        remaining = self.get_slots(level)
+
+        if level == self.pact_slot_level and _max:
+            max_non_pact = _max - self.max_pact_slots
+            remaining_non_pact = remaining - self.num_pact_slots
+            nonpact_slot_bubbles = bubble_format(remaining_non_pact, max_non_pact)
+            pact_slot_bubbles = bubble_format(
+                self.num_pact_slots, self.max_pact_slots,
+                used_char=constants.EMPTY_DIAMOND, unused_char=constants.FILLED_DIAMOND
+            )
+            return f"`{level}` {nonpact_slot_bubbles}{pact_slot_bubbles}"
+
+        return f"`{level}` {bubble_format(remaining, _max)}" if _max else ''
+
     def slots_str(self, level: int = None):
         """
         :param int level: The level of spell slot to return.
         :returns: A string representing the caster's remaining spell slots.
         """
-        out = ''
-        if level:
-            assert 0 < level < 10
-            _max = self.get_max_slots(level)
-            remaining = self.get_slots(level)
-            out += f"`{level}` {bubble_format(remaining, _max)}\n"
-        else:
-            for level in range(1, 10):
-                _max = self.get_max_slots(level)
-                remaining = self.get_slots(level)
-                if _max:
-                    out += f"`{level}` {bubble_format(remaining, _max)}\n"
+        if level is None:
+            return self.all_slots_str()
+        return self._slots_str_minimal(level) or "No spell slots."
+
+    def all_slots_str(self):
+        """Returns a string representing all of the character's spell slots."""
+        out = []
+        for level in range(1, 10):
+            if level_str := self._slots_str_minimal(level):
+                out.append(level_str)
         if not out:
-            out = "No spell slots."
-        return out.strip()
+            return "No spell slots."
+        return '\n'.join(out)
 
     # ===== utils =====
     def get_slots(self, level):

--- a/cogs5e/models/sheet/spellcasting.py
+++ b/cogs5e/models/sheet/spellcasting.py
@@ -53,7 +53,7 @@ class Spellbook:
             nonpact_slot_bubbles = bubble_format(remaining_non_pact, max_non_pact)
             pact_slot_bubbles = bubble_format(
                 self.num_pact_slots, self.max_pact_slots,
-                used_char=constants.EMPTY_DIAMOND, unused_char=constants.FILLED_DIAMOND
+                used_char=constants.EMPTY_BUBBLE_ALT, unused_char=constants.FILLED_BUBBLE_ALT
             )
             return f"`{level}` {nonpact_slot_bubbles}{pact_slot_bubbles}"
 

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -134,7 +134,7 @@ class BeyondSheetParser(SheetLoaderABC):
                     raise ExternalImportError(f"Beyond returned an error: {resp.status} - {resp.reason}")
         character['_id'] = char_id
         self.character_data = character
-        self._is_live = ddb_user.user_id == str(character['ownerId'])
+        self._is_live = (ddb_user is not None) and (ddb_user.user_id == str(character['ownerId']))
         log.debug(character)
         return character
 

--- a/cogsmisc/tutorials/spellcasting.py
+++ b/cogsmisc/tutorials/spellcasting.py
@@ -153,10 +153,10 @@ class Spellcasting(Tutorial):
             warlock_info = ""
             try:
                 character = await ctx.get_character()
-                if (warlock_level := character.levels.get("Warlock")) and warlock_level == character.levels.total_level:
+                if warlock_level := character.levels.get("Warlock"):
                     if character.sheet_type == 'beyond':
-                        warlock_info = "Since you're a Warlock, your spell slots will reset on a Short Rest, too!"
-                    else:
+                        warlock_info = "Since you're a Warlock, your pact slots will reset on a Short Rest, too!"
+                    elif warlock_level == character.levels.total_level:
                         warlock_info = f"By the way, since you're a Warlock, you can also set your spell slots to recover on a Short Rest with `{ctx.prefix}csettings srslots true`."
             except NoCharacter:
                 pass

--- a/gamedata/spell.py
+++ b/gamedata/spell.py
@@ -183,17 +183,17 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
                 embed.title = "Cannot cast spell!"
                 if not caster.spellbook.get_slots(l):
                     # out of spell slots
-                    err = f"You don't have enough level {l} slots left! Use `-l <level>` to cast at a different level, " \
-                          f"`{ctx.prefix}g lr` to take a long rest, or `-i` to ignore spell slots!"
+                    err = (f"You don't have enough level {l} slots left! Use `-l <level>` to cast at a different "
+                           f"level, `{ctx.prefix}g lr` to take a long rest, or `-i` to ignore spell slots!")
                 elif self.name not in caster.spellbook:
                     # don't know spell
-                    err = f"You don't know this spell! Use `{ctx.prefix}sb add {self.name}` to add it to your spellbook, " \
-                          f"or pass `-i` to ignore restrictions."
+                    err = (f"You don't know this spell! Use `{ctx.prefix}sb add {self.name}` to add it to your "
+                           f"spellbook, or pass `-i` to ignore restrictions.")
                 else:
                     # ?
-                    err = "Not enough spell slots remaining, or spell not in known spell list!\n" \
-                          f"Use `{ctx.prefix}game longrest` to restore all spell slots if this is a character, " \
-                          f"or pass `-i` to ignore restrictions."
+                    err = ("Not enough spell slots remaining, or spell not in known spell list!\n"
+                           f"Use `{ctx.prefix}game longrest` to restore all spell slots if this is a character, "
+                           f"or pass `-i` to ignore restrictions.")
                 embed.description = err
                 if l > 0:
                     embed.add_field(name="Spell Slots", value=caster.spellbook.remaining_casts_of(self, l))
@@ -201,8 +201,11 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
 
             # #1000: is this spell prepared (soft check)?
             if not is_prepared:
-                skip_prep_conf = await confirm(ctx, "This spell is not prepared. Do you want to cast it anyway?",
-                                               delete_msgs=True)
+                skip_prep_conf = await confirm(
+                    ctx,
+                    f"{self.name} is not prepared. Do you want to cast it anyway? (Reply with yes/no)",
+                    delete_msgs=True
+                )
                 if not skip_prep_conf:
                     embed = EmbedWithAuthor(
                         ctx, title=f"Cannot cast spell!",

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -31,3 +31,8 @@ SKILL_MAP = {'acrobatics': 'dexterity', 'animalHandling': 'wisdom', 'arcana': 'i
 # ---- emojis, icons, other discord things ----
 DDB_LOGO_EMOJI = '<:beyond:783780183559372890>'
 DDB_LOGO_ICON = 'https://cdn.discordapp.com/emojis/783780183559372890.png?v=1'
+EMPTY_BUBBLE = '\u3007'
+FILLED_BUBBLE = '\u25c9'
+# pact slots
+EMPTY_DIAMOND = '\u25c7'
+FILLED_DIAMOND = '\u25c8'

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -34,5 +34,5 @@ DDB_LOGO_ICON = 'https://cdn.discordapp.com/emojis/783780183559372890.png?v=1'
 EMPTY_BUBBLE = '\u3007'
 FILLED_BUBBLE = '\u25c9'
 # pact slots
-EMPTY_DIAMOND = '\u25c7'
-FILLED_DIAMOND = '\u25c8'
+EMPTY_BUBBLE_ALT = '\u25a2'
+FILLED_BUBBLE_ALT = '\u25a3'

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -286,14 +286,15 @@ def camel_to_title(string):
     return re.sub(r'((?<=[a-z])[A-Z]|(?<!\A)[A-Z](?=[a-z]))', r' \1', string).title()
 
 
-def bubble_format(value: int, max_: int, fill_from_right=False):
+def bubble_format(value: int, max_: int, fill_from_right=False, used_char=constants.EMPTY_BUBBLE,
+                  unused_char=constants.FILLED_BUBBLE):
     """Returns a bubble string to represent a counter's value."""
     if max_ > 100:
         return f"{value}/{max_}"
 
     used = max_ - value
-    filled = '\u25c9' * value
-    empty = '\u3007' * used
+    filled = unused_char * value
+    empty = used_char * used
     if fill_from_right:
         return f"{empty}{filled}"
     return f"{filled}{empty}"


### PR DESCRIPTION
### Summary
- Updates the hint in the Spellcasting tutorial to show even if the caster is not a full Warlock
- Displays pact slots differently from non-pact slots
- Refactors the character used for bubble display to a constant
- Fixes an issue where DDB import would fail if the user had no account linked
- Fixes ghost slots appearing on the first update that grants pact slots

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
