### PR TITLE
2022w05

### DIFF
--- a/cogs5e/models/automation/effects/castspell.py
+++ b/cogs5e/models/automation/effects/castspell.py
@@ -7,8 +7,10 @@ from ..results import CastSpellResult
 
 
 class CastSpell(Effect):
-    def __init__(self, id: int, level: int = None, dc: str = None, attackBonus: str = None, castingMod: str = None,
-                 **kwargs):
+    def __init__(
+        self, id: int, level: int = None, dc: str = None, attackBonus: str = None, castingMod: str = None,
+        **kwargs
+    ):
         super().__init__("spell", **kwargs)
         self.id = id
         self.level = level
@@ -18,8 +20,12 @@ class CastSpell(Effect):
 
     def to_dict(self):
         out = super().to_dict()
-        out.update({"id": self.id, "level": self.level, "dc": self.dc, "attackBonus": self.attack_bonus,
-                    "castingMod": self.casting_mod})
+        out.update(
+            {
+                "id": self.id, "level": self.level, "dc": self.dc, "attackBonus": self.attack_bonus,
+                "castingMod": self.casting_mod
+            }
+        )
         return out
 
     async def preflight(self, autoctx):
@@ -72,10 +78,17 @@ class CastSpell(Effect):
             autoctx.evaluator.builtins['spell'] = old_spell_override
             autoctx.spell_level_override = old_level_override
             autoctx.spell = None
-        else:  # copied from Spell.cast
+
+            # display higher level info
+            if cast_level != spell.level and spell.higherlevels:
+                autoctx.effect_queue(f"**At Higher Levels**: {smart_trim(spell.higherlevels)}")
+        else:
+            # copied from Spell.cast
             results = []
             autoctx.queue(smart_trim(spell.description))
             autoctx.push_embed_field(title=spell.name)
+
+            # display higher level info
             if cast_level != spell.level and spell.higherlevels:
                 autoctx.queue(smart_trim(spell.higherlevels))
                 autoctx.push_embed_field(title="At Higher Levels")

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -94,10 +94,7 @@ class Damage(Effect):
         if in_crit:
             dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)
             if critdice and not autoctx.is_spell:
-                # add X critdice to the leftmost node if it's dice
-                left = d20.utils.leftmost(dice_ast)
-                if isinstance(left, d20.ast.Dice):
-                    left.num += int(critdice)
+                utils.critdice_tree_update(dice_ast, int(critdice))
 
         # -c #
         if in_crit:

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import d20
 import draconic
 
@@ -42,10 +44,10 @@ def upcast_scaled_dice(effect, autoctx, dice_ast):
     return dice_ast
 
 
-def mi_mapper(minimum):
+def mi_mapper(minimum: int) -> Callable[[d20.ast.Node], d20.ast.Node]:
     """Returns a function that maps Dice AST objects to OperatedDice with miX attached."""
 
-    def mapper(node):
+    def mapper(node: d20.ast.Node):
         if isinstance(node, d20.ast.Dice):
             miX = d20.ast.SetOperator('mi', [d20.ast.SetSelector(None, int(minimum))])
             return d20.ast.OperatedDice(node, miX)
@@ -54,7 +56,7 @@ def mi_mapper(minimum):
     return mapper
 
 
-def max_mapper(node):
+def max_mapper(node: d20.ast.Node):
     """A function that maps Dice AST objects to OperatedDice that set their values to their maximum."""
     if isinstance(node, d20.ast.Dice):
         miX = d20.ast.SetOperator('mi', [d20.ast.SetSelector(None, node.size)])
@@ -62,11 +64,33 @@ def max_mapper(node):
     return node
 
 
-def crit_mapper(node):
+def crit_mapper(node: d20.ast.Node):
     """A function that doubles the number of dice for each Dice AST node."""
     if isinstance(node, d20.ast.Dice):
         return d20.ast.Dice(node.num * 2, node.size)
     return node
+
+
+def critdice_tree_update(dice_ast: d20.ast.Node, critdice: int):
+    """
+    Modifies the AST by adding *critdice* dice to any leftmost Dice, branching recursively on any Set.
+
+    .. note::
+        This mutates the AST, so it should be copied before calling to avoid mutating the cached AST.
+    """
+    left = dice_ast
+    while left.children:
+        # if we encounter a set going down the left branch, branch and run recursively on all children
+        if isinstance(left, d20.ast.NumberSet):
+            for child in left.children:
+                critdice_tree_update(child, critdice)
+            return
+        # otherwise continue down the left branch
+        left = left.children[0]
+
+    # if we're at the bottom of the branch and it's the dice, add *critdice*
+    if isinstance(left, d20.ast.Dice):
+        left.num += critdice
 
 
 def stringify_intexpr(evaluator, expr):

--- a/gamedata/spell.py
+++ b/gamedata/spell.py
@@ -271,9 +271,10 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
             if phrase:
                 embed.description = f"*{phrase}*"
             embed.add_field(name="Description", value=smart_trim(self.description), inline=False)
-            if l != self.level and self.higherlevels:
-                embed.add_field(name="At Higher Levels", value=smart_trim(self.higherlevels), inline=False)
             embed.set_footer(text="No spell automation found.")
+
+        if l != self.level and self.higherlevels:
+            embed.add_field(name="At Higher Levels", value=smart_trim(self.higherlevels), inline=False)
 
         if l > 0 and not i:
             embed.add_field(name="Spell Slots", value=caster.spellbook.remaining_casts_of(self, l))


### PR DESCRIPTION
### Summary
- Display a spell's "At Higher Levels" section when cast at a higher level through `!cast` or a `CastSpell` automation node
- Fixes an issue where the `critdice` csetting would not add additional crit dice to any dice nodes beyond the first in a Set node, even if the Set node was the main weapon dice (e.g. `(1d8, 1d8)kh1+5` on a crit with critdice 1 should become `(3d8, 3d8)kh1+5`, not `(3d8,2d8)kh1+5`)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
