### PR TITLE
feat(argparser): make add_context accept dicts

### DIFF
--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -298,8 +298,21 @@ class ParsedArguments:
 
         :param context: The context to add arguments to.
         :param args: The arguments to add.
-        :type args: :class:`~utils.argparser.ParsedArguments`
+        :type args: :class:`~utils.argparser.ParsedArguments`, or dict[str, list[str]]
         """
+        if isinstance(args, dict):
+            if all(
+                isinstance(k, (collections.UserString, str))
+                and isinstance(v, (collections.UserList, list))
+                and all(isinstance(i, (collections.UserString, str)) for i in v)
+                for k, v in args.items()
+            ):
+                args = ParsedArguments.from_dict(args)
+            else:
+                raise InvalidArgument(f"Argument is not in the format dict[str, list[str]] (in {args})")
+        elif not isinstance(args, ParsedArguments):
+            raise InvalidArgument(f"Argument is not a dict or ParsedArguments (in {args})")
+
         self._contexts[context] = args
 
     # builtins


### PR DESCRIPTION
### Summary
As of currently, to add a context to a ParsedArguments object based on a dict, you would need to create a temporary ParsedArguments object in a way which was harder to read.

This has the `add_context` method internally convert the dictionary into the correct ParsedArguments object without it needing to be done on the user's side.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
