### PR TITLE
feat(sheetManager): add deleteAfter to character switch

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -365,9 +365,12 @@ class SheetManager(commands.Cog):
         result = await char.set_active(ctx)
         await try_delete(ctx.message)
         if result.did_unset_server_active:
-            await ctx.send(f"Active character changed to {char.name}. Your server active character has been unset.")
+            await ctx.send(
+                f"Active character changed to {char.name}. Your server active character has been unset.",
+                delete_after=30
+            )
         else:
-            await ctx.send(f"Active character changed to {char.name}.")
+            await ctx.send(f"Active character changed to {char.name}.", delete_after=15)
 
     @character.command(name='server')
     @commands.guild_only()


### PR DESCRIPTION
### Summary

Makes it so `!char <name>` deletes the message after 15s (30s if active server character is unset)

This does not affect `!char server` messages.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
