### PR TITLE
Inherent Attack Advantage and lastAttackHadAdvantage metavar

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -104,6 +104,7 @@ class Attack(Effect):
         autoctx.metavars["lastAttackDidCrit"] = False
         autoctx.metavars["lastAttackRollTotal"] = 0  # 1362
         autoctx.metavars["lastAttackNaturalRoll"] = 0  # 1495
+        autoctx.metavars["lastAttackHadAdvantage"] = 0
         did_hit = True
         did_crit = False
         to_hit_roll = None
@@ -163,6 +164,7 @@ class Attack(Effect):
 
             autoctx.metavars["lastAttackRollTotal"] = to_hit_roll.total  # 1362
             autoctx.metavars["lastAttackNaturalRoll"] = d20_value  # 1495
+            autoctx.metavars["lastAttackHadAdvantage"] = adv
 
             # output
             if not hide:  # not hidden

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -255,14 +255,13 @@ class Attack(Effect):
             attack_bonus = stringify_intexpr(evaluator, self.bonus)
 
         out = f"Attack: {attack_bonus:+} to hit"
-        if self.adv:
-            match self.adv:
-                case 1:
-                    out += ", with advantage"
-                case 2:
-                    out += ", with Elven Accuracy"
-                case -1:
-                    out += ", with disdvantage"
+        match self.adv:
+            case 1:
+                out += ", with advantage"
+            case 2:
+                out += ", with Elven Accuracy"
+            case -1:
+                out += ", with disdvantage"
         if self.hit:
             hit_out = self.build_child_str(self.hit, caster, evaluator)
             if hit_out:

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -8,11 +8,12 @@ from ..utils import stringify_intexpr
 
 
 class Attack(Effect):
-    def __init__(self, hit: list, miss: list, attackBonus: str = None, **kwargs):
+    def __init__(self, hit: list, miss: list, attackBonus: str = None, adv: int = None, **kwargs):
         super().__init__("attack", **kwargs)
         self.hit = hit
         self.miss = miss
         self.bonus = attackBonus
+        self.adv = adv
 
     @classmethod
     def from_data(cls, data):
@@ -27,6 +28,8 @@ class Attack(Effect):
         out.update({"hit": hit, "miss": miss})
         if self.bonus is not None:
             out["attackBonus"] = self.bonus
+        if self.adv is not None:
+            out["adv"] = self.adv
         return out
 
     def run(self, autoctx):
@@ -59,6 +62,13 @@ class Attack(Effect):
             if "criton" not in args:
                 criton = autoctx.character.options.crit_on
 
+        # explicit advantage
+        if self.adv:
+            try:
+                self.adv = autoctx.parse_intexpression(self.adv)
+            except Exception:
+                raise AutomationException(f"{self.adv!r} cannot be interpreted as an advantage type.")
+
         # check for combatant IEffects
         if autoctx.combatant:
             # bonus (#224)
@@ -69,12 +79,20 @@ class Attack(Effect):
                 b = effect_b
             # Combine args/ieffect advantages - adv/dis (#1552)
             adv = reconcile_adv(
-                adv=args.last("adv", type_=bool, ephem=True) or autoctx.combatant.active_effects("adv"),
-                dis=args.last("dis", type_=bool, ephem=True) or autoctx.combatant.active_effects("dis"),
-                ea=args.last("ea", type_=bool, ephem=True) or autoctx.combatant.active_effects("ea"),
+                adv=args.last("adv", type_=bool, ephem=True)
+                or autoctx.combatant.active_effects("adv")
+                or self.adv == 1,
+                dis=args.last("dis", type_=bool, ephem=True)
+                or autoctx.combatant.active_effects("dis")
+                or self.adv == -1,
+                ea=args.last("ea", type_=bool, ephem=True) or autoctx.combatant.active_effects("ea") or self.adv == 2,
             )
         else:
-            adv = args.adv(ea=True, ephem=True)
+            adv = reconcile_adv(
+                adv=args.last("adv", type_=bool, ephem=True) or self.adv == 1,
+                dis=args.last("dis", type_=bool, ephem=True) or self.adv == -1,
+                ea=args.last("ea", type_=bool, ephem=True) or self.adv == 2,
+            )
 
         # ==== target options ====
         if autoctx.target.character:
@@ -237,6 +255,14 @@ class Attack(Effect):
             attack_bonus = stringify_intexpr(evaluator, self.bonus)
 
         out = f"Attack: {attack_bonus:+} to hit"
+        if self.adv:
+            match self.adv:
+                case 1:
+                    out += ", with advantage"
+                case 2:
+                    out += ", with Elven Accuracy"
+                case -1:
+                    out += ", with disdvantage"
         if self.hit:
             hit_out = self.build_child_str(self.hit, caster, evaluator)
             if hit_out:

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -63,6 +63,7 @@ Attack
         hit: Effect[];
         miss: Effect[];
         attackBonus?: IntExpression;
+        adv?: IntExpression;
     }
 
 An Attack effect makes an attack roll against a targeted creature.
@@ -80,6 +81,11 @@ It must be inside a Target effect.
 
      *optional* - An IntExpression that details what attack bonus to use (defaults to caster's spell attack mod).
 
+.. attribute:: adv
+
+     *optional* - An IntExpression that details whether the attack has inherent advantage or not. ``0`` for flat, ``1``;
+     for Advantage, ``2`` for Elven Accuracy, ``-1`` for Disadvantage (Default is flat).
+
 **Variables**
 
 - ``lastAttackDidHit`` (:class:`bool`) Whether the attack hit.
@@ -87,6 +93,8 @@ It must be inside a Target effect.
 - ``lastAttackRollTotal`` (:class:`int`) The result of the last to-hit roll (0 if no roll was made).
 - ``lastAttackNaturalRoll`` (:class:`int`) The natural roll of the last to-hit roll (e.g. `10` in `1d20 (10) + 5 = 15`;
   0 if no roll was made).
+- ``lastAttackHadAdvantage`` (:class:`int`) The advantage type of the last to-hit roll. ``0`` for flat, ``1`` for;
+  Advantage, ``2`` for Elven Accuracy, ``-1`` for Disadvantage
 
 Save
 ----


### PR DESCRIPTION
### Summary
This PR adds support for automation attack effects to have inherent advantage, as well as adds a metavar for whether the last attack had advantage or not (``lastAttackHadAdvantage``).

Ties in with https://github.com/avrae/avrae-service/pull/47 and https://github.com/avrae/avrae.io/pull/640

Implements AFR-931

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
