### PR TITLE
Settings Menu Fixes / DM Role Select

### DIFF
--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -166,11 +166,13 @@ class Dice(commands.Cog):
         await ctx.send(f"{ctx.author.mention}\n{out}", allowed_mentions=discord.AllowedMentions(users=[ctx.author]))
         await Stats.increase_stat(ctx, "dice_rolled_life")
 
-    @commands.group(name='monattack', aliases=['ma', 'monster_attack'], invoke_without_command=True, help=f"""
+    @commands.group(
+        name='monattack', aliases=['ma', 'monster_attack'], invoke_without_command=True, help=f"""
     Rolls a monster's attack.
     __**Valid Arguments**__
     {VALID_AUTOMATION_ARGS}
-    """)
+    """
+    )
     async def monster_atk(self, ctx, monster_name, atk_name=None, *, args=''):
         if atk_name is None or atk_name == 'list':
             return await self.monster_atk_list(ctx, monster_name)
@@ -204,10 +206,12 @@ class Dice(commands.Cog):
         monster = await select_monster_full(ctx, monster_name)
         await actionutils.send_action_list(ctx, caster=monster, attacks=monster.attacks)
 
-    @commands.command(name='moncheck', aliases=['mc', 'monster_check'], help=f"""
+    @commands.command(
+        name='moncheck', aliases=['mc', 'monster_check'], help=f"""
     Rolls a check for a monster.
     {VALID_CHECK_ARGS}
-    """)
+    """
+    )
     async def monster_check(self, ctx, monster_name, check, *args):
         monster: Monster = await select_monster_full(ctx, monster_name)
 
@@ -230,10 +234,12 @@ class Dice(commands.Cog):
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
 
-    @commands.command(name='monsave', aliases=['ms', 'monster_save'], help=f"""
+    @commands.command(
+        name='monsave', aliases=['ms', 'monster_save'], help=f"""
     Rolls a save for a monster.
     {VALID_SAVE_ARGS}
-    """)
+    """
+    )
     async def monster_save(self, ctx, monster_name, save_stat, *args):
         monster: Monster = await select_monster_full(ctx, monster_name)
 
@@ -254,13 +260,15 @@ class Dice(commands.Cog):
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
 
-    @commands.command(name='moncast', aliases=['mcast', 'monster_cast'], help=f"""
+    @commands.command(
+        name='moncast', aliases=['mcast', 'monster_cast'], help=f"""
     Casts a spell as a monster.
     __**Valid Arguments**__
     {VALID_SPELLCASTING_ARGS}
     
     {VALID_AUTOMATION_ARGS}
-    """)
+    """
+    )
     async def monster_cast(self, ctx, monster_name, spell_name, *args):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
@@ -273,8 +281,10 @@ class Dice(commands.Cog):
             try:
                 spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.name in monster.spellbook)
             except NoSelectionElements:
-                return await ctx.send(f"No matching spells found in the creature's spellbook. Cast again "
-                                      f"with the `-i` argument to ignore restrictions!")
+                return await ctx.send(
+                    f"No matching spells found in the creature's spellbook. Cast again "
+                    f"with the `-i` argument to ignore restrictions!"
+                )
         else:
             spell = await select_spell_full(ctx, spell_name)
 
@@ -317,7 +327,8 @@ class Dice(commands.Cog):
         if not await self.bot.ldclient.variation(
                 "cog.dice.inline_rolling.enabled",
                 user=discord_user_to_dict(message.author),
-                default=False):
+                default=False
+        ):
             return
 
         if message.guild is not None:  # (always enabled in pms)
@@ -361,7 +372,8 @@ class Dice(commands.Cog):
         if not await self.bot.ldclient.variation(
                 "cog.dice.inline_rolling.enabled",
                 user=discord_user_to_dict(message.author),
-                default=False):
+                default=False
+        ):
             return
 
         # if inline rolling is not set to reactions, skip

