### PR TITLE
Add Critical Damage Type Server Settings

### DIFF
--- a/cogs5e/models/automation/__init__.py
+++ b/cogs5e/models/automation/__init__.py
@@ -37,6 +37,7 @@ class Automation:
         title=None,
         before=None,
         after=None,
+        crit_type=None,
     ):
         """
         Runs automation.
@@ -69,12 +70,25 @@ class Automation:
         :type before: function
         :param after: A function, taking in the AutomationContext, to run after automation runs.
         :type after: function
+        :param crit_type: The method of adding critical damage
+        :type crit_type: utils.enums.CritDamageType
         :rtype: AutomationResult
         """
         if not targets:
             targets = [None]  # outputs a single iteration of effects in a generic meta field
         autoctx = AutomationContext(
-            ctx, embed, caster, targets, args, combat, spell, conc_effect, ab_override, dc_override, spell_override
+            ctx,
+            embed,
+            caster,
+            targets,
+            args,
+            combat,
+            spell,
+            conc_effect,
+            ab_override,
+            dc_override,
+            spell_override,
+            crit_type=crit_type,
         )
 
         results = []

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -4,6 +4,7 @@ import d20
 import draconic
 
 from cogs5e.models.sheet.resistance import Resistances, do_resistances
+from utils.enums import CritDamageType
 from . import Effect
 from .roll import RollEffectMetaVar
 from .. import utils
@@ -51,6 +52,10 @@ class Damage(Effect):
         critdice = sum(args.get("critdice", type_=int))
         hide = args.last("h", type_=bool)
 
+        crit_damage_type = autoctx.crit_type
+        if crit_damage_type is None:
+            crit_damage_type = CritDamageType.NORMAL
+
         # character-specific arguments
         if autoctx.character and "critdice" not in args:
             critdice = autoctx.character.options.extra_crit_dice
@@ -91,9 +96,18 @@ class Damage(Effect):
         # Disable critical damage in saves (#1556)
         in_crit = (autoctx.in_crit or crit_arg) and not (nocrit or autoctx.in_save)
         if in_crit:
-            dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)
+            if crit_damage_type == CritDamageType.MAX_ADD:
+                dice_ast = d20.utils.tree_map(utils.max_add_crit_mapper, dice_ast)
+            elif crit_damage_type == CritDamageType.DOUBLE_ALL:
+                dice_ast.roll = d20.ast.BinOp(d20.ast.Parenthetical(dice_ast.roll), "*", d20.ast.Literal(2))
+            else:
+                dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)
             if critdice and not autoctx.is_spell:
-                utils.critdice_tree_update(dice_ast, int(critdice))
+                if crit_damage_type == CritDamageType.DOUBLE_ALL:
+                    crit_ast = utils.crit_dice_gen(dice_ast, critdice)
+                    dice_ast.roll = d20.ast.BinOp(dice_ast.roll, "+", crit_ast)
+                else:
+                    utils.critdice_tree_update(dice_ast, int(critdice))
 
         # -c #
         if in_crit:

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -53,8 +53,6 @@ class Damage(Effect):
         hide = args.last("h", type_=bool)
 
         crit_damage_type = autoctx.crit_type
-        if crit_damage_type is None:
-            crit_damage_type = CritDamageType.NORMAL
 
         # character-specific arguments
         if autoctx.character and "critdice" not in args:
@@ -107,7 +105,8 @@ class Damage(Effect):
             if critdice and not autoctx.is_spell:
                 if crit_damage_type in (CritDamageType.DOUBLE_ALL, CritDamageType.DOUBLE_DICE):
                     crit_ast = utils.crit_dice_gen(dice_ast, critdice)
