### PR TITLE
Add forced rolls as ephemeral arg to attack

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -132,7 +132,7 @@ class Attack(Effect):
             if ac:
                 to_hit_message = f'**To Hit (AC {ac})**:'
             if force_roll:
-                to_hit_message = '**To Hit**: Forced Roll!'
+                to_hit_message = f'{to_hit_message} Forced Roll!'
 
             if b:
                 to_hit_roll = d20.roll(f"{formatted_d20}+{attack_bonus}+{b}")

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -47,6 +47,7 @@ class Attack(Effect):
         reroll = args.last('reroll', 0, int)
         criton = args.last('criton', 20, int)
         ac = args.last('ac', None, int)
+        force_roll = args.last('attackroll', None, int, ephem=True)
 
         # ==== caster options ====
         # character-specific arguments
@@ -116,7 +117,9 @@ class Attack(Effect):
             if reroll:
                 reroll_str = f"ro{reroll}"
 
-            if adv == 1:
+            if force_roll:
+                formatted_d20 = f"{force_roll}"
+            elif adv == 1:
                 formatted_d20 = f'2d20{reroll_str}kh1'
             elif adv == 2:
                 formatted_d20 = f'3d20{reroll_str}kh1'
@@ -125,9 +128,11 @@ class Attack(Effect):
             else:
                 formatted_d20 = f'1d20{reroll_str}'
 
-            to_hit_message = 'To Hit'
+            to_hit_message = '**To Hit**:'
             if ac:
-                to_hit_message = f'To Hit (AC {ac})'
+                to_hit_message = f'**To Hit (AC {ac})**:'
+            if force_roll:
+                to_hit_message = '**To Hit**: Forced Roll!'
 
             if b:
                 to_hit_roll = d20.roll(f"{formatted_d20}+{attack_bonus}+{b}")
@@ -159,7 +164,7 @@ class Attack(Effect):
 
             # output
             if not hide:  # not hidden
-                autoctx.queue(f"**{to_hit_message}**: {to_hit_roll.result}")
+                autoctx.queue(f"{to_hit_message} {to_hit_roll.result}")
             elif target_has_ac:  # hidden
                 if not did_hit:
                     hit_type = 'MISS'
@@ -168,10 +173,10 @@ class Attack(Effect):
                 else:
                     hit_type = 'HIT'
                 autoctx.queue(f"**To Hit**: {formatted_d20}... = `{hit_type}`")
-                autoctx.add_pm(str(autoctx.ctx.author.id), f"**{to_hit_message}**: {to_hit_roll.result}")
+                autoctx.add_pm(str(autoctx.ctx.author.id), f"{to_hit_message} {to_hit_roll.result}")
             else:  # hidden, no ac
                 autoctx.queue(f"**To Hit**: {formatted_d20}... = `{to_hit_roll.total}`")
-                autoctx.add_pm(str(autoctx.ctx.author.id), f"**{to_hit_message}**: {to_hit_roll.result}")
+                autoctx.add_pm(str(autoctx.ctx.author.id), f"{to_hit_message} {to_hit_roll.result}")
 
             if not did_hit:
                 children = self.on_miss(autoctx)

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -58,6 +58,7 @@ An italicized argument below means the argument supports ephemeral arguments - e
 *ea* - Elven Accuracy, double advantage on the attack roll.
 *hit* - The attack automatically hits.
 *miss* - The attack automatically misses.
+*-attackroll <value>* - Force the rolled attack to be a fixed number plus modifiers.
 *crit* - The attack automatically crits.
 -ac <target ac> - Overrides target AC.
 *-b <bonus>* - Adds a bonus to hit.


### PR DESCRIPTION
### Summary
Add Forced Rolls as an ephemeral arg to attack automation.
`-attackroll <value>` will replace the normal d20 part of the roll with a fixed number, keeping all other modifiers.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
