### PR TITLE
Only unsubscribe from Bestiary on successful import

### DIFF
--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -129,17 +129,19 @@ class Homebrew(commands.Cog):
         loading = await ctx.send("Updating bestiary (this may take a while for large bestiaries)...")
 
         old_server_subs = await active_bestiary.server_subscriptions(ctx)
-        await active_bestiary.unsubscribe(ctx)
         bestiary = await Bestiary.from_critterdb(ctx, active_bestiary.upstream, active_bestiary.published)
 
-        await bestiary.add_server_subscriptions(ctx, old_server_subs)
-        await bestiary.set_active(ctx)
-        await bestiary.load_monsters(ctx)
-        await loading.edit(content=f"Imported and updated {bestiary.name}!")
-        embed = HomebrewEmbedWithAuthor(ctx)
-        embed.title = bestiary.name
-        embed.description = '\n'.join(m.name for m in bestiary.monsters)
-        await ctx.send(embed=embed)
+        if bestiary:
+            await active_bestiary.unsubscribe(ctx)
+
+            await bestiary.add_server_subscriptions(ctx, old_server_subs)
+            await bestiary.set_active(ctx)
+            await bestiary.load_monsters(ctx)
+            await loading.edit(content=f"Imported and updated {bestiary.name}!")
+            embed = HomebrewEmbedWithAuthor(ctx)
+            embed.title = bestiary.name
+            embed.description = '\n'.join(m.name for m in bestiary.monsters)
+            await ctx.send(embed=embed)
 
     @bestiary.group(name='server', invoke_without_command=True)
     @commands.guild_only()

--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -133,7 +133,6 @@ class Homebrew(commands.Cog):
 
         if bestiary:
             await active_bestiary.unsubscribe(ctx)
-
             await bestiary.add_server_subscriptions(ctx, old_server_subs)
             await bestiary.set_active(ctx)
             await bestiary.load_monsters(ctx)


### PR DESCRIPTION
### Summary
Resolves #1716 

Changes the update code to check for a successful import before unsubscribing from the previous version.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
