### PR TITLE
Add Csetting for Coins Autoconvert

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -197,7 +197,7 @@ class GameTrack(commands.Cog):
             return await gameutils.send_current_coin(ctx, character, args)
 
         coins = gameutils.parse_coin_args(args)
-        deltas = await resolve_strict_coins(character.coinpurse, coins, ctx=ctx)
+        deltas = await resolve_strict_coins(character.coinpurse, coins, ctx, character.options.autoconvert_coins)
         character.coinpurse.update_currency(deltas)
         await character.commit(ctx)
         return await gameutils.send_current_coin(ctx, character, deltas=deltas)

--- a/cogs5e/utils/gameutils.py
+++ b/cogs5e/utils/gameutils.py
@@ -118,9 +118,8 @@ def _parse_coin_args_re(args: str) -> CoinsArgs:
     return out
 
 
-async def resolve_strict_coins(coinpurse, coins: CoinsArgs, ctx):
-    character = await ctx.get_character()
-    convert_mode = character.options.autoconvert_coins
+async def resolve_strict_coins(coinpurse, coins: CoinsArgs, ctx, mode: CoinsAutoConvert = 0):
+
     if (coinpurse.total + coins.total) < 0:
         raise InvalidArgument("You cannot put a currency into negative numbers.")
     if not all(
@@ -132,8 +131,8 @@ async def resolve_strict_coins(coinpurse, coins: CoinsArgs, ctx):
             coinpurse.cp + coins.cp >= 0,
         )
     ):