-                    dice_ast.roll = d20.ast.BinOp(dice_ast.roll, "+", crit_ast)
+                    if crit_ast:
+                        dice_ast.roll = d20.ast.BinOp(dice_ast.roll, "+", crit_ast)
                 else:
                     utils.critdice_tree_update(dice_ast, int(critdice))
 

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -100,10 +100,12 @@ class Damage(Effect):
                 dice_ast = d20.utils.tree_map(utils.max_add_crit_mapper, dice_ast)
             elif crit_damage_type == CritDamageType.DOUBLE_ALL:
                 dice_ast.roll = d20.ast.BinOp(d20.ast.Parenthetical(dice_ast.roll), "*", d20.ast.Literal(2))
+            elif crit_damage_type == CritDamageType.DOUBLE_DICE:
+                dice_ast = d20.utils.tree_map(utils.double_dice_crit_mapper, dice_ast)
             else:
                 dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)
             if critdice and not autoctx.is_spell:
-                if crit_damage_type == CritDamageType.DOUBLE_ALL:
+                if crit_damage_type in (CritDamageType.DOUBLE_ALL, CritDamageType.DOUBLE_DICE):
                     crit_ast = utils.crit_dice_gen(dice_ast, critdice)
                     dice_ast.roll = d20.ast.BinOp(dice_ast.roll, "+", crit_ast)
                 else:

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -23,6 +23,7 @@ class AutomationContext:
         ab_override=None,
         dc_override=None,
         spell_override=None,
+        crit_type=None,
     ):
         self.ctx = ctx
         self.embed = embed
@@ -37,6 +38,8 @@ class AutomationContext:
         self.dc_override = dc_override
         self.spell_level_override = None  # used in Cast Spell effect
         self.conc_effect = conc_effect
+
+        self.crit_type = crit_type
 
         self.metavars = {
             # caster, targets as default (#1335)

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -3,6 +3,7 @@ import aliasing.api.statblock
 import aliasing.evaluators
 import cogs5e.initiative.combatant as init
 from cogs5e.models import character as character_api, embeds
+from utils.enums import CritDamageType
 from .errors import AutomationEvaluationException, InvalidIntExpression
 from .utils import maybe_alias_statblock
 
@@ -23,7 +24,7 @@ class AutomationContext:
         ab_override=None,
         dc_override=None,
         spell_override=None,
-        crit_type=None,
+        crit_type=CritDamageType.NORMAL,
     ):
         self.ctx = ctx
         self.embed = embed

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -79,17 +79,17 @@ def crit_mapper(node: d20.ast.Node):
 
 
 def double_dice_crit_mapper(node: d20.ast.Node):
-    """A function that doubles the number of dice for each Dice AST node."""
+    """A function that replaces each Dice AST node with itself multiplied by 2."""
     if isinstance(node, d20.ast.Dice):
-        return d20.ast.BinOp(d20.ast.Parenthetical(node), "*", d20.ast.Literal(2))
+        return d20.ast.BinOp(node, "*", d20.ast.Literal(2))
     return node
 
 
 def crit_dice_gen(dice_ast: d20.ast.Node, critdice: int):
-    """A function that finds the size of left most Dice AST node and generates crit dice based on that."""
-    left = dice_ast
-    while left.children:
-        left = left.children[0]
+    """A function that finds the size of left most Dice AST node and generates crit dice based on that, for
+    crit types that double all original dice, but not any additional crit dice. By finding the left most dice,
+    we do our best to ensure its based on the weapon/source and not any other additional bonuses."""
+    left = d20.utils.leftmost(dice_ast)
 
     # if we're at the bottom of the branch and it's the dice, add *critdice*
     if isinstance(left, d20.ast.Dice):

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -64,11 +64,29 @@ def max_mapper(node: d20.ast.Node):
     return node
 
 
+def max_add_crit_mapper(node: d20.ast.Node):
+    """A function that adds the maximum value of each Dice AST node as a literal"""
+    if isinstance(node, d20.ast.Dice):
+        return d20.ast.BinOp(node, "+", d20.ast.Literal(node.num * node.size))
+    return node
+
+
 def crit_mapper(node: d20.ast.Node):
     """A function that doubles the number of dice for each Dice AST node."""
     if isinstance(node, d20.ast.Dice):
         return d20.ast.Dice(node.num * 2, node.size)
     return node
