### PR TITLE
Expose random.choices()

### DIFF
--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -176,6 +176,10 @@ def randchoice(seq):
     return random.choice(seq)
 
 
+def randchoices(population, weights=None, cum_weights=None, k=1):
+    return random.choices(population, weights=weights, cum_weights=cum_weights, k=k)
+
+
 # signatures
 SIG_SECRET = config.DRACONIC_SIGNATURE_SECRET
 SIG_STRUCT = struct.Struct("!QQQ12sB")  # u64, u64, u64, byte[12], u8 - https://docs.python.org/3/library/struct.html

--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -177,6 +177,10 @@ def randchoice(seq):
 
 
 def randchoices(population, weights=None, cum_weights=None, k=1):
+    if k > MAX_ITER_LENGTH:
+        draconic._raise_in_context(draconic.IterableTooLong, "The length of the output is too large.")
+    if max(population, key=approx_len_of) * k > MAX_ITER_LENGTH:
+        draconic._raise_in_context(draconic.IterableTooLong, "The length of your input is too large.")
     return random.choices(population, weights=weights, cum_weights=cum_weights, k=k)
 
 

--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -16,6 +16,7 @@ from utils import config
 from utils.dice import RerollableStringifier
 from .context import AliasAuthor, AliasChannel, AliasGuild
 from ..utils import ExecutionScope
+from draconic.types import approx_len_of
 
 MAX_ITER_LENGTH = 10000
 

--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -25,6 +25,7 @@ from aliasing.api.functions import (
     err,
     rand,
     randchoice,
+    randchoices,
     randint,
     roll,
     safe_range,
@@ -67,6 +68,7 @@ DEFAULT_BUILTINS = {
     "rand": rand,
     "randint": randint,
     "randchoice": randchoice,
+    "randchoices": randchoices,
 }
 SCRIPTING_RE = re.compile(
     r"(?<!\\)(?:"  # backslash-escape

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -482,7 +482,7 @@ Draconic Functions
     If no ``weights`` or ``cum_weights`` are input, the items in ``population`` will have equal odds of being chosen.
     If no ``k`` is input, the output length will be 1.
     
-    :param population: The itterable to choose a random items from.
+    :param population: The itterable to choose random items from.
     :type population: iterable.
     :param weights: The odds for each item in the ``population`` iterable.
     :type weights: list of ints

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -466,7 +466,25 @@ Draconic Functions
     :return: A random integer.
     :rtype: int
 
-.. function:: randchoice(seq)
+.. function:: randchoice(population, weights=None, cum_weights=None, k=1)
+    
+    Returns a list of random items from ``population`` of ``k`` length with either weighted or cumulatively weighted odds.
+    The ``weights`` [2,1,1] are equal to ``cum_weights`` [2,3,4]. 
+    If no ``weights`` or ``cum_weights`` are input, the items in ``population`` will have equal odds of being chosen.
+    If no ``k`` is input, the output length will be 1.
+    
+    :param population: The itterable to choose a random items from.
+    :type population: iterable.
+    :param weights: The odds for each item in the ``population`` iterable.
+    :type weights: list of ints
+    :param cum_weights: The cumulative odds for each item in the ``population`` itterable.
+    :type cum_weights: list of ints
+    :param k: The length of the output.
+    :type k: int
+    :return: A list of random items from the iterable.
+    :rtype: list
+
+.. function:: randchoices(seq)
     
     Returns a random item from ``seq``.
     

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -466,7 +466,16 @@ Draconic Functions
     :return: A random integer.
     :rtype: int
 
-.. function:: randchoice(population, weights=None, cum_weights=None, k=1)
+.. function:: randchoice(seq)
+    
+    Returns a random item from ``seq``.
+    
+    :param seq: The itterable to choose a random item from.
+    :type seq: iterable.
+    :return: A random item from the iterable.
+    :rtype: Any.
+
+.. function:: randchoices(population, weights=None, cum_weights=None, k=1)
     
     Returns a list of random items from ``population`` of ``k`` length with either weighted or cumulatively weighted odds.
     The ``weights`` [2,1,1] are equal to ``cum_weights`` [2,3,4]. 
@@ -483,16 +492,7 @@ Draconic Functions
     :type k: int
     :return: A list of random items from the iterable.
     :rtype: list
-
-.. function:: randchoices(seq)
     
-    Returns a random item from ``seq``.
-    
-    :param seq: The itterable to choose a random item from.
-    :type seq: iterable.
-    :return: A random item from the iterable.
-    :rtype: Any.
-
 .. autofunction:: aliasing.api.functions.roll
 
 .. autofunction:: aliasing.evaluators.ScriptingEvaluator.set_uvar(name, value)


### PR DESCRIPTION
### Summary
This PR solves AFR-850 by exposing the Random function random.choices() which allows for the creation of lists of arbitrary length when given an itterable, a desired length, and either weighted odds or cumulative weighted odds

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
![image](https://user-images.githubusercontent.com/15987706/162549340-0bfee7d4-21ee-4bb7-9a86-0278b23b1c9e.png)
