### PR TITLE
Add the option to disable campaign CTA in server settings

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -704,8 +704,11 @@ async def send_ddb_ctas(ctx, character):
     gamelog_flag = await ctx.bot.ldclient.variation('cog.gamelog.cta.enabled', ld_dict, False)
 
     # get server settings for whether to pull up campaign settings
-    guild_settings = await ctx.get_server_settings()
-    show_campaign_cta = guild_settings.show_campaign_cta
+    if ctx.guild is not None:
+        guild_settings = await ctx.get_server_settings()
+        show_campaign_cta = guild_settings.show_campaign_cta
+    else:
+        show_campaign_cta = False
 
     # has the user seen this cta within the last 7d?
     if await ctx.bot.rdb.get(f"cog.sheetmanager.cta.seen.{ctx.author.id}"):

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -736,8 +736,8 @@ async def send_ddb_ctas(ctx, character):
                 name="Link Your D&D Beyond Campaign",
                 value=f"Sync rolls between a Discord channel and your D&D Beyond character sheet by linking your "
                       f"campaign! Use `{ctx.prefix}campaign https://www.dndbeyond.com/campaigns/"
-                      f"{character.ddb_campaign_id}` in the Discord channel you want to link it to."
-                      f"This message can be disabled in {ctx.prefix}server_settings.",
+                      f"{character.ddb_campaign_id}` in the Discord channel you want to link it to.\n"
+                      f"This message can be disabled in `{ctx.prefix}server_settings`.",
                 inline=False
             )
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -733,7 +733,8 @@ async def send_ddb_ctas(ctx, character):
                 name="Link Your D&D Beyond Campaign",
                 value=f"Sync rolls between a Discord channel and your D&D Beyond character sheet by linking your "
                       f"campaign! Use `{ctx.prefix}campaign https://www.dndbeyond.com/campaigns/"
-                      f"{character.ddb_campaign_id}` in the Discord channel you want to link it to.",
+                      f"{character.ddb_campaign_id}` in the Discord channel you want to link it to."
+                      f"This message can be disabled in {ctx.prefix}server_settings.",
                 inline=False
             )
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -703,6 +703,10 @@ async def send_ddb_ctas(ctx, character):
         ld_dict = {"key": str(ctx.author.id), "anonymous": True}
     gamelog_flag = await ctx.bot.ldclient.variation('cog.gamelog.cta.enabled', ld_dict, False)
 
+    # get server settings for whether to pull up campaign settings
+    guild_settings = await ctx.get_server_settings()
+    show_campaign_cta = guild_settings.show_campaign_cta
+
     # has the user seen this cta within the last 7d?
     if await ctx.bot.rdb.get(f"cog.sheetmanager.cta.seen.{ctx.author.id}"):
         return
@@ -721,7 +725,7 @@ async def send_ddb_ctas(ctx, character):
             inline=False
         )
     # game log
