### PR TITLE
Use strict get_combatant

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -181,7 +181,7 @@ class InitTracker(commands.Cog):
 
         combat = await ctx.get_combat()
 
-        if combat.get_combatant(name) is not None:
+        if combat.get_combatant(name, True) is not None:
             await ctx.send("Combatant already exists.")
             return
 
@@ -274,7 +274,7 @@ class InitTracker(commands.Cog):
             raw_name = name_template
             to_continue = False
 
-            while combat.get_combatant(name) and name_num < 100:  # keep increasing to avoid duplicates
+            while combat.get_combatant(name, True) and name_num < 100:  # keep increasing to avoid duplicates
                 if "#" in raw_name:
                     name_num += 1
                     name = raw_name.replace("#", str(name_num))
@@ -381,7 +381,7 @@ class InitTracker(commands.Cog):
 
         combat = await ctx.get_combat()
 
-        if combat.get_combatant(char.name) is not None:
+        if combat.get_combatant(char.name, True) is not None:
             await ctx.send("Combatant already exists.")
             return
 


### PR DESCRIPTION
### Summary
Currently the three commands that add to initiative use non-strict get_combatant() to see if a combatant already exists with their name, which means if someone joins with the name "Daniel", any attempts to add a combatant with a subset of the characters in Daniel ("D", "Dan", "niel", "ani", etc) returns the error "Combatant already exists". This switches those three commands to use strict mode, which only matches against exact case-insensitive names.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