--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -521,7 +521,9 @@ def _find_inline_exprs(content, context_before=5, context_after=2, max_context_l
     if len(after_bits) > context_after:
         last_after_end_idx -= len(after_bits[-1])
         discarded_after = True
-    last_after_end_idx = min(last_after_end_idx, max_context_len)
+    if last_after_end_idx > max_context_len:
+        last_after_end_idx = max_context_len
+        discarded_after = True
     trimmed_segments.append(last_after[0:last_after_end_idx])
     # we also use whether or not the chopped-off bits at the very start and end exist for ellipses
 

--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -397,15 +397,14 @@ class Dice(commands.Cog):
 
             try:
                 result = roller.roll(expr, allow_comments=True)
-            except d20.RollSyntaxError:
-                continue
-            except d20.RollError as e:
-                out.append(f"{context_before}({e!s}){context_after}")
-            else:
                 if not result.comment:
                     out.append(f"{context_before}({result.result}){context_after}")
                 else:
                     out.append(f"**{result.comment}**: {result.result}")
+            except d20.RollSyntaxError:
+                continue
+            except d20.RollError as e:
+                out.append(f"{context_before}({e!s}){context_after}")
 
         if not out:
             return

--- a/cogs5e/dice.py
+++ b/cogs5e/dice.py
@@ -502,7 +502,7 @@ def _find_inline_exprs(content, context_before=5, context_after=2, max_context_l
         after_bits = text.split(maxsplit=context_after)
         if len(after_bits) > context_after:
             last_after_end_idx -= len(after_bits[-1])
-        last_after_end_idx = min(last_after_end_idx, before_idx)
+        last_after_end_idx = min(last_after_end_idx, before_idx, max_context_len)
         last_after = text[0:last_after_end_idx]
 
         trimmed_segments.extend((last_after, before, expr))
@@ -521,6 +521,7 @@ def _find_inline_exprs(content, context_before=5, context_after=2, max_context_l
     if len(after_bits) > context_after:
         last_after_end_idx -= len(after_bits[-1])
         discarded_after = True
+    last_after_end_idx = min(last_after_end_idx, max_context_len)
     trimmed_segments.append(last_after[0:last_after_end_idx])
     # we also use whether or not the chopped-off bits at the very start and end exist for ellipses
 

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -16,8 +16,8 @@ from cogs5e.models.embeds import EmbedWithAuthor, add_fields_from_long_text, set
 from cogsmisc.stats import Stats
 from gamedata.compendium import compendium
 from gamedata.klass import ClassFeature
-from gamedata.lookuputils import HOMEBREW_EMOJI, available, can_access, get_item_choices, get_monster_choices, \
-    get_spell_choices, handle_source_footer
+from gamedata.lookuputils import (HOMEBREW_EMOJI, available, can_access, get_item_choices, get_monster_choices,
+    get_spell_choices, handle_source_footer)
 from gamedata.race import RaceFeature
 from utils import checks, img
 from utils.argparser import argparse
@@ -42,8 +42,10 @@ class Lookup(commands.Cog):
                             f"a certain type.\nCategories: {categories}"
 
         for actiontype in compendium.rule_references:
-            embed.add_field(name=actiontype['fullName'], value=', '.join(a['name'] for a in actiontype['items']),
-                            inline=False)
+            embed.add_field(
+                name=actiontype['fullName'], value=', '.join(a['name'] for a in actiontype['items']),
+                inline=False
+            )
 
         await destination.send(embed=embed)
 
@@ -117,7 +119,8 @@ class Lookup(commands.Cog):
         result: RaceFeature = await self._lookup_search3(
             ctx,
             {'race': compendium.rfeats, 'subrace': compendium.subrfeats},
-            name, 'racefeat')
+            name, 'racefeat'
+        )
 
         embed = EmbedWithAuthor(ctx)
         embed.title = result.name
@@ -133,7 +136,8 @@ class Lookup(commands.Cog):
         result: gamedata.Race = await self._lookup_search3(
             ctx,
             {'race': compendium.races, 'subrace': compendium.subraces},
-            name, 'race')
+            name, 'race'
+        )
 
         embed = EmbedWithAuthor(ctx)
         embed.title = result.name
@@ -152,7 +156,8 @@ class Lookup(commands.Cog):
         result: ClassFeature = await self._lookup_search3(
             ctx,
             {'class': compendium.cfeats, 'class-feature': compendium.optional_cfeats},
-            name, query_type='classfeat')
+            name, query_type='classfeat'
+        )
 
         embed = EmbedWithAuthor(ctx)
         embed.title = result.name
