### PR TITLE
Bugfixes for Coinpurse and -attackroll

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -764,7 +764,7 @@ class AliasCoinpurse:
 
     def autoconvert(self):
         """
-        Converts all of your coins into the lowest amount of coins possible.
+        Converts all of your coins into the highest value coins possible.
         100cp turns into 1gp, 5sp turns into 1ep, etc.
         """
         self._coinpurse.consolidate_coins()

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -204,7 +204,7 @@ class GameTrack(commands.Cog):
 
     @game_coinpurse.command(name="convert", aliases=["consolidate"])
     async def game_coinpurse_convert(self, ctx):
-        """Converts all of your coins into the lowest amount of coins possible.
+        """Converts all of your coins into the highest value coins possible.
         100cp turns into 1gp, 5sp turns into 1ep, etc."""
         character: Character = await ctx.get_character()
         deltas = character.coinpurse.consolidate_coins()

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -213,7 +213,7 @@ class GameTrack(commands.Cog):
 
     @game.group(name="hp", invoke_without_command=True)
     async def game_hp(self, ctx, *, hp: str = None):
-        """Modifies the HP of a the current active character."""
+        """Modifies the HP of the current active character."""
         character: Character = await ctx.get_character()
         caster = await targetutils.maybe_combat_caster(ctx, character)
 
@@ -259,7 +259,7 @@ class GameTrack(commands.Cog):
 
     @game.command(name="thp")
     async def game_thp(self, ctx, *, thp: str = None):
-        """Modifies the temp HP of a the current active character.
+        """Modifies the temp HP of the current active character.
         If positive, assumes set; if negative, assumes mod."""
         character: Character = await ctx.get_character()
         caster = await targetutils.maybe_combat_caster(ctx, character)

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -153,7 +153,7 @@ class Attack(Effect):
             # assign hit values
             if d20_value >= criton or to_hit_roll.crit == d20.CritType.CRIT:  # natural crit
                 did_crit = True if not nocrit else False
-            elif to_hit_roll.crit == d20.CritType.FAIL:  # crit fail
+            elif to_hit_roll.crit == d20.CritType.FAIL or force_roll == 1:  # crit fail
                 did_hit = False
             elif ac and to_hit_roll.total < ac:  # miss
                 did_hit = False

--- a/cogs5e/models/sheet/coinpurse.py
+++ b/cogs5e/models/sheet/coinpurse.py
@@ -83,7 +83,7 @@ class Coinpurse(HasIntegrationMixin):
             coins.pp += pp_borrowed
         if self.pp + coins.pp < 0:
             # Still not enough? Convert the total transaction to copper, run again
-            if (self.total + coins.total) > 0:
+            if (self.total + coins.total) >= 0:
                 return self.auto_convert_down(CoinsArgs(cp=int(coins.total * 100)))
             else:
                 raise InvalidArgument("You do not have enough coins to cover this transaction.")

--- a/cogs5e/models/sheet/coinpurse.py
+++ b/cogs5e/models/sheet/coinpurse.py
@@ -82,7 +82,11 @@ class Coinpurse(HasIntegrationMixin):
             coins.gp -= pp_borrowed * 10
             coins.pp += pp_borrowed
         if self.pp + coins.pp < 0:
-            raise InvalidArgument("You do not have enough coins to cover this transaction.")
+            # Still not enough? Convert the total transaction to copper, run again
+            if (self.total + coins.total) > 0:
+                return self.auto_convert_down(CoinsArgs(cp=int(coins.total * 100)))
+            else:
+                raise InvalidArgument("You do not have enough coins to cover this transaction.")
         return coins
 
     def consolidate_coins(self) -> CoinsArgs:

--- a/cogs5e/sheets/dicecloud.py
+++ b/cogs5e/sheets/dicecloud.py
@@ -186,7 +186,7 @@ class DicecloudParser(SheetLoaderABC):
 
         for i in self.character_data.get("items"):
             if re.fullmatch(
-                r"^((plat(inum)?|gold|electrum|silver|copper)( coins?|pieces?)?|(pp|gp|ep|sp|cp))",
+                r"^((plat(inum)?|gold|electrum|silver|copper)( coins?| pieces?)?|(pp|gp|ep|sp|cp))",
                 i["name"],
                 re.IGNORECASE,
             ):

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -18,7 +18,7 @@ from d20 import RollSyntaxError
 from google.auth.transport.requests import Request
 from google.oauth2.service_account import Credentials
 from gspread import SpreadsheetNotFound
-from gspread.exceptions import APIError
+from gspread.exceptions import APIError, WorksheetNotFound
 from gspread.utils import a1_to_rowcol, fill_gaps
 from cogs5e.models.sheet.coinpurse import Coinpurse
 
@@ -342,7 +342,10 @@ class GoogleSheet(SheetLoaderABC):
             self.additional = TempCharacter(doc.worksheet("Additional"))
             self.version = (2, 1) if "2.1" in vcell else (2, 0) if "2" in vcell else (1, 0)
             if self.version >= (2, 1):