+
+
+def crit_dice_gen(dice_ast: d20.ast.Node, critdice: int):
+    """A function that finds the size of left most Dice AST node and generates crit dice based on that."""
+    left = dice_ast
+    while left.children:
+        left = left.children[0]
+
+    # if we're at the bottom of the branch and it's the dice, add *critdice*
+    if isinstance(left, d20.ast.Dice):
+        return d20.ast.Dice(critdice, left.size)
 
 
 def critdice_tree_update(dice_ast: d20.ast.Node, critdice: int):

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -78,6 +78,13 @@ def crit_mapper(node: d20.ast.Node):
     return node
 
 
+def double_dice_crit_mapper(node: d20.ast.Node):
+    """A function that doubles the number of dice for each Dice AST node."""
+    if isinstance(node, d20.ast.Dice):
+        return d20.ast.BinOp(d20.ast.Parenthetical(node), "*", d20.ast.Literal(2))
+    return node
+
+
 def crit_dice_gen(dice_ast: d20.ast.Node, critdice: int):
     """A function that finds the size of left most Dice AST node and generates crit dice based on that."""
     left = dice_ast

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -108,7 +108,12 @@ async def _run_common(ctx, embed, args, caster, action, targets, combat):
     :type combat: None or cogs5e.models.initiative.Combat
     :rtype: cogs5e.models.automation.AutomationResult
     """
-    result = await action.automation.run(ctx, embed, caster, targets, args, combat=combat, title=embed.title)
+    guild_settings = await ctx.get_server_settings()
+    crit_type = guild_settings.crit_type
+
+    result = await action.automation.run(
+        ctx, embed, caster, targets, args, combat=combat, title=embed.title, crit_type=crit_type
+    )
     if combat:
         await combat.final()
     # commit character only if we have not already committed it via combat final

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -5,6 +5,7 @@ import discord
 from cogs5e.models import embeds
 from cogs5e.models.errors import RequiresLicense
 from gamedata import lookuputils
+from utils.enums import CritDamageType
 from utils.functions import a_or_an, maybe_http_url, natural_join, search_and_select
 
 
@@ -109,7 +110,10 @@ async def _run_common(ctx, embed, args, caster, action, targets, combat):
     :rtype: cogs5e.models.automation.AutomationResult
     """
     guild_settings = await ctx.get_server_settings()