@@ -197,8 +202,10 @@ class Lookup(commands.Cog):
             embed.add_field(name="Starting Proficiencies", value=result.proficiencies, inline=False)
             embed.add_field(name="Starting Equipment", value=result.equipment, inline=False)
 
-            handle_source_footer(embed, result, f"Use {ctx.prefix}classfeat to look up a feature.",
-                                 add_source_str=False)
+            handle_source_footer(
+                embed, result, f"Use {ctx.prefix}classfeat to look up a feature.",
+                add_source_str=False
+            )
         else:
             embed.title = f"{result.name}, Level {level}"
 
@@ -211,16 +218,20 @@ class Lookup(commands.Cog):
             for f in level_features:
                 embed.add_field(name=f.name, value=trim_str(f.text, 1024), inline=False)
 
-            handle_source_footer(embed, result, f"Use {ctx.prefix}classfeat to look up a feature if it is cut off.",
-                                 add_source_str=False)
+            handle_source_footer(
+                embed, result, f"Use {ctx.prefix}classfeat to look up a feature if it is cut off.",
+                add_source_str=False
+            )
 
         await (await self._get_destination(ctx)).send(embed=embed)
 
     @commands.command()
     async def subclass(self, ctx, *, name: str):
         """Looks up a subclass."""
-        result: gamedata.Subclass = await self._lookup_search3(ctx, {'class': compendium.subclasses}, name,
-                                                               query_type='subclass')
+        result: gamedata.Subclass = await self._lookup_search3(
+            ctx, {'class': compendium.subclasses}, name,
+            query_type='subclass'
+        )
 
         embed = EmbedWithAuthor(ctx)
         embed.url = result.url
@@ -232,8 +243,10 @@ class Lookup(commands.Cog):
                 text = trim_str(feature.text, 1024)
                 embed.add_field(name=feature.name, value=text, inline=False)
 
-        handle_source_footer(embed, result, f"Use {ctx.prefix}classfeat to look up a feature if it is cut off.",
-                             add_source_str=False)
+        handle_source_footer(
+            embed, result, f"Use {ctx.prefix}classfeat to look up a feature if it is cut off.",
+            add_source_str=False
+        )
 
         await (await self._get_destination(ctx)).send(embed=embed)
 
@@ -648,14 +661,17 @@ class Lookup(commands.Cog):
 
         result, metadata = await search_and_select(
             ctx, choices, query, lambda e: e[0].name, return_metadata=True,
-            selectkey=selectkey)
+            selectkey=selectkey
+        )
 
         # get the entity
         entity, entity_entitlement_type = result
 
         # log the query
-        await self._add_training_data(query_type, query, entity.name, metadata=metadata, srd=entity.is_free,
-                                      could_view=can_access(entity, available_ids[entity_entitlement_type]))
+        await self._add_training_data(
+            query_type, query, entity.name, metadata=metadata, srd=entity.is_free,
+            could_view=can_access(entity, available_ids[entity_entitlement_type])
+        )
 
         # display error if not srd
         if not can_access(entity, available_ids[entity_entitlement_type]):
@@ -667,7 +683,7 @@ class Lookup(commands.Cog):
     async def on_guild_join(self, guild):
         # This method automatically allows full monster lookup for new large servers.
         # These settings can be changed by any server admin.
-        existing_guild_settings = await self.bot.mdb.guild_settings.find_one({"guild_id": guild.id})
+        existing_guild_settings = await utils.settings.ServerSettings.for_guild(self.bot.mdb, guild.id)
         if existing_guild_settings is not None:
             return
 

--- a/tests/cogs5e/dice_test.py
+++ b/tests/cogs5e/dice_test.py
@@ -136,7 +136,7 @@ async def test_inline_rolling_reaction(avrae, dhttp, mock_ldclient):
             avrae.message("[[1d20]]")
             await dhttp.receive_reaction('\N{game die}')
             # first time interaction
-            # await dhttp.receive_message(dm=True)
+            await dhttp.receive_message(dm=True)
 
             avrae.add_reaction('\N{game die}')
             await dhttp.receive_message(rf'\({D20_PATTERN}\)')

--- a/tests/cogs5e/dice_test.py
+++ b/tests/cogs5e/dice_test.py
@@ -2,7 +2,9 @@ import discord
 import pytest
 
 from gamedata.compendium import compendium