-                self.inventory = TempCharacter(doc.worksheet("Inventory"))
+                try:
+                    self.inventory = TempCharacter(doc.worksheet("Inventory"))
+                except WorksheetNotFound:
+                    self.inventory = None
 
     # main loading methods
     async def load_character(self, ctx, args):

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -499,7 +499,10 @@ class GoogleSheet(SheetLoaderABC):
 
         for c_type in COIN_TYPES:
             if self.version >= (2, 1):
-                coin_value = self.inventory.unformatted_value(COIN_TYPES[c_type]["gSheet"]["v2"]) or 0
+                if not self.inventory:  # If they renamed the sheet or deleted it
+                    coin_value = 0
+                else:
+                    coin_value = self.inventory.unformatted_value(COIN_TYPES[c_type]["gSheet"]["v2"]) or 0
             else:
                 coin_value = self.character_data.unformatted_value(COIN_TYPES[c_type]["gSheet"]["v14"]) or 0
             try:
@@ -507,7 +510,7 @@ class GoogleSheet(SheetLoaderABC):
             except ValueError as e:
                 if self.version >= (2, 1):
                     cell = COIN_TYPES[c_type]["gSheet"]["v2"]
-                    sheet = self.inventory.worksheet.title
+                    sheet = "Inventory"
                 else:
                     cell = COIN_TYPES[c_type]["gSheet"]["v14"]
                     sheet = self.character_data.worksheet.title

--- a/cogs5e/utils/gameutils.py
+++ b/cogs5e/utils/gameutils.py
@@ -63,6 +63,9 @@ def parse_coin_args(args: str) -> CoinsArgs:
     Otherwise, allows the user to specify currencies in the form ``/(([+-]?\d+)\s*([pgesc]p)?)+/``
     (e.g. +1gp -2sp 3cp).
     """
+
+    # Remove commas, in the case of `+3,104gp` or `-2,000.05`
+    args = args.replace(",", "")
     try:
         return _parse_coin_args_float(float(args))
     except ValueError:

--- a/cogs5e/utils/gameutils.py
+++ b/cogs5e/utils/gameutils.py
@@ -77,19 +77,13 @@ def _parse_coin_args_float(coins: float) -> CoinsArgs:
     Parses a float into currencies. The input is assumed to be in gp, and any sub-cp values will be truncated.
     """
     # if any sub-copper passed (i.e. 1-thousandth), truncate it
-    total_copper = int(abs(coins * 100))
+    total_copper = int(coins * 100)
 
-    # this floor/mod math gets wonky when dealing with negative numbers (e.g. -2.62 becomes -3gp +3sp +8cp)
-    # so we do all our math in the positives
-    sign = 1 if coins >= 0 else -1
-
-    if sign == -1:
+    if coins < 0:
         # If it's a negative value, remove all the lowest coins first
-        return CoinsArgs(cp=sign * total_copper)
+        return CoinsArgs(cp=total_copper)
     else:
