### PR TITLE
Make these all use embed_for_monster

### DIFF
--- a/cogs5e/dice/cog.py
+++ b/cogs5e/dice/cog.py
@@ -235,10 +235,7 @@ class Dice(commands.Cog):
         args = await helpers.parse_snippets(args, ctx, statblock=monster)
         args = argparse(args)
 
-        embed = discord.Embed()
-        embed.colour = random.randint(0, 0xFFFFFF)
-        if not args.last("h", type_=bool):
-            embed.set_thumbnail(url=monster.get_image_url())
+        embed = embed_for_monster(monster, args)
 
         checkutils.run_save(save_stat, monster, args, embed)
 
@@ -268,8 +265,8 @@ class Dice(commands.Cog):
                 spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.name in monster.spellbook)
             except NoSelectionElements:
                 return await ctx.send(
-                    f"No matching spells found in the creature's spellbook. Cast again "
-                    f"with the `-i` argument to ignore restrictions!"
+                    "No matching spells found in the creature's spellbook. Cast again "
+                    "with the `-i` argument to ignore restrictions!"
                 )
         else:
             spell = await select_spell_full(ctx, spell_name)
@@ -278,11 +275,7 @@ class Dice(commands.Cog):
         result = await spell.cast(ctx, caster, targets, args, combat=combat)
 
         # embed display
-        embed = result.embed
-        embed.colour = random.randint(0, 0xFFFFFF)
-        if not args.last("h", type_=bool) and "thumb" not in args:
-            embed.set_thumbnail(url=monster.get_image_url())
-
+        embed = embed_for_monster(monster, args, result.embed)
         handle_source_footer(embed, monster, add_source_str=False)
 
         # save changes: combat state
@@ -304,9 +297,10 @@ class Dice(commands.Cog):
         await self.inline.handle_reaction_inline_rolls(reaction, user)
 
 
-def embed_for_monster(monster, args):
-    embed = discord.Embed()
+def embed_for_monster(monster, args, embed=None):
+    if not embed:
+        embed = discord.Embed()
     embed.colour = random.randint(0, 0xFFFFFF)
-    if not args.last("h", type_=bool):
+    if not args.last("h", type_=bool) and "thumb" not in args:
         embed.set_thumbnail(url=monster.get_image_url())
     return embed


### PR DESCRIPTION
### Summary
Simple clean up that makes all the functions in cog.py use the helper function embed_for_monster

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
- [X] This PR is a minor code cleanup
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
