### PR TITLE
Reset monster daily spells like leveled slots

### DIFF
--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -390,11 +390,6 @@ class MonsterSpellbook(Spellbook):
         })
         return d
 
-    def reset_slots(self):
-        super().reset_slots()
-        for spell, max in self.daily_max.items():
-            self.daily[spell] = max
-
     # ===== utils =====
     def slots_str(self, level: int = None):
         if level is not None:
@@ -454,3 +449,8 @@ class MonsterCastableSpellbook(MonsterSpellbook):
                 raise CounterOutOfBounds(f"You do not have any remaining casts of {spell.name}.")
         else:
             self.use_slot(level, pact=pact)
+
+    def reset_slots(self):
+        super().reset_slots()
+        for spell, max in self.daily_max.items():
+            self.daily[spell] = max

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -390,6 +390,11 @@ class MonsterSpellbook(Spellbook):
         })
         return d
 
+    def reset_slots(self):
+        super().reset_slots()
+        for spell, max in self.daily_max.items():
+            self.daily[spell] = max
+
     # ===== utils =====
     def slots_str(self, level: int = None):
         if level is not None:


### PR DESCRIPTION
### Summary
This change resets a monster's daily spells when `.reset_slots()` is called.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
