### PR TITLE
Fixed typo in `!roll` help string

### DIFF
--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -80,7 +80,7 @@ class Dice(commands.Cog):
         `!r 2d20kl1-2` - Disadvantage roll, using Keep Lowest format
         `!r 4d6mi2[fire]` - Elemental Adept, Fire
         `!r 10d6ra6` - Wild Magic Sorcerer Spell Bombardment
-        `!r 4d6ro<3` - Great Weapon Master
+        `!r 4d6ro<3` - Great Weapon Fighting
         `!r 2d6e6` - Explode on 6
         `!r (1d6,1d8,1d10)kh2` - Keep 2 highest rolls of a set of dice
 


### PR DESCRIPTION
### Summary
`!roll` help mentions Great Weapon Master (the feat) instead of Great Weapon Fighting (the fighting style)
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
