### PR TITLE
Nightly: Settings Menu DM Roles

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -277,14 +277,16 @@ class Lookup(commands.Cog):
         __Valid Arguments__
         -h - Shows the obfuscated stat block, even if you can see the full stat block.
         """
-        guild_settings = await ctx.get_server_settings()
-        pm = guild_settings.lookup_pm_result
-        pm_dm = guild_settings.lookup_pm_dm
-        req_dm_monster = guild_settings.lookup_dm_required
-
-        if req_dm_monster and ctx.guild:
-            visible = guild_settings.is_dm(ctx.author)
+        if ctx.guild is not None:
+            guild_settings = await ctx.get_server_settings()
+            pm = guild_settings.lookup_pm_result
+            pm_dm = guild_settings.lookup_pm_dm
+            req_dm_monster = guild_settings.lookup_dm_required
+            visible = (not req_dm_monster) or guild_settings.is_dm(ctx.author)
         else:
+            pm = False
+            pm_dm = False
+            req_dm_monster = False
             visible = True
 
         # #817 -h arg for monster lookup

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -270,19 +270,20 @@ class Lookup(commands.Cog):
     # ==== monsters ====
     @commands.command()
     async def monster(self, ctx, *, name: str):
-        """Looks up a monster.
-        Generally requires a Game Master role to show full stat block.
-        Game Master Roles: GM, DM, Game Master, Dungeon Master
+        """
+        Looks up a monster.
+        If you are not a Dungeon Master, this command may display partially hidden information. See !servsettings
+        to view which roles on a server count as Dungeon Master roles.
         __Valid Arguments__
-        -h - Shows the obfuscated stat block, even if you can see the full stat block."""
+        -h - Shows the obfuscated stat block, even if you can see the full stat block.
+        """
         guild_settings = await ctx.get_server_settings()
         pm = guild_settings.lookup_pm_result
         pm_dm = guild_settings.lookup_pm_dm
         req_dm_monster = guild_settings.lookup_dm_required
 
-        visible_roles = {'gm', 'game master', 'dm', 'dungeon master'}
         if req_dm_monster and ctx.guild:
-            visible = True if visible_roles.intersection(set(str(r).lower() for r in ctx.author.roles)) else False
+            visible = guild_settings.is_dm(ctx.author)
         else:
             visible = True
 

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -194,8 +194,8 @@ class Tutorials(commands.Cog):
                   f"all for free! To get started, try out the D&D Beyond tutorial."
                   f"```\n{prefix}tutorial beyond\n```\n"
                   f"\u203b By default, for servers with less than 250 members, a monster's full stat block will be "
-                  f"hidden unless you have a Discord role named `Dungeon Master`. You can turn this off with "
-                  f"`{prefix}lookup_settings -req_dm_monster false`."
+                  f"hidden unless you have a Discord role named `Dungeon Master`. You can turn this off or change the "
+                  f"DM role with `{prefix}servsettings`."
         )
 
         embed.add_field(

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -158,8 +158,6 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
                 await input_msg.delete()
         except (ValueError, asyncio.TimeoutError, pydantic.ValidationError):
             await interaction.send("No valid color found. Press `Select Color` to try again.", ephemeral=True)
-        except disnake.HTTPException:
-            pass
         else:
             await self.commit_settings()
             await interaction.send("Your embed color has been updated.", ephemeral=True)

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -1,6 +1,5 @@
 import abc
 import asyncio
-import re
 from contextlib import suppress
 from typing import List, Optional, TYPE_CHECKING, TypeVar
 


### PR DESCRIPTION
### Summary
- Adds the ability for server admins to select which roles count as a DM for monster lookups and init management
- Fixes an issue where !monster would error in PMs

Merging into nightly

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
