### PR TITLE
Add support for 'Savage Attacker' feat

### DIFF
--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -50,6 +50,7 @@ class Damage(Effect):
         mi_arg = args.last("mi", None, int)
         dtype_args = args.get("dtype", [], ephem=True)
         critdice = sum(args.get("critdice", type_=int))
+        savage = args.last("savage", None, bool, ephem=True)
         hide = args.last("h", type_=bool)
 
         crit_damage_type = autoctx.crit_type
@@ -79,6 +80,11 @@ class Damage(Effect):
         damage = autoctx.parse_annostr(damage)
         dice_ast = copy.copy(d20.parse(damage))
         dice_ast = utils.upcast_scaled_dice(self, autoctx, dice_ast)
+
+        if savage:
+            dice_ast.roll = d20.ast.OperatedSet(
+                d20.ast.NumberSet([dice_ast.roll, dice_ast.roll]), d20.SetOperator("k", [d20.SetSelector("h", 1)])
+            )
 
         # -mi # (#527)
         if mi_arg:

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -79,6 +79,7 @@ sadv/sdis - Gives the target advantage/disadvantage on the saving throw.
 *-d <damage>* - Adds additional damage.
 *-c <damage>* - Adds additional damage for when the attack crits, not doubled.
 *-mi <value>* - Minimum value of each die on the damage roll.
+*savage* - Rolls two sets of the base damage dice, choosing the higher of the two.
 
 __Damage Types__
 *magical* - Makes the damage type of the attack magical.


### PR DESCRIPTION
### Summary
This PR adds an arg for automation that rolls the damage dice twice, taking the higher of the two. This is primarily for things like Savage Attacker or the Butchers Bib.

This has been requested/discussed in the past (though the only formal request I can find is from [2018](https://discord.com/channels/269275778867396608/297190603819843586/456240614137135105), but likely due to the feat being viewed as 'mathematically bad' by the D&D community, it never saw much support, so we've mostly resolved to telling users the best option is to have two attacks, one with the damage 'advantage' and one without. 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
