### PR TITLE
Add minimum attack roll handling arg

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -50,6 +50,7 @@ class Attack(Effect):
         criton = args.last("criton", 20, int)
         ac = args.last("ac", None, int)
         force_roll = args.last("attackroll", None, int, ephem=True)
+        min_attack_roll = args.last("ma", 0, int)
 
         # ==== caster options ====
         # character-specific arguments
@@ -118,6 +119,9 @@ class Attack(Effect):
             reroll_str = ""
             if reroll:
                 reroll_str = f"ro{reroll}"
+            # minimum attack roll (#1742)
+            if min_attack_roll:
+                reroll_str = f"{reroll_str}mi{min_attack_roll}"
 
             if force_roll:
                 formatted_d20 = f"{force_roll}"

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -50,7 +50,7 @@ class Attack(Effect):
         criton = args.last("criton", 20, int)
         ac = args.last("ac", None, int)
         force_roll = args.last("attackroll", None, int, ephem=True)
-        min_attack_roll = args.last("ma", 0, int)
+        min_attack_roll = args.last("attackmin", 0, int)
 
         # ==== caster options ====
         # character-specific arguments

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -57,7 +57,7 @@ An italicized argument below means the argument supports ephemeral arguments - e
 *hit* - The attack automatically hits.
 *miss* - The attack automatically misses.
 *-attackroll <value>* - Force the rolled attack to be a fixed number plus modifiers.
-*-ma <value>* - Minimum value of the rolled attack before modifiers.
+*-attackmin <value>* - Minimum value of the rolled attack before modifiers.
 *crit* - The attack automatically crits.
 -ac <target ac> - Overrides target AC.
 *-b <bonus>* - Adds a bonus to hit.

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -57,6 +57,7 @@ An italicized argument below means the argument supports ephemeral arguments - e
 *hit* - The attack automatically hits.
 *miss* - The attack automatically misses.
 *-attackroll <value>* - Force the rolled attack to be a fixed number plus modifiers.
+*-ma <value>* - Minimum value of the rolled attack before modifiers.
 *crit* - The attack automatically crits.
 -ac <target ac> - Overrides target AC.
 *-b <bonus>* - Adds a bonus to hit.


### PR DESCRIPTION
### Summary
Add minimum attack roll handling arg with `-ma #` to not conflict with `-mi #` damage minimum

Resolves #AFR-891
When combined with #1740

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
