### PR TITLE
Allow setting initial value during cc creation

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -156,9 +156,9 @@ class AliasCharacter(AliasStatBlock):
         :param str dispType: Either ``None`` or ``'bubble'``.
         :param str reset_to: The value the counter should reset to. Supports :ref:`cvar-table` parsing.
         :param str reset_by: How much the counter should change by on a reset. Supports dice but not cvars.
-        :param str initial_value: The initial value of the counter.
         :param str title: The title of the counter.
         :param str desc: The description of the counter.
+        :param str initial_value: The initial value of the counter.
         :rtype: AliasCustomCounter
         :returns: The newly created counter.
         """

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -156,6 +156,7 @@ class AliasCharacter(AliasStatBlock):
         :param str dispType: Either ``None`` or ``'bubble'``.
         :param str reset_to: The value the counter should reset to. Supports :ref:`cvar-table` parsing.
         :param str reset_by: How much the counter should change by on a reset. Supports dice but not cvars.
+        :param str initial_value: The initial value of the counter.
         :param str title: The title of the counter.
         :param str desc: The description of the counter.
         :rtype: AliasCustomCounter

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -109,8 +109,8 @@ class AliasCharacter(AliasStatBlock):
         self._character.consumables.remove(to_delete)
 
     def create_cc_nx(self, name: str, minVal: str = None, maxVal: str = None, reset: str = None,
-                     dispType: str = None, reset_to: str = None, reset_by: str = None, initial_value: str = None,
-                     title: str = None, desc: str = None):
+                     dispType: str = None, reset_to: str = None, reset_by: str = None,
+                     title: str = None, desc: str = None, initial_value: str = None):
         """
         Creates a custom counter if one with the given name does not already exist.
         Equivalent to:
@@ -130,12 +130,12 @@ class AliasCharacter(AliasStatBlock):
             reset_to = str(reset_to)
         if reset_by is not None:
             reset_by = str(reset_by)
-        if initial_value is not None:
-            initial_value = str(initial_value)
         if title is not None:
             title = str(title)
         if desc is not None:
             desc = str(desc)
+        if initial_value is not None:
+            initial_value = str(initial_value)
 
         if not self.cc_exists(name):
             new_consumable = player_api.CustomCounter.new(

--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -109,7 +109,7 @@ class AliasCharacter(AliasStatBlock):
         self._character.consumables.remove(to_delete)
 
     def create_cc_nx(self, name: str, minVal: str = None, maxVal: str = None, reset: str = None,
-                     dispType: str = None, reset_to: str = None, reset_by: str = None,
+                     dispType: str = None, reset_to: str = None, reset_by: str = None, initial_value: str = None,
                      title: str = None, desc: str = None):
         """
         Creates a custom counter if one with the given name does not already exist.
@@ -130,6 +130,8 @@ class AliasCharacter(AliasStatBlock):
             reset_to = str(reset_to)
         if reset_by is not None:
             reset_by = str(reset_by)
+        if initial_value is not None:
+            initial_value = str(initial_value)
         if title is not None:
             title = str(title)
         if desc is not None:
@@ -138,7 +140,7 @@ class AliasCharacter(AliasStatBlock):
         if not self.cc_exists(name):
             new_consumable = player_api.CustomCounter.new(
                 self._character, name, minVal, maxVal, reset, dispType,
-                title=title, desc=desc, reset_to=reset_to, reset_by=reset_by)
+                title=title, desc=desc, reset_to=reset_to, reset_by=reset_by, initial_value=initial_value)
             self._character.consumables.append(new_consumable)
             self._consumables = None  # reset cache
             return AliasCustomCounter(new_consumable)

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -556,6 +556,7 @@ class GameTrack(commands.Cog):
         `-reset <short|long|none>` - Counter will reset to max on a short/long rest, or not ever when "none". Default - will reset on a call of `!cc reset`.
         `-max <max value>` - The maximum value of the counter.
         `-min <min value>` - The minimum value of the counter.
+        `-value <value>` - The initial value for the counter.
         `-type <bubble|default>` - Whether the counter displays bubbles to show remaining uses or numbers. Default - numbers.
         `-resetto <value>` - The value to reset the counter to. Default - maximum.
         `-resetby <value>` - Rather than resetting to a certain value, modify the counter by this much per reset. Supports dice.
@@ -576,12 +577,13 @@ class GameTrack(commands.Cog):
         _type = args.last('type')
         reset_to = args.last('resetto')
         reset_by = args.last('resetby')
+        initial_value = args.last('value')
         title = args.last('title')
         desc = args.last('desc')
         try:
             new_counter = CustomCounter.new(
                 character, name, maxv=_max, minv=_min, reset=_reset, display_type=_type,
-                reset_to=reset_to, reset_by=reset_by, title=title, desc=desc
+                reset_to=reset_to, reset_by=reset_by, initial_value=initial_value, title=title, desc=desc
             )
             character.consumables.append(new_counter)
             await character.commit(ctx)

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -115,7 +115,7 @@ class CustomCounter:
 
     @classmethod
     def new(cls, character, name, minv=None, maxv=None, reset=None, display_type=None, live_id=None,
-            reset_to=None, reset_by=None, title=None, desc=None):
+            reset_to=None, reset_by=None, initial_value=None, title=None, desc=None):
         if reset not in ('short', 'long', 'none', None):
             raise InvalidArgument("Invalid reset.")
         if any(c in name for c in ".$"):
@@ -159,12 +159,13 @@ class CustomCounter:
             except d20.RollSyntaxError:
                 raise InvalidArgument(f"{reset_by} (`resetby`) cannot be interpreted as a number or dice string.")
 
-        # set initial value
-        initial_value = max(0, min_value or 0)
-        if reset_to_value is not None:
-            initial_value = reset_to_value
-        elif max_value is not None:
-            initial_value = max_value
+        # set initial value if not already set
+        if initial_value is None:
+            initial_value = max(0, min_value or 0)
+            if reset_to_value is not None:
+                initial_value = reset_to_value
+            elif max_value is not None:
+                initial_value = max_value
 
         # length checks
         if desc and len(desc) > 1024:

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -166,6 +166,8 @@ class CustomCounter:
                 initial_value = reset_to_value
             elif max_value is not None:
                 initial_value = max_value
+        else:
+            initial_value = character.evaluate_math(initial_value)
 
         # length checks
         if desc and len(desc) > 1024:

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -168,6 +168,11 @@ class CustomCounter:
                 initial_value = max_value
         else:
             initial_value = character.evaluate_math(initial_value)
+            # clamp initial value to min and max
+            if min_value is not None:
+                initial_value = max(initial_value, min_value)
+            if max_value is not None:
+                initial_value = min(initial_value, max_value)
 
         # length checks
         if desc and len(desc) > 1024:

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -115,7 +115,7 @@ class CustomCounter:
 
     @classmethod
     def new(cls, character, name, minv=None, maxv=None, reset=None, display_type=None, live_id=None,
-            reset_to=None, reset_by=None, initial_value=None, title=None, desc=None):
+            reset_to=None, reset_by=None, title=None, desc=None, initial_value=None):
         if reset not in ('short', 'long', 'none', None):
             raise InvalidArgument("Invalid reset.")
         if any(c in name for c in ".$"):


### PR DESCRIPTION
### Summary
Resolves AFR-921 (not on GitHub)

Add an `initial_value` kwarg to `create_cc_nx` and the respective internal object. Also adds the `-value` flag for `!cc create`.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
