### PR TITLE
Parse automation YAMLs in CritterDB descriptions

### DIFF
--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -85,6 +85,9 @@ class Homebrew(commands.Cog):
 
         If your attacks don't seem to be importing properly, you can add a hidden line to the description to set it:
         `<avrae hidden>NAME|TOHITBONUS|DAMAGE</avrae>`
+
+        For more complex automation, you can create an attack on the Avrae Dashboard and copy the exported YAML into the CritterDB attack description as follows:
+        `<avrae hidden>YAML</avrae>`
         """
 
         # ex: https://critterdb.com//#/publishedbestiary/view/5acb0aa187653a455731b890

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -373,7 +373,7 @@ def parse_critterdb_traits(data, key):
                     for a in conflicts:
                         attacks.remove(a)
                     attacks.extend(attack_yaml)
-                except Exception:
+                except yaml.YAMLError:
                     simple_override = AVRAE_ATTACK_OVERRIDES_SIMPLE_RE.fullmatch(override.group(1))
                     if simple_override:
                         attacks.append({'name': simple_override.group(1) or name,

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -392,7 +392,7 @@ def parse_critterdb_traits(data, key):
                             atk['name'] = atk_name = atk.get('name') or name
                             try:
                                 attacks.append(Attack.from_dict(atk))
-                            except KeyError:
+                            except Exception:
                                 raise ExternalImportError(
                                     f"An automation YAML contained an invalid attack ({data['name']}: {atk_name})")
                         else:

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -369,11 +369,13 @@ def parse_critterdb_traits(data, key):
                     attack_yaml = yaml.safe_load(override.group(1))
                     if not isinstance(attack_yaml, list):
                         attack_yaml = [attack_yaml]
+                    if not all(isinstance(x, dict) for x in attack_yaml):
+                        raise ValueError('Invalid YAML')
                     conflicts = [a for a in attacks if a['name'].lower() in [new['name'].lower() for new in attack_yaml]]
                     for a in conflicts:
                         attacks.remove(a)
                     attacks.extend(attack_yaml)
-                except yaml.YAMLError:
+                except (yaml.YAMLError, ValueError, KeyError):
                     simple_override = AVRAE_ATTACK_OVERRIDES_SIMPLE_RE.fullmatch(override.group(1))
                     if simple_override:
                         attacks.append({'name': simple_override.group(1) or name,

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -373,16 +373,12 @@ def parse_critterdb_traits(data, key):
                     for a in conflicts:
                         attacks.remove(a)
                     attacks.extend(attack_yaml)
-                except Exception as err:
+                except Exception:
                     simple_override = AVRAE_ATTACK_OVERRIDES_SIMPLE_RE.fullmatch(override.group(1))
                     if simple_override:
                         attacks.append({'name': simple_override.group(1) or name,
                                         'attackBonus': simple_override.group(2) or None, 'damage': simple_override.group(3) or None,
                                         'details': desc})
-                    else:
-                        attacks.append({'name': 'Error',
-                                        'attackBonus': None, 'damage': None,
-                                        'details': str(err) + '\n' + str(attack_yaml)})
         elif raw_atks:
             for atk in raw_atks:
                 if atk.group(6) and atk.group(7):  # versatile

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -503,7 +503,7 @@ def parse_critterdb_spellcasting(traits, base_stats):
             extracted = extract_spells(type_will_spells.group("spells"))
             will_spells.extend(s.name for s in extracted)
 
-        for type_daily_spells in re.finditer(r"(?P<times>\d+)/day: (?P<spells>.+)$", desc, re.MULTILINE):
+        for type_daily_spells in re.finditer(r"(?P<times>\d+)/day(?: each)?: (?P<spells>.+)$", desc, re.MULTILINE):
             extracted = extract_spells(type_daily_spells.group("spells"))
             times_per_day = int(type_daily_spells.group("times"))
             for ts in extracted:

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import re
 from math import floor
+from copy import deepcopy
 
 import aiohttp
 from markdownify import markdownify
@@ -10,7 +11,7 @@ import yaml
 
 import gamedata.compendium as gd
 from cogs5e.models.errors import ExternalImportError, NoActiveBrew
-from cogs5e.models.sheet.attack import AttackList
+from cogs5e.models.sheet.attack import AttackList, Attack
 from cogs5e.models.sheet.base import BaseStats, Saves, Skills
 from cogs5e.models.sheet.resistance import Resistances
 from cogs5e.models.sheet.spellcasting import SpellbookSpell
@@ -382,8 +383,9 @@ def parse_critterdb_traits(data, key):
                             raise ValueError('Invalid YAML')
                         elif 'name' not in atk:
                             atk['name'] = name
+                        Attack.from_dict(deepcopy(atk))
                     attacks.extend(attack_yaml)
-                except (yaml.YAMLError, ValueError):
+                except (yaml.YAMLError, ValueError, KeyError):
                     simple_override = AVRAE_ATTACK_OVERRIDES_SIMPLE_RE.fullmatch(override.group(1))
                     if simple_override:
                         attacks.append({'name': simple_override.group(1) or name,


### PR DESCRIPTION
### Summary
Allows Avrae to parse YAMLs within `<avrae hidden></avrae>` tags in CritterDB action descriptions. Old override patterns still work too.

It appears to work but I am new to this so would appreciate more experienced people checking/improving the code.

I prepared a test monster with one attack that isn't overridden, one that's overridden using the old format, one that's overridden with a JSON and one that's overridden with a YAML.
https://critterdb.com/#/publishedbestiary/view/61ab7827e6e6ad7f5718c354

FR got 16 upvotes but I don't think it's still open. https://discord.com/channels/269275778867396608/834514549356625960/834970483148587048

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