-    crit_type = guild_settings.crit_type
+    if guild_settings:
+        crit_type = guild_settings.crit_type
+    else:
+        crit_type = CritDamageType.NORMAL
 
     result = await action.automation.run(
         ctx, embed, caster, targets, args, combat=combat, title=embed.title, crit_type=crit_type

--- a/gamedata/spell.py
+++ b/gamedata/spell.py
@@ -10,6 +10,7 @@ from cogs5e.models.errors import AvraeException, InvalidArgument
 from cogs5e.initiative.effect import Effect
 from cogs5e.initiative.types import BaseCombatant
 from utils.constants import STAT_ABBREVIATIONS
+from utils.enums import CritDamageType
 from utils.functions import confirm, maybe_http_url, smart_trim, verbose_stat
 from .mixins import AutomatibleMixin, DescribableMixin
 from .shared import Sourced
@@ -301,10 +302,14 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
             effect_result = caster.add_effect(conc_effect)
             conc_conflict = effect_result["conc_conflict"]
 
+        guild_settings = await ctx.get_server_settings()
+        if guild_settings:
+            crit_type = guild_settings.crit_type
+        else:
+            crit_type = CritDamageType.NORMAL
+
         # run
         automation_result = None
-        guild_settings = await ctx.get_server_settings()
-        crit_type = guild_settings.crit_type
         if self.automation and self.automation.effects:
             title = f"{caster.name} cast {self.name}!"
             automation_result = await self.automation.run(

--- a/gamedata/spell.py
+++ b/gamedata/spell.py
@@ -303,6 +303,8 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
 
         # run
         automation_result = None
+        guild_settings = await ctx.get_server_settings()
+        crit_type = guild_settings.crit_type
         if self.automation and self.automation.effects:
             title = f"{caster.name} cast {self.name}!"
             automation_result = await self.automation.run(
@@ -318,6 +320,7 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
                 dc_override=dc_override,
                 spell_override=spell_override,
                 title=title,
+                crit_type=crit_type,
             )
         else:  # no automation, display spell description
             phrase = args.join("phrase", "\n")

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -307,6 +307,7 @@ _CRIT_TYPE_OPTIONS = [
     disnake.SelectOption(label="Double Dice Number (Default)", value=str(CritDamageType.NORMAL.value)),
     disnake.SelectOption(label="Add Max Dice Value", value=str(CritDamageType.MAX_ADD.value)),
     disnake.SelectOption(label="Double Total", value=str(CritDamageType.DOUBLE_ALL.value)),
+    disnake.SelectOption(label="Double Dice Total", value=str(CritDamageType.DOUBLE_DICE.value)),
 ]
 
 
@@ -362,10 +363,11 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         embed.add_field(
             name="Crit Damage Type",
             value=f"**{crit_type_desc(self.settings.crit_type)}**\n"
-            f"_This affects how critical damage is treated on the server. Default is to double the amount of dice"
-            f"rolled (`2d8 + 4` -> `4d8 + 4`), 'Add Max Dice Value' will add the maximum value of each die to the "
-            f"total (`2d8 + 4` -> `2d8 + 4 + 16`), and double total will double everything (`2d8 + 4` -> `(2d8 + 4) "
-            f"* 2`)._",
+            f'_This affects how critical damage is treated on the server. "Double Dice Amount" doubles the amount of '
+            f'dice rolled (`2d8 + 4` -> `4d8 + 4`). "Add Max Dice Value" will add the maximum value of each die to '
+            f'the total (`2d8 + 4` -> `2d8 + 4 + 16`). "Double Total" will double everything (`2d8 + 4` -> `'
+            f'(2d8 + 4) * 2`). "Double Dice Toal" will double the total value of the dice rolled (`2d8 + 4` -> `(2d8) '
+            f"* 2 + 4`)._",
             inline=False,
         )
 
@@ -395,4 +397,6 @@ def crit_type_desc(mode):
         else "Add Max Dice Value"
         if mode == CritDamageType.MAX_ADD
         else "Double Total"
+        if mode == CritDamageType.DOUBLE_ALL
+        else "Double Dice Total"
     )

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -304,10 +304,10 @@ class _InlineRollingSettingsUI(ServerSettingsMenuBase):
 
 
 _CRIT_TYPE_OPTIONS = [
-    disnake.SelectOption(label="Double Dice Number (Default)", value=str(CritDamageType.NORMAL.value)),
     disnake.SelectOption(label="Add Max Dice Value", value=str(CritDamageType.MAX_ADD.value)),
-    disnake.SelectOption(label="Double Total", value=str(CritDamageType.DOUBLE_ALL.value)),
+    disnake.SelectOption(label="Double Dice Number (Default)", value=str(CritDamageType.NORMAL.value)),
     disnake.SelectOption(label="Double Dice Total", value=str(CritDamageType.DOUBLE_DICE.value)),
+    disnake.SelectOption(label="Double Total", value=str(CritDamageType.DOUBLE_ALL.value)),
 ]
 
 
@@ -363,11 +363,15 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         embed.add_field(
             name="Crit Damage Type",
             value=f"**{crit_type_desc(self.settings.crit_type)}**\n"
-            f'_This affects how critical damage is treated on the server. "Double Dice Amount" doubles the amount of '
-            f'dice rolled (`2d8 + 4` -> `4d8 + 4`). "Add Max Dice Value" will add the maximum value of each die to '
-            f'the total (`2d8 + 4` -> `2d8 + 4 + 16`). "Double Total" will double everything (`2d8 + 4` -> `'
-            f'(2d8 + 4) * 2`). "Double Dice Total" will double the total value of the dice rolled (`2d8 + 4` -> `(2d8) '
-            f"* 2 + 4`)._",
+            f"_This affects how critical damage is treated on the server._\n"
+            f" ● Add Max Dice Value\n"
+            f"> _This type adds the maximum value of each die to the total._\n> `2d8 + 4` -> `2d8 + 16 + 4`\n"
+            f" ● Double Dice Amount (Default)\n"
+            f"> _This type doubles the amount of dice rolled._\n> `2d8 + 4` -> `4d8 + 4`\n"
+            f" ● Double Dice Total\n"
+            f"> _This type doubles the total value of the dice rolled._\n> `2d8 + 4` -> `(2d8) * 2 + 4`\n"
+            f" ● Double Total\n"
+            f"> _This type doubles the total, including modifiers._\n> `2d8 + 4` -> `(2d8 + 4) * 2`",
             inline=False,
         )
 

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -6,6 +6,7 @@ from typing import List, Optional, TYPE_CHECKING, TypeVar
 import disnake
 
 from utils.aldclient import discord_user_to_dict
+from utils.enums import CritDamageType
 from utils.functions import natural_join
 from utils.settings.guild import InlineRollingType, ServerSettings
 from .menu import MenuBase
@@ -95,7 +96,9 @@ class ServerSettingsUI(ServerSettingsMenuBase):
             nlp_enabled_description = f"\n**Contribute Message Data to NLP Training**: {self.settings.upenn_nlp_opt_in}"
         embed.add_field(
             name="Miscellaneous Settings",
-            value=f"**Show DDB Campaign Message**: {self.settings.show_campaign_cta}" f"{nlp_enabled_description}",
+            value=f"**Show DDB Campaign Message**: {self.settings.show_campaign_cta}\n"
+            f"**Critical Damage Type**: {crit_type_desc(self.settings.crit_type)}"
+            f"{nlp_enabled_description}",
             inline=False,
         )
 
@@ -300,11 +303,25 @@ class _InlineRollingSettingsUI(ServerSettingsMenuBase):
         return {"embed": embed}
 
 
+_CRIT_TYPE_OPTIONS = [
+    disnake.SelectOption(label="Double Dice Number (Default)", value=str(CritDamageType.NORMAL.value)),
+    disnake.SelectOption(label="Add Max Dice Value", value=str(CritDamageType.MAX_ADD.value)),
+    disnake.SelectOption(label="Double Total", value=str(CritDamageType.DOUBLE_ALL.value)),
+]
+
+
 class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
     # ==== ui ====
     @disnake.ui.button(label="Toggle DDB Campaign Message", style=disnake.ButtonStyle.primary, row=1)
     async def toggle_campaign_cta(self, _: disnake.ui.Button, interaction: disnake.Interaction):
         self.settings.show_campaign_cta = not self.settings.show_campaign_cta
+        await self.commit_settings()
+        await self.refresh_content(interaction)
+
+    @disnake.ui.select(placeholder="Crit Damage Type", options=_CRIT_TYPE_OPTIONS)
+    async def crit_type_select(self, select: disnake.ui.Select, interaction: disnake.Interaction):
+        value = select.values[0]
+        self.settings.crit_type = int(value)
         await self.commit_settings()
         await self.refresh_content(interaction)
 
@@ -342,6 +359,15 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
             f"you import a character in an unlinked campaign.*",
             inline=False,
         )
