### PR TITLE
Do not sort keys

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -590,7 +590,8 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         """
         Serializes an object to a YAML string. See `yaml.safe_dump <https://pyyaml.org/wiki/PyYAMLDocumentation>`_.
         """
-        return yaml.dump(obj, Dumper=self._yaml_dumper, default_flow_style=False, line_break=True, indent=indent)
+        return yaml.dump(obj, Dumper=self._yaml_dumper, default_flow_style=False, line_break=True, indent=indent,
+                        sort_keys=False)
 
     # ==== json ====
     def _json_decoder(self):

--- a/tests/aliasing/evaluators_test.py
+++ b/tests/aliasing/evaluators_test.py
@@ -83,13 +83,13 @@ async def test_yaml_dumping(draconic_evaluator):
     draconic_evaluator.eval(
         'data = {"name": "Dice", "age": "old", "languages": 3, "drinks": ["beer", "wine", "apple juice"]}')
     expected_data = textwrap.dedent("""
+    name: Dice
     age: old
+    languages: 3
     drinks:
     - beer
     - wine
     - apple juice
-    languages: 3
-    name: Dice
     """).strip()
 
     result = draconic_evaluator.eval("dump_yaml(data)")


### PR DESCRIPTION
### Summary
Added the `sort_keys=False` kwarg in the `yaml.dump` method to prevent the ordering of the yaml string to break.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