-from tests.utils import ATTACK_PATTERN, D20_PATTERN, DAMAGE_PATTERN, TO_HIT_PATTERN, requires_data
+from tests.utils import (ATTACK_PATTERN, D20_PATTERN, DAMAGE_PATTERN, TO_HIT_PATTERN, requires_data,
+    server_settings)
+from utils.settings.guild import InlineRollingType
 
 pytestmark = pytest.mark.asyncio
 
@@ -41,8 +43,10 @@ async def test_ma(avrae, dhttp):
 
     avrae.message("!ma kobold dagger -h")
     await dhttp.receive_delete()
-    await dhttp.receive_message(f"An unknown creature attacks with a Dagger!\n"
-                                f"{TO_HIT_PATTERN}\n({DAMAGE_PATTERN}\n)?\*Melee Weapon Attack:.+", dm=True)
+    await dhttp.receive_message(
+        f"An unknown creature attacks with a Dagger!\n"
+        f"{TO_HIT_PATTERN}\n({DAMAGE_PATTERN}\n)?\*Melee Weapon Attack:.+", dm=True
+    )
     atk_embed = discord.Embed(title="An unknown creature attacks with a Dagger!")
     atk_embed.add_field(name="Meta", inline=False, value=ATTACK_PATTERN)
     await dhttp.receive_message(embed=atk_embed)
@@ -53,13 +57,21 @@ async def test_mc(avrae, dhttp):
     dhttp.clear()
 
     avrae.message("!mc kobold acro")
-    await dhttp.receive_message(embed=discord.Embed(title="A Kobold makes an Acrobatics check!",
-                                                    description=D20_PATTERN))
+    await dhttp.receive_message(
+        embed=discord.Embed(
+            title="A Kobold makes an Acrobatics check!",
+            description=D20_PATTERN
+        )
+    )
     await dhttp.receive_delete()
 
     avrae.message("!mc kobold acro -h")
-    await dhttp.receive_message(embed=discord.Embed(title="An unknown creature makes an Acrobatics check!",
-                                                    description=D20_PATTERN))
+    await dhttp.receive_message(
+        embed=discord.Embed(
+            title="An unknown creature makes an Acrobatics check!",
+            description=D20_PATTERN
+        )
+    )
     await dhttp.receive_delete()
 
 
@@ -68,13 +80,21 @@ async def test_ms(avrae, dhttp):
     dhttp.clear()
 
     avrae.message("!ms kobold dex")
-    await dhttp.receive_message(embed=discord.Embed(title="A Kobold makes a Dexterity Save!",
-                                                    description=D20_PATTERN))
+    await dhttp.receive_message(
+        embed=discord.Embed(
+            title="A Kobold makes a Dexterity Save!",
+            description=D20_PATTERN
+        )
+    )
     await dhttp.receive_delete()
 
     avrae.message("!ms kobold dex -h")
-    await dhttp.receive_message(embed=discord.Embed(title="An unknown creature makes a Dexterity Save!",
-                                                    description=D20_PATTERN))
+    await dhttp.receive_message(
+        embed=discord.Embed(
+            title="An unknown creature makes a Dexterity Save!",
+            description=D20_PATTERN
+        )
+    )
     await dhttp.receive_delete()
 
 
@@ -100,6 +120,38 @@ async def test_multiroll(avrae, dhttp):
     avrae.message("!rr 10 1d20")
     await dhttp.receive_delete()
     await dhttp.receive_message(rf"<@!?\d+>\nRolling 10 iterations...\n({D20_PATTERN}\n){{10}}\d+ total.")