+        embed.add_field(
+            name="Crit Damage Type",
+            value=f"**{crit_type_desc(self.settings.crit_type)}**\n"
+            f"_This affects how critical damage is treated on the server. Default is to double the amount of dice"
+            f"rolled (`2d8 + 4` -> `4d8 + 4`), 'Add Max Dice Value' will add the maximum value of each die to the "
+            f"total (`2d8 + 4` -> `2d8 + 4 + 16`), and double total will double everything (`2d8 + 4` -> `(2d8 + 4) "
+            f"* 2`)._",
+            inline=False,
+        )
 
         nlp_feature_flag = await self.bot.ldclient.variation(
             "cog.initiative.upenn_nlp.enabled", user=discord_user_to_dict(self.owner), default=False
@@ -360,3 +386,13 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
             )
 
         return {"embed": embed}
+
+
+def crit_type_desc(mode):
+    return (
+        "Double Dice Amount (Default)"
+        if mode == CritDamageType.NORMAL
+        else "Add Max Dice Value"
+        if mode == CritDamageType.MAX_ADD
+        else "Double Total"
+    )

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -366,7 +366,7 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
             f'_This affects how critical damage is treated on the server. "Double Dice Amount" doubles the amount of '
             f'dice rolled (`2d8 + 4` -> `4d8 + 4`). "Add Max Dice Value" will add the maximum value of each die to '
             f'the total (`2d8 + 4` -> `2d8 + 4 + 16`). "Double Total" will double everything (`2d8 + 4` -> `'
