### PR TITLE
2022w11

### DIFF
--- a/cogsmisc/adminUtils.py
+++ b/cogsmisc/adminUtils.py
@@ -32,7 +32,6 @@ class AdminUtils(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        bot.loop.create_task(self.load_admin())
         bot.loop.create_task(self.admin_pubsub())
         self.blacklisted_serv_ids = set()
         self.whitelisted_serv_ids = set()
@@ -42,7 +41,7 @@ class AdminUtils(commands.Cog):
         self._ps_requests_pending = {}
 
     # ==== setup tasks ====
-    async def load_admin(self):
+    async def cog_load(self):
         self.bot.muted = set(await self.bot.rdb.jget("muted", []))
         self.blacklisted_serv_ids = set(await self.bot.rdb.jget("blacklist", []))
         self.whitelisted_serv_ids = set(await self.bot.rdb.jget("server-whitelist", []))

--- a/cogsmisc/core.py
+++ b/cogsmisc/core.py
@@ -177,7 +177,7 @@ class Core(commands.Cog):
             )
             return await ctx.send(embed=embed)
 
-        embed.title = f"Hello, {ddb_user.username}!"
+        embed.title = f"Hello, {ddb_user.display_name}!"
         embed.url = "https://www.dndbeyond.com/account"
         default_desc = (
             f"Thanks for linking your account! We'll reach out to you when the purchases you've made "
@@ -206,6 +206,7 @@ class Core(commands.Cog):
 
         await ctx.send(
             f"```\nD&D Beyond Username: {ddb_user.username}\n"
+            f"Display Name: {ddb_user.display_name}\n"
             f"User ID: {ddb_user.user_id}\n"
             f"Roles: {ddb_user.roles}\n"
             f"Subscriber: {ddb_user.subscriber}\n"

--- a/ddb/auth.py
+++ b/ddb/auth.py
@@ -12,13 +12,23 @@ from utils.config import (
 
 
 class BeyondUser:
-    def __init__(self, token: str, user_id: str, username: str, roles: list, subscriber=None, subscription_tier=None):
+    def __init__(
+        self,
+        token: str,
+        user_id: str,
+        username: str,
+        roles: list,
+        subscriber=None,
+        subscription_tier=None,
+        display_name=None,
+    ):
         self.token = token
         self.user_id = user_id
         self.username = username
         self.roles = roles
         self.subscriber = subscriber
         self.subscription_tier = subscription_tier
+        self.display_name = display_name or username
 
     @classmethod
     def from_jwt(cls, token):
@@ -34,11 +44,12 @@ class BeyondUser:
         )
         return cls(
             token,
-            payload["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"],
-            payload["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"],
-            payload.get("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", []),
-            payload.get("http://schemas.dndbeyond.com/ws/2019/08/identity/claims/subscriber"),
-            payload.get("http://schemas.dndbeyond.com/ws/2019/08/identity/claims/subscriptiontier"),
+            user_id=payload["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"],
+            username=payload["http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"],
+            roles=payload.get("http://schemas.microsoft.com/ws/2008/06/identity/claims/role", []),
+            subscriber=payload.get("http://schemas.dndbeyond.com/ws/2019/08/identity/claims/subscriber"),
+            subscription_tier=payload.get("http://schemas.dndbeyond.com/ws/2019/08/identity/claims/subscriptiontier"),
+            display_name=payload.get("displayName"),
         )
 
     @classmethod
@@ -53,6 +64,7 @@ class BeyondUser:
             "roles": self.roles,
             "subscriber": self.subscriber,
             "subscription_tier": self.subscription_tier,
+            "display_name": self.display_name,
         }
 
     def to_ld_dict(self):


### PR DESCRIPTION
### Summary
- dev: use `cog_load` to load admin cog instead of creating a task in the constructor, which could fail if the loop had not yet initialized
- Add support for the `displayName` attribute in DDB JWTs to display DDB user nicknames instead of usernames
- Expire cached DDB JWTs 1 second early to prevent network latency making us use JWTs that are ~20-100ms expired and causing 403s

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
