### PR TITLE
Ignore more cache directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,7 @@ venv/
 temp/
 tempvenv/
 
-/.cache/
-/.pytest_cache/
+/.*cache/
 
 *.json
 !*.spec.json


### PR DESCRIPTION
### Summary
The `.gitignore` hardcodes 2 cache directories, this changes it to instead filter `/.*cache/`, in order to catch more directories like `/.mypy_cache/`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
