### PR TITLE
Fix bestiary spellcasting not catching "1 slot"

### DIFF
--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -491,7 +491,7 @@ def parse_critterdb_spellcasting(traits, base_stats):
 
         for type_leveled_spells in re.finditer(
                 r"(?:"
-                r"(?:(?P<level>\d)[stndrh]{2}\slevel \((?P<slots>\d+) slots\))"
+                r"(?:(?P<level>\d)[stndrh]{2}\slevel \((?P<slots>\d+) slots?\))"
                 r"|(?:Cantrip \(at will\))): "
                 r"(?P<spells>.+)$",
                 desc, re.MULTILINE):


### PR DESCRIPTION
Thanks to Croebh, you too can shamelessly get +1 commit on the graph.

### Summary
With the regex as it stands, it would only catch slot descriptions that are plural, such as "2 slots" or "3 slots", but it would ignore the singular form "1 slot". This fixes it by making the trailing `s` optional.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
