### PR TITLE
Add command consume to monimage, monster, and token

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -455,23 +455,23 @@ class Lookup(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command()
-    async def token(self, ctx, *, name=""):
+    async def token(self, ctx, name=None, *args):
         """
         Shows a monster or your character's token.
         __Valid Arguments__
         -border <plain|none (player token only)> - Overrides the token border.
         """
-        if not name or name.startswith("-"):
+        if name is None or name.startswith("-"):
             token_cmd = self.bot.get_command("playertoken")
             if token_cmd is None:
                 return await ctx.send("Error: SheetManager cog not loaded.")
-            return await ctx.invoke(token_cmd, name)
+            if name:
+                args = (name, *args)
+            return await ctx.invoke(token_cmd, *args)
 
         # select monster
-        token_args = argparse(name)
+        token_args = argparse(args)
         hide_name = token_args.get("h", False, bool)
-        if not name.find("-") == -1:  # remove the args from the name
-            name = name[: name.find("-")].rstrip()
         if hide_name:
             await try_delete(ctx.message)
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -333,7 +333,7 @@ class SheetManager(commands.Cog):
         await ctx.send("Portrait override removed!")
 
     @commands.command(hidden=True)  # hidden, as just called by token command
-    async def playertoken(self, ctx, args):
+    async def playertoken(self, ctx, *args):
         """
         Generates and sends a token for use on VTTs.
         __Valid Arguments__

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -330,10 +330,10 @@ class SheetManager(commands.Cog):
         char: Character = await ctx.get_character()
         char.overrides.image = None
         await char.commit(ctx)
-        await ctx.send(f"Portrait override removed!")
+        await ctx.send("Portrait override removed!")
 
     @commands.command(hidden=True)  # hidden, as just called by token command
-    async def playertoken(self, ctx, *args):
+    async def playertoken(self, ctx, args):
         """
         Generates and sends a token for use on VTTs.
         __Valid Arguments__

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -145,7 +145,7 @@ class SheetManager(commands.Cog):
 
         out = f"Created attack {attack.name}!"
         if conflict:
-            out += f" Removed a duplicate attack."
+            out += " Removed a duplicate attack."
         await ctx.send(out)
 
     @action.command(name="import")
@@ -298,7 +298,7 @@ class SheetManager(commands.Cog):
         char: Character = await ctx.get_character()
         char.overrides.desc = None
         await char.commit(ctx)
-        await ctx.send(f"Description override removed!")
+        await ctx.send("Description override removed!")
 
     @commands.group(invoke_without_command=True)
     async def portrait(self, ctx):


### PR DESCRIPTION
### Summary
Now consumes the command sent for monimage, monster, and token lookup if -h is passed

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