+
+
+async def test_inline_rolling_disabled(avrae, dhttp, mock_ldclient):
+    # set correct server settings and feature flags
+    async with server_settings(avrae, inline_enabled=InlineRollingType.DISABLED):
+        with mock_ldclient.flags({'cog.dice.inline_rolling.enabled': True}):
+            avrae.message("[[1d20]]")
+            assert dhttp.queue_empty()
+
+
+async def test_inline_rolling_reaction(avrae, dhttp, mock_ldclient):
+    async with server_settings(avrae, inline_enabled=InlineRollingType.REACTION):
+        with mock_ldclient.flags({'cog.dice.inline_rolling.enabled': True}):
+            avrae.message("[[1d20]]")
+            await dhttp.receive_reaction('\N{game die}')
+            # first time interaction
+            # await dhttp.receive_message(dm=True)
+
+            avrae.add_reaction('\N{game die}')
+            await dhttp.receive_message(rf'\({D20_PATTERN}\)')
+
+
+async def test_inline_rolling_enabled(avrae, dhttp, mock_ldclient):
+    async with server_settings(avrae, inline_enabled=InlineRollingType.ENABLED):
+        with mock_ldclient.flags({'cog.dice.inline_rolling.enabled': True}):
+            avrae.message("[[1d20]]")
+            # first time interaction
+            await dhttp.receive_message(dm=True)
+            await dhttp.receive_message(rf'\({D20_PATTERN}\)')
+
+            avrae.message("one two [[1d20]] three four five")
+            await dhttp.receive_message(rf'one two \({D20_PATTERN}\) three four\.\.\.')
 
 
 async def test_roll(avrae, dhttp):

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -299,11 +299,14 @@ class _GameplaySettingsUI(CharacterSettingsMenuBase):
                   f"will be treated as a 10 if it rolls 9 or lower.*",
             inline=False
         )
+        sr_slot_note = ""
+        if self.character.spellbook.max_pact_slots is not None:
+            sr_slot_note = " Note that your pact slots will reset on a short rest even if this setting is disabled."
         embed.add_field(
             name="Reset All Spell Slots on Short Rest",
             value=f"**{self.settings.srslots}**\n"
                   f"*If this is enabled, all of your spell slots (including non-pact slots) will reset on a short "
-                  f"rest. Note that pact slots will reset on a short rest even if this setting is disabled.*",
+                  f"rest.{sr_slot_note}*",
             inline=False
         )
         return {"embed": embed}

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -158,11 +158,12 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
             await interaction.send("No valid color found. Press `Select Color` to try again.", ephemeral=True)
         except disnake.HTTPException:
             pass
+        else:
+            await self.commit_settings()
+            await interaction.send("Your embed color has been updated.", ephemeral=True)
         finally:
             button.disabled = False
-            await self.commit_settings()
             await self.refresh_content(interaction)
-            await interaction.send("Your embed color has been updated.", ephemeral=True)
 
     @disnake.ui.button(label='Reset Color', style=disnake.ButtonStyle.danger)
     async def reset_color(self, _: disnake.ui.Button, interaction: disnake.Interaction):

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+from contextlib import suppress
 from typing import TYPE_CHECKING, TypeVar
 
 import disnake
@@ -148,12 +149,13 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
         try:
             input_msg: disnake.Message = await self.bot.wait_for(
                 'message', timeout=60,
-                check=lambda msg: msg.author == interaction.author and msg.channel == interaction.channel
+                check=lambda msg: msg.author == interaction.author and msg.channel.id == interaction.channel_id
             )
             color_val = pydantic.color.Color(input_msg.content)
             r, g, b = color_val.as_rgb_tuple(alpha=False)
             self.settings.color = (r << 16) + (g << 8) + b
-            await input_msg.delete()
+            with suppress(disnake.HTTPException):
+                await input_msg.delete()
         except (ValueError, asyncio.TimeoutError, pydantic.ValidationError):
             await interaction.send("No valid color found. Press `Select Color` to try again.", ephemeral=True)
         except disnake.HTTPException:

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -34,7 +34,10 @@ class MenuBase(disnake.ui.View):
     async def on_timeout(self):
         if self.message is None:
             return
-        await self.message.edit(view=None)
+        try:
+            await self.message.edit(view=None)
+        except disnake.HTTPException:
+            pass
 
     # ==== content ====
     async def get_content(self) -> Mapping:


### PR DESCRIPTION
### Summary
- Fixes an issue where certain RollErrors (e.g. divide by zero) would not output an error in inline rolling
- Improves the csettings color selector behaviour on an invalid color
- Only displays csettings pact slots note if character actually has pact slots
- Fixes an issue where the last context in an inline roll would not trim if it was over 128 characters
- Fixes an issue where the csettings color selector would not work in DMs
- Fixes an issue where `!monster` would not work in DMs
- Added the ability to choose DM roles through the servsettings menu

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