-        if convert_mode == CoinsAutoConvert.NEVER or (
-            convert_mode == CoinsAutoConvert.ASK
+        if mode == CoinsAutoConvert.NEVER or (
+            mode == CoinsAutoConvert.ASK
             and coins.explicit
             and not await confirm(
                 ctx,

--- a/tests/utiltests/coinpurse_test.py
+++ b/tests/utiltests/coinpurse_test.py
@@ -4,6 +4,7 @@ from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.coinpurse import Coinpurse, CoinsArgs
 from cogs5e.utils.gameutils import parse_coin_args, resolve_strict_coins
 from tests.utils import ContextBotProxy
+from utils.enums import CoinsAutoConvert
 
 pytestmark = pytest.mark.asyncio
 
@@ -28,8 +29,17 @@ async def test_resolve_strict_coins(avrae):
         Coinpurse(pp=1), CoinsArgs(cp=-1, explicit=False), ContextBotProxy(avrae)
     ) == CoinsArgs(pp=-1, gp=9, ep=1, sp=4, cp=9)
 
+    assert await resolve_strict_coins(
+        Coinpurse(pp=1), CoinsArgs(cp=-1, explicit=True), ContextBotProxy(avrae), CoinsAutoConvert.ALWAYS
+    ) == CoinsArgs(pp=-1, gp=9, ep=1, sp=4, cp=9, explicit=True)
+
     with pytest.raises(InvalidArgument):
         await resolve_strict_coins(Coinpurse(gp=1), CoinsArgs(pp=-1, explicit=False), ContextBotProxy(avrae))
+
+    with pytest.raises(InvalidArgument):
+        await resolve_strict_coins(
+            Coinpurse(gp=1), CoinsArgs(cp=-1, explicit=True), ContextBotProxy(avrae), CoinsAutoConvert.NEVER
+        )
 
 
 async def test_coin_autoconvert_down():

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -104,7 +104,8 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
             name="Cosmetic Settings",
             value=f"**Embed Color**: {color_setting_desc(self.settings.color)}\n"
             f"**Show Character Image**: {self.settings.embed_image}\n"
-            f"**Use Compact Coin Display:** {self.settings.compact_coins}",
+            f"**Use Compact Coin Display:** {self.settings.compact_coins}\n"
+            f"**Coin Conversion Mode**: {autoconvert_coins_desc(self.settings.autoconvert_coins)}",
             inline=False,
         )
         embed.add_field(
@@ -127,6 +128,13 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
                 sync_desc_lines.append(f"**Inbound Sync**: {self.settings.sync_inbound}")
             embed.add_field(name="Character Sync Settings", value="\n".join(sync_desc_lines), inline=False)
         return {"embed": embed}
+
+
+_AUTOCONVERT_SELECT_OPTIONS = [
+    disnake.SelectOption(label="Always Ask", value="0"),
+    disnake.SelectOption(label="Always Convert", value="1"),
+    disnake.SelectOption(label="Never Convert", value="-1"),
+]
 
 
 class _CosmeticSettingsUI(CharacterSettingsMenuBase):
@@ -177,7 +185,14 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
         await self.commit_settings()
         await self.refresh_content(interaction)
 
-    @disnake.ui.button(label="Back", style=disnake.ButtonStyle.grey, row=3)
+    @disnake.ui.select(placeholder="Coin Conversion Mode", options=_AUTOCONVERT_SELECT_OPTIONS, row=3)
+    async def autoconvert_select(self, select: disnake.ui.Select, interaction: disnake.Interaction):
+        value = select.values[0]
+        self.settings.autoconvert_coins = int(value)
+        await self.commit_settings()
+        await self.refresh_content(interaction)
+
+    @disnake.ui.button(label="Back", style=disnake.ButtonStyle.grey, row=4)
     async def back(self, _: disnake.ui.Button, interaction: disnake.Interaction):
         await self.defer_to(CharacterSettingsUI, interaction)
 
@@ -203,6 +218,13 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
             name="Compact Coin Display",
             value=f"**{self.settings.compact_coins}**\n"
             f"*If this is enabled, your coins will be displayed in decimal gold format.*",
+            inline=False,
+        )
+        embed.add_field(
+            name="Coin Conversion Mode",
+            value=f"**{autoconvert_coins_desc(self.settings.autoconvert_coins)}**\n"
+            f"*Whether or not it should ask you if you would like to auto-convert your coins if you try so spend "
+            f"more than you currently have.*",
             inline=False,
         )
         return {"embed": embed}
@@ -379,3 +401,7 @@ def color_setting_desc(color):
 
 def crit_range_desc(crit_on):
     return "20" if crit_on == 20 else f"{crit_on}-20"
+
+
+def autoconvert_coins_desc(mode):
+    return "Always Ask" if mode == 0 else "Always Convert" if mode == 1 else "Never Convert"

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -9,6 +9,7 @@ import pydantic.color
 
 from cogs5e.models import embeds
 from cogs5e.models.character import Character
+from utils.enums import CoinsAutoConvert
 from utils.settings import CharacterSettings
 from .menu import MenuBase
 
@@ -131,9 +132,9 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
 
 
 _AUTOCONVERT_SELECT_OPTIONS = [
-    disnake.SelectOption(label="Always Ask", value="0"),
-    disnake.SelectOption(label="Always Convert", value="1"),
-    disnake.SelectOption(label="Never Convert", value="2"),
+    disnake.SelectOption(label="Always Ask", value=str(CoinsAutoConvert.ASK.value)),
+    disnake.SelectOption(label="Always Convert", value=str(CoinsAutoConvert.ALWAYS.value)),
+    disnake.SelectOption(label="Never Convert", value=str(CoinsAutoConvert.NEVER.value)),
 ]
 
 
@@ -404,4 +405,10 @@ def crit_range_desc(crit_on):
 
 
 def autoconvert_coins_desc(mode):
-    return "Always Ask" if mode == 0 else "Always Convert" if mode == 1 else "Never Convert"
+    return (
+        "Always Ask"
+        if mode == CoinsAutoConvert.ASK
+        else "Always Convert"
+        if mode == CoinsAutoConvert.ALWAYS
+        else "Never Convert"
+    )

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -133,7 +133,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
 _AUTOCONVERT_SELECT_OPTIONS = [
     disnake.SelectOption(label="Always Ask", value="0"),
     disnake.SelectOption(label="Always Convert", value="1"),
-    disnake.SelectOption(label="Never Convert", value="-1"),
+    disnake.SelectOption(label="Never Convert", value="2"),
 ]
 
 

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -223,8 +223,8 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
         embed.add_field(
             name="Coin Conversion Mode",
             value=f"**{autoconvert_coins_desc(self.settings.autoconvert_coins)}**\n"
-            f"*Whether or not it should ask you if you would like to auto-convert your coins if you try so spend "
-            f"more than you currently have.*",
+            f"*If a coin transaction would cause you to have a negative number of a certain currency, "
+            f"whether to automatically convert other coins to cover the transaction.*",
             inline=False,
         )
         return {"embed": embed}

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -15,4 +15,4 @@ class ActivationType(enum.IntEnum):
 class CoinsAutoConvert(enum.IntEnum):
     ASK = 0
     ALWAYS = 1
-    NEVER = -1
+    NEVER = 2

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -10,3 +10,9 @@ class ActivationType(enum.IntEnum):
     MINUTE = 6
     HOUR = 7
     SPECIAL = 8
+
+
+class CoinsAutoConvert(enum.IntEnum):
+    ASK = 0
+    ALWAYS = 1
+    NEVER = -1

--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -24,7 +24,7 @@ class CharacterSettings(SettingsBaseModel):
     reroll: Optional[conint(ge=1, le=20)] = None
     talent: bool = False
     srslots: bool = False
-    autoconvert_coins: int = CoinsAutoConvert.ASK
+    autoconvert_coins: CoinsAutoConvert = CoinsAutoConvert.ASK
 
     # character sync
     sync_outbound: bool = True  # avrae to upstream

--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -181,7 +181,7 @@ CHARACTER_SETTINGS = {
     "autoconvertcoins": CSetting(
         "autoconvert_coins",
         "number",
-        description="auto convert coins mode, 0 for ask everytime, 1 for always convert, -1 for never convert",
+        description=f"auto convert coins mode, {CoinsAutoConvert.ASK.value} for ask everytime, {CoinsAutoConvert.ALWAYS.value} for always convert, {CoinsAutoConvert.NEVER.value} for never convert",
         default="ask everytime",
         display_func=lambda val: "ask everytime" if val == 0 else "always convert" if val == 1 else "never convert",
     ),

--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -6,7 +6,7 @@ from pydantic.color import Color
 
 from utils.functions import get_positivity
 from . import SettingsBaseModel
-from ..enums import CoinsAutoConvert
+from utils.enums import CoinsAutoConvert
 
 log = logging.getLogger(__name__)
 

--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -6,6 +6,7 @@ from pydantic.color import Color
 
 from utils.functions import get_positivity
 from . import SettingsBaseModel
+from ..enums import CoinsAutoConvert
 
 log = logging.getLogger(__name__)
 
@@ -23,6 +24,7 @@ class CharacterSettings(SettingsBaseModel):
     reroll: Optional[conint(ge=1, le=20)] = None
     talent: bool = False
     srslots: bool = False
+    autoconvert_coins: int = CoinsAutoConvert.ASK
 
     # character sync
     sync_outbound: bool = True  # avrae to upstream
@@ -175,5 +177,12 @@ CHARACTER_SETTINGS = {
         description="compact coin display",
         default="disabled",
         display_func=lambda val: "enabled" if val else "disabled",
+    ),
+    "autoconvertcoins": CSetting(
+        "autoconvert_coins",
+        "number",
+        description="auto convert coins mode, 0 for ask everytime, 1 for always convert, -1 for never convert",
+        default="ask everytime",
+        display_func=lambda val: "ask everytime" if val == 0 else "always convert" if val == 1 else "never convert",
     ),
 }

--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -181,7 +181,9 @@ CHARACTER_SETTINGS = {
     "autoconvertcoins": CSetting(
         "autoconvert_coins",
         "number",
-        description=f"auto convert coins mode, {CoinsAutoConvert.ASK.value} for ask everytime, {CoinsAutoConvert.ALWAYS.value} for always convert, {CoinsAutoConvert.NEVER.value} for never convert",
+        description=f"auto convert coins mode, {CoinsAutoConvert.ASK.value} for ask everytime, "
+        f"{CoinsAutoConvert.ALWAYS.value} for always convert, "
+        f"{CoinsAutoConvert.NEVER.value} for never convert",
         default="ask everytime",
         display_func=lambda val: "ask everytime" if val == 0 else "always convert" if val == 1 else "never convert",
     ),


### PR DESCRIPTION
### Summary
This adds a csetting for how the user wants to handle autoconverting of coins if they attempt to remove more coins of explicit types than they currently have. Defaults to Always Ask, but has option for Never Convert and Always Convert.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
