### PR TITLE
Switch from using avatar url to the avatar key

### DIFF
--- a/utils/functions.py
+++ b/utils/functions.py
@@ -449,7 +449,7 @@ async def user_from_id(ctx, the_id):
                 "$set": {
                     "username": the_user.name,
                     "discriminator": the_user.discriminator,
-                    "avatar": the_user.display_avatar.url,
+                    "avatar": the_user.display_avatar.key,
                     "bot": the_user.bot,
                 }
             },

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -449,7 +449,7 @@ async def user_from_id(ctx, the_id):
                 "$set": {
                     "username": the_user.name,
                     "discriminator": the_user.discriminator,
-                    "avatar": the_user.display_avatar.key,
+                    "avatar": the_user.display_avatar.key if the_user.avatar else None,  # None if using default avatar
                     "bot": the_user.bot,
                 }
             },

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -443,13 +443,14 @@ async def user_from_id(ctx, the_id):
     """
 
     async def update_known_user(the_user):
+        avatar_hash = the_user.avatar.key if the_user.avatar is not None else None
         await ctx.bot.mdb.users.update_one(
             {"id": str(the_user.id)},
             {
                 "$set": {
                     "username": the_user.name,
                     "discriminator": the_user.discriminator,
-                    "avatar": the_user.display_avatar.key if the_user.avatar else None,  # None if using default avatar
+                    "avatar": avatar_hash,
                     "bot": the_user.bot,
                 }
             },


### PR DESCRIPTION
### Summary
The bot was saving the entire avatar URL to the database, while the website was doing just the key. This changes it to the key in order to match how the website (which actually uses this information) handles it.

https://github.com/avrae/avrae-service/pull/48

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
