### PR TITLE
Datadog/tracing

### DIFF
--- a/cogsmisc/adminUtils.py
+++ b/cogsmisc/adminUtils.py
@@ -65,7 +65,8 @@ class AdminUtils(commands.Cog):
             "whois": self._whois,
             "ping": self._ping,
             "restart_shard": self._restart_shard,
-            "kill_cluster": self._kill_cluster
+            "kill_cluster": self._kill_cluster,
+            "set_dd_sample_rate": self._set_dd_sample_rate
         }
         while True:  # if we ever disconnect from pubsub, wait 5s and try reinitializing
             try:  # connect to the pubsub channel
@@ -229,6 +230,15 @@ class AdminUtils(commands.Cog):
                        f"# {e.entitlement_entity_id=}, {e.entitlement_entity_type=} ({entitlement_entity_name})\n"
                        f"{e!r}\n```")
 
+    @admin.command(hidden=True, name="dd-sample-rate")
+    @checks.is_owner()
+    async def admin_dd_sample_rate(self, ctx, sample_rate: float):
+        """Sets the DataDog sample rate."""
+        if not 0. <= sample_rate <= 1.:
+            return await ctx.send("sample rate must be between 0 and 1")
+        resp = await self.pscall("set_dd_sample_rate", kwargs={"sample_rate": sample_rate})
+        await self._send_replies(ctx, resp)
+
     # ---- cluster management ----
     @admin.command(hidden=True, name="restart-shard")
     @checks.is_owner()
@@ -373,6 +383,19 @@ class AdminUtils(commands.Cog):
 
     async def _ping(self):
         return dict(self.bot.latencies)
+
+    async def _set_dd_sample_rate(self, sample_rate: float):
+        if config.DD_SERVICE is None:
+            return "no DD_SERVICE set, this process is not sampling"
+        import ddtrace.sampler
+        ddtrace.tracer.configure(
+            sampler=ddtrace.sampler.DatadogSampler(
+                rules=[
+                    ddtrace.sampler.SamplingRule(sample_rate=sample_rate)
+                ]
+            )
+        )
+        return f"sample rate set to {sample_rate}"
 
     async def _restart_shard(self, shard_id: int):
         if (shard := self.bot.get_shard(shard_id)) is None:

--- a/dbot.py
+++ b/dbot.py
@@ -218,12 +218,14 @@ bot = Avrae(
     allowed_mentions=discord.AllowedMentions.none(), intents=intents, chunk_guilds_at_startup=False
 )
 
-log_formatter = logging.Formatter('%(levelname)s:%(name)s: %(message)s')
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(log_formatter)
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-logger.addHandler(handler)
+if config.DD_SERVICE is None:
+    # the datadog setup configures the logging its own way, so we don't set it up here so there's no duplicates
+    log_formatter = logging.Formatter('%(levelname)s:%(name)s: %(message)s')
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(log_formatter)
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
 log = logging.getLogger('bot')
 
 

--- a/utils/datadog.py
+++ b/utils/datadog.py
@@ -42,7 +42,8 @@ def _patch_logging():
                '[dd.service=%(dd.service)s dd.env=%(dd.env)s '
                'dd.version=%(dd.version)s '
                'dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]'
-               '- %(message)s'
+               '- %(message)s',
+        level=logging.INFO
     )
 
 

--- a/utils/datadog.py
+++ b/utils/datadog.py
@@ -1,6 +1,7 @@
 import logging
 
 import ddtrace
+import ddtrace.sampler
 from ddtrace.profiling import Profiler
 
 from utils import config
@@ -10,6 +11,13 @@ def do_patches():
     ddtrace.config.env = config.ENVIRONMENT
     ddtrace.config.service = config.DD_SERVICE
     ddtrace.config.version = config.GIT_COMMIT_SHA
+    ddtrace.tracer.configure(
+        sampler=ddtrace.sampler.DatadogSampler(
+            rules=[
+                ddtrace.sampler.SamplingRule(sample_rate=0.01)
+            ]
+        )
+    )
     ddtrace.patch_all(
         logging=True
     )


### PR DESCRIPTION
### Summary
Adds `!admin dd-sample-rate <sample rate>` to change the datadog sample rate during runtime (defaults to 1% on each start).

Also fixes everything logging twice when datadog is enabled.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
