### PR TITLE
tweak(Dockerfile): only use ddtrace-run in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY --chown=avrae:avrae . .
 # Download AWS pubkey to connect to documentDB
 RUN if [ "$ENVIRONMENT" = "production" ]; then wget https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem; fi
 
-ENTRYPOINT .local/bin/ddtrace-run python dbot.py $DBOT_ARGS
+ENTRYPOINT if [ "$ENVIRONMENT" = "production" ]; then .local/bin/ddtrace-run python dbot.py $DBOT_ARGS; else python dbot.py $DBOT_ARGS; fi


### PR DESCRIPTION
### Summary
When iterating on development locally, ddtrace-run is generally unnecessary, as most people would not have DataDog setup, much less for a local clone.

This PR modifies the Dockerfile to only use ddtrace-run when the `ENVIRONMENT` == `production`, removing the errors from DataDog about being unable to connect.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