-        return CoinsArgs(
-            gp=sign * (total_copper // 100), sp=sign * ((total_copper % 100) // 10), cp=sign * (total_copper % 10)
-        )
+        return CoinsArgs(gp=total_copper // 100, sp=(total_copper % 100) // 10, cp=total_copper % 10)
 
 
 def _parse_coin_args_re(args: str) -> CoinsArgs:

--- a/cogs5e/utils/gameutils.py
+++ b/cogs5e/utils/gameutils.py
@@ -83,9 +83,13 @@ def _parse_coin_args_float(coins: float) -> CoinsArgs:
     # so we do all our math in the positives
     sign = 1 if coins >= 0 else -1
 
-    return CoinsArgs(
-        gp=sign * (total_copper // 100), sp=sign * ((total_copper % 100) // 10), cp=sign * (total_copper % 10)
-    )
+    if sign == -1:
+        # If it's a negative value, remove all the lowest coins first
+        return CoinsArgs(cp=sign * total_copper)
+    else:
+        return CoinsArgs(
+            gp=sign * (total_copper // 100), sp=sign * ((total_copper % 100) // 10), cp=sign * (total_copper % 10)
+        )
 
 
 def _parse_coin_args_re(args: str) -> CoinsArgs:

--- a/cogs5e/utils/gameutils.py
+++ b/cogs5e/utils/gameutils.py
@@ -138,7 +138,7 @@ async def resolve_strict_coins(coinpurse, coins: CoinsArgs, ctx):
         if coins.explicit and not await confirm(
             ctx,
             "You don't have enough of the chosen coins to complete this transaction"
-            ". Auto convert from larger coins? (Reply with yes/no)",
+            ". Auto convert from other coins? (Reply with yes/no)",
         ):
             raise InvalidArgument("You cannot put a currency into negative numbers.")
         coins = coinpurse.auto_convert_down(coins)

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -1179,6 +1179,18 @@ AliasCoinpurse
 
         :type: int
 
+    .. attribute:: str(AliasCoinpurse)
+
+        Returns a string representation of the entire coinpurse. If the character setting for Compact Coins is enabled, this will only return your float gold, otherwise will return all 5 coin types.
+
+        :type: str
+
+    .. attribute:: AliasCoinpurse[cointype]
+
+        Gets the value of the given coin type.
+
+        :type: int
+
 StatBlock Models
 ----------------
 

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -1169,6 +1169,12 @@ AliasCoinpurse
 .. autoclass:: aliasing.api.character.AliasCoinpurse()
     :members:
 
+    .. attribute:: str(AliasCoinpurse)
+
+        Returns a string representation of the entire coinpurse. If the character setting for Compact Coins is enabled, this will only return your float gold, otherwise will return all 5 coin types.
+
+        :type: str
+
     .. attribute:: pp
         gp
         ep
@@ -1178,12 +1184,6 @@ AliasCoinpurse
         The value of the given coin type.
 
         :type: int
-
-    .. attribute:: str(AliasCoinpurse)
-
-        Returns a string representation of the entire coinpurse. If the character setting for Compact Coins is enabled, this will only return your float gold, otherwise will return all 5 coin types.
-
-        :type: str
 
     .. attribute:: AliasCoinpurse[cointype]
 

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -489,7 +489,7 @@ Draconic Functions
 
 .. autofunction:: aliasing.evaluators.ScriptingEvaluator.uvar_exists(name)
 
-.. autofunction:: aliasing.api.functions.vroll(rollStr, multiply=1, add=0
+.. autofunction:: aliasing.api.functions.vroll(rollStr, multiply=1, add=0)
 
 .. autofunction:: aliasing.api.functions.parse_coins(args: str) -> dict
 

--- a/tests/cogs5e/models/automation/effects_test.py
+++ b/tests/cogs5e/models/automation/effects_test.py
@@ -146,6 +146,7 @@ class TestText:
         avrae.message(
             '!a import {"name":"Text Test","automation":[{"type": "text", "text": {"id": 75, "typeId": 12168134}}],"_v":2}'
         )
+        await dhttp.drain()
         avrae.message('!a "Text Test"')
         await dhttp.drain()
 
@@ -153,6 +154,7 @@ class TestText:
         avrae.message(
             '!a import {"name":"Text Test2","automation":[{"type": "text", "text": {"id": -75, "typeId": 12168134}}],"_v":2}'
         )
+        await dhttp.drain()
         avrae.message('!a "Text Test2"')
         await dhttp.drain()
 
@@ -160,6 +162,7 @@ class TestText:
         avrae.message(
             '!a import {"name":"Text Test3","automation":[{"type": "text", "text": {"id": -9999999, "typeId": 12168134}}],"_v":2}'
         )
+        await dhttp.drain()
         avrae.message('!a "Text Test3"')
         await dhttp.drain()
 

--- a/tests/utiltests/coinpurse_test.py
+++ b/tests/utiltests/coinpurse_test.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.asyncio
 async def test_parse_coin_args():
     assert parse_coin_args("+10") == CoinsArgs(gp=10, explicit=False)
     assert parse_coin_args("+10cp +10gp -8ep") == CoinsArgs(gp=10, ep=-8, cp=10, explicit=True)
-    assert parse_coin_args("-10.47") == CoinsArgs(gp=-10, sp=-4, cp=-7, explicit=False)
+    assert parse_coin_args("-10.47") == CoinsArgs(cp=-1047, explicit=False)
     assert parse_coin_args("+10.388888") == CoinsArgs(gp=10, sp=3, cp=8, explicit=False)
 
 
@@ -37,6 +37,9 @@ async def test_coin_autoconvert_down():
     assert Coinpurse(pp=10, gp=3, cp=1).auto_convert_down(CoinsArgs(cp=-2)) == CoinsArgs(gp=-1, ep=1, sp=4, cp=8)
     with pytest.raises(InvalidArgument):
         Coinpurse(gp=1).auto_convert_down(CoinsArgs(pp=-1, explicit=False))
+    assert Coinpurse(pp=10, gp=10).auto_convert_down(CoinsArgs(pp=-11)) == CoinsArgs(pp=-10, gp=-10)
+    with pytest.raises(InvalidArgument):
+        Coinpurse(pp=10, gp=9).auto_convert_down(CoinsArgs(pp=-11, explicit=False))
 
 
 async def test_coin_autoconvert_up():


### PR DESCRIPTION
### Summary
Fixes a number of issues with the 3.4.0 patch:

- Adds docs for ``AliasCoinpurse[cointype]`` and ``str(AliasCoinpurse)``
- Fix an import error if a Gsheet 2.1 user renamed/deleted their 'Inventory' worksheet
- Reorder the coinpurse api docs slightly
- Slight rewording on the autoconvert help
- Strip comma's out on ``parse_coin_args`` to handle if the user had used digit grouping
- Fixed a minor typo in the helps for ``!game hp`` and ``!game thp`` 
- Make ``-attackroll 1`` count as a critical failure
- Handle the conversion of higher coins to lower when autoconverting
- Fix a race condition in entity reference tests
- Fix a small regex problem with Dicecloud coin import

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