-            f'(2d8 + 4) * 2`). "Double Dice Toal" will double the total value of the dice rolled (`2d8 + 4` -> `(2d8) '
+            f'(2d8 + 4) * 2`). "Double Dice Total" will double the total value of the dice rolled (`2d8 + 4` -> `(2d8) '
             f"* 2 + 4`)._",
             inline=False,
         )

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -16,3 +16,9 @@ class CoinsAutoConvert(enum.IntEnum):
     ASK = 0
     ALWAYS = 1
     NEVER = 2
+
+
+class CritDamageType(enum.IntEnum):
+    NORMAL = 0
+    MAX_ADD = 1
+    DOUBLE_ALL = 2

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -22,3 +22,4 @@ class CritDamageType(enum.IntEnum):
     NORMAL = 0
     MAX_ADD = 1
     DOUBLE_ALL = 2
+    DOUBLE_DICE = 3

--- a/utils/settings/guild.py
+++ b/utils/settings/guild.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import disnake
 
 from . import SettingsBaseModel
+from utils.enums import CritDamageType
 
 DEFAULT_DM_ROLE_NAMES = {"dm", "gm", "dungeon master", "game master"}
 
@@ -23,6 +24,7 @@ class ServerSettings(SettingsBaseModel):
     inline_enabled: InlineRollingType = InlineRollingType.DISABLED
     show_campaign_cta: bool = True
     upenn_nlp_opt_in: bool = False
+    crit_type: CritDamageType = CritDamageType.NORMAL
 
     # ==== lifecycle ====
     @classmethod


### PR DESCRIPTION
### Summary
Adds two alternative crit damage types, with a selector in servsettings.

"Double Dice Amount", or RAW, doubles the amount of dice rolled (``2d8 + 4`` -> ``4d8 + 4``). 
"Add Max Dice Value", or Crunchy Crits, will add the maximum value of each die to the total (``2d8 + 4`` -> ``2d8 + 4 + 16``). 
"Double Total", will double everything (``2d8 + 4 -> (2d8 + 4) * 2``).
"Double Dice Total", or Mercer Crits, will double the total value of the dice rolled (``2d8 + 4`` -> ``(2d8) * 2 + 4``)

![image](https://user-images.githubusercontent.com/5848891/160954052-42ec57fc-3fde-4590-9ac9-27840f6182ac.png)

Resolves https://github.com/avrae/avrae/issues/875

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