-    if character.ddb_campaign_id and gamelog_flag:
+    if character.ddb_campaign_id and gamelog_flag and show_campaign_cta:
         try:
             await CampaignLink.from_id(ctx.bot.mdb, character.ddb_campaign_id)
         except NoCampaignLink:

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -315,7 +315,6 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         embed = disnake.Embed(
             title=f"Server Settings ({self.guild.name}) / Miscellaneous Settings",
             colour=disnake.Colour.blurple(),
-            description="These settings affect less significant parts of Avrae."
         )
         embed.add_field(
             name="Show DDB Campaign Message",

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -301,7 +301,7 @@ class _InlineRollingSettingsUI(ServerSettingsMenuBase):
 class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
     # ==== ui ====
     @disnake.ui.button(label='Toggle DDB Campaign Message', style=disnake.ButtonStyle.primary, row=1)
-    async def toggle_campaign_cts(self, _: disnake.ui.Button, interaction: disnake.Interaction):
+    async def toggle_campaign_cta(self, _: disnake.ui.Button, interaction: disnake.Interaction):
         self.settings.show_campaign_cta = not self.settings.show_campaign_cta
         await self.commit_settings()
         await self.refresh_content(interaction)

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -63,6 +63,10 @@ class ServerSettingsUI(ServerSettingsMenuBase):
     async def inline_rolling_settings(self, _: disnake.ui.Button, interaction: disnake.Interaction):
         await self.defer_to(_InlineRollingSettingsUI, interaction)
 
+    @disnake.ui.button(label='Miscellaneous Settings', style=disnake.ButtonStyle.primary)
+    async def miscellaneous_settings(self, _: disnake.ui.Button, interaction: disnake.Interaction):
+        await self.defer_to(_MiscellaneousSettingsUI, interaction)
+
     @disnake.ui.button(label='Exit', style=disnake.ButtonStyle.danger)
     async def exit(self, *_):
         await self.on_timeout()
@@ -87,6 +91,11 @@ class ServerSettingsUI(ServerSettingsMenuBase):
         embed.add_field(
             name="Inline Rolling Settings",
             value=await self.get_inline_rolling_desc(),
+            inline=False
+        )
+        embed.add_field(
+            name="Miscellaneous Settings",
+            value=f"**Show DDB Campaign Message**: {self.settings.show_campaign_cta}",
             inline=False
         )
         return {"embed": embed}
@@ -286,5 +295,33 @@ class _InlineRollingSettingsUI(ServerSettingsMenuBase):
             title=f"Server Settings ({self.guild.name}) / Inline Rolling Settings",
             colour=disnake.Colour.blurple(),
             description=await self.get_inline_rolling_desc()
+        )
+        return {"embed": embed}
+
+class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
+    # ==== ui ====
+    @disnake.ui.button(label='Toggle DDB Campaign Message', style=disnake.ButtonStyle.primary, row=1)
+    async def toggle_campaign_cts(self, _: disnake.ui.Button, interaction: disnake.Interaction):
+        self.settings.show_campaign_cta = not self.settings.show_campaign_cta
+        await self.commit_settings()
+        await self.refresh_content(interaction)
+
+    @disnake.ui.button(label='Back', style=disnake.ButtonStyle.grey, row=4)
+    async def back(self, _: disnake.ui.Button, interaction: disnake.Interaction):
+        await self.defer_to(ServerSettingsUI, interaction)
+
+    # ==== content ====
+    async def get_content(self):
+        embed = disnake.Embed(
+            title=f"Server Settings ({self.guild.name}) / Miscellaneous Settings",
+            colour=disnake.Colour.blurple(),
+            description="These settings affect less significant parts of Avrae."
+        )
+        embed.add_field(
+            name="Show DDB Campaign Message",
+            value=f"**{self.settings.show_campaign_cta}**\n"
+                  f"*If this is enabled, every week a reminder about D&D Beyond's Campaign integration "
+                  f"will be shown after a character updates.*",
+            inline=False
         )
         return {"embed": embed}

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -298,6 +298,7 @@ class _InlineRollingSettingsUI(ServerSettingsMenuBase):
         )
         return {"embed": embed}
 
+
 class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
     # ==== ui ====
     @disnake.ui.button(label='Toggle DDB Campaign Message', style=disnake.ButtonStyle.primary, row=1)
@@ -319,7 +320,8 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         embed.add_field(
             name="Show DDB Campaign Message",
             value=f"**{self.settings.show_campaign_cta}**\n"
-                  f"*If this is enabled, you will receive occasional reminders to link your D&D Beyond campaign when you import a character in an unlinked campaign.*",
+                  f"*If this is enabled, you will receive occasional reminders to link your D&D Beyond campaign when "
+                  f"you import a character in an unlinked campaign.*",
             inline=False
         )
         return {"embed": embed}

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -319,8 +319,7 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         embed.add_field(
             name="Show DDB Campaign Message",
             value=f"**{self.settings.show_campaign_cta}**\n"
-                  f"*If this is enabled, every week a reminder about D&D Beyond's Campaign integration "
-                  f"will be shown after a character updates.*",
+                  f"*If this is enabled, you will receive occasional reminders to link your D&D Beyond campaign when you import a character in an unlinked campaign.*",
             inline=False
         )
         return {"embed": embed}

--- a/utils/settings/guild.py
+++ b/utils/settings/guild.py
@@ -21,6 +21,7 @@ class ServerSettings(SettingsBaseModel):
     lookup_pm_dm: bool = False
     lookup_pm_result: bool = False
     inline_enabled: InlineRollingType = InlineRollingType.DISABLED
+    show_campaign_cta: bool = True
 
     # ==== lifecycle ====
     @classmethod


### PR DESCRIPTION
### Summary
Added a new server setting to check to toggle the campaign CTA that appears when you import or update a character, as well as making the necessary checks in send_ddb_ctas()

### Checklist

#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.

 Changes to be committed:
	modified:   cogs5e/sheetManager.py
	modified:   ui/servsettings.py
	modified:   utils/settings/guild.py