### PR TITLE
Jokeen/3.5 hotfixes

### DIFF
--- a/cogs5e/charGen.py
+++ b/cogs5e/charGen.py
@@ -69,7 +69,7 @@ async def roll_stats(ctx):
         rules.append(f"At least {t} under {m}")
 
     ast = d20.parse(dice, allow_comments=True)
-    roller = d20.Roller(context=PersistentRollContext(max_rolls=1000))
+    roller = d20.Roller(context=PersistentRollContext(max_rolls=2500))
 
     stat_rolls = []
     try:

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -101,11 +101,11 @@ class Damage(Effect):
         in_crit = (autoctx.in_crit or crit_arg) and not (nocrit or autoctx.in_save)
         if in_crit:
             if crit_damage_type == CritDamageType.MAX_ADD:
-                dice_ast = d20.utils.tree_map(utils.max_add_crit_mapper, dice_ast)
+                dice_ast = utils.tree_map_prefix(utils.max_add_crit_mapper, dice_ast)
             elif crit_damage_type == CritDamageType.DOUBLE_ALL:
                 dice_ast.roll = d20.ast.BinOp(d20.ast.Parenthetical(dice_ast.roll), "*", d20.ast.Literal(2))
             elif crit_damage_type == CritDamageType.DOUBLE_DICE:
-                dice_ast = d20.utils.tree_map(utils.double_dice_crit_mapper, dice_ast)
+                dice_ast = utils.tree_map_prefix(utils.double_dice_crit_mapper, dice_ast)
             else:
                 dice_ast = d20.utils.tree_map(utils.crit_mapper, dice_ast)
             if critdice and not autoctx.is_spell:

--- a/ddb/dice/tree.py
+++ b/ddb/dice/tree.py
@@ -232,7 +232,7 @@ class DiceNotation:
 
         recurse(result.expr.roll)
 
-        return cls(dice_set, sum(constants))
+        return cls(dice_set, int(sum(constants)))
 
     def d20_ast(self, **kwargs):
         """

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -102,7 +102,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
     async def get_content(self):
         embed = embeds.EmbedWithCharacter(self.character, title=f"Character Settings for {self.character.name}")
         embed.add_field(
-            name="**__Cosmetic Settings__**",
+            name="__Cosmetic Settings__",
             value=f"**Embed Color**: {color_setting_desc(self.settings.color)}\n"
             f"**Show Character Image**: {self.settings.embed_image}\n"
             f"**Use Compact Coin Display:** {self.settings.compact_coins}\n"
@@ -110,7 +110,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
             inline=False,
         )
         embed.add_field(
-            name="**__Gameplay Settings__**",
+            name="__Gameplay Settings__",
             value=f"**Crit Range**: {crit_range_desc(self.settings.crit_on)}\n"
             f"**Extra Crit Dice**: {self.settings.extra_crit_dice}\n"
             f"**Reroll**: {self.settings.reroll}\n"
@@ -127,7 +127,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
                 sync_desc_lines.append(f"**Outbound Sync**: {self.settings.sync_outbound}")
             if inbound:
                 sync_desc_lines.append(f"**Inbound Sync**: {self.settings.sync_inbound}")
-            embed.add_field(name="**__Character Sync Settings__**", value="\n".join(sync_desc_lines), inline=False)
+            embed.add_field(name="__Character Sync Settings__", value="\n".join(sync_desc_lines), inline=False)
         return {"embed": embed}
 
 

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -102,7 +102,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
     async def get_content(self):
         embed = embeds.EmbedWithCharacter(self.character, title=f"Character Settings for {self.character.name}")
         embed.add_field(
-            name="Cosmetic Settings",
+            name="**__Cosmetic Settings__**",
             value=f"**Embed Color**: {color_setting_desc(self.settings.color)}\n"
             f"**Show Character Image**: {self.settings.embed_image}\n"
             f"**Use Compact Coin Display:** {self.settings.compact_coins}\n"
@@ -110,7 +110,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
             inline=False,
         )
         embed.add_field(
-            name="Gameplay Settings",
+            name="**__Gameplay Settings__**",
             value=f"**Crit Range**: {crit_range_desc(self.settings.crit_on)}\n"
             f"**Extra Crit Dice**: {self.settings.extra_crit_dice}\n"
             f"**Reroll**: {self.settings.reroll}\n"
@@ -127,7 +127,7 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
                 sync_desc_lines.append(f"**Outbound Sync**: {self.settings.sync_outbound}")
             if inbound:
                 sync_desc_lines.append(f"**Inbound Sync**: {self.settings.sync_inbound}")
-            embed.add_field(name="Character Sync Settings", value="\n".join(sync_desc_lines), inline=False)
+            embed.add_field(name="**__Character Sync Settings__**", value="\n".join(sync_desc_lines), inline=False)
         return {"embed": embed}
 
 

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -432,11 +432,15 @@ class _RollStatsSettingsUI(ServerSettingsMenuBase):
     async def select_dice(self, button: disnake.ui.Button, interaction: disnake.Interaction):
         async with self.disable_component(interaction, button):
             randchar_dice = await self.prompt_message(
-                interaction, "Choose a new dice string to roll by sending a message in this channel."
+                interaction,
+                "Choose a new dice string to roll by sending a message in this channel. If you wish to "
+                "use the default dice (4d6kh3), respond with 'default'.",
             )
             if randchar_dice is None:
                 await interaction.send(f"No valid dice found. Press `{button.label}` to try again.", ephemeral=True)
                 return
+            if randchar_dice.lower() == "default":
+                randchar_dice = "4d6kh3"
             try:
                 d20.parse(randchar_dice)
             except d20.errors.RollSyntaxError:

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -99,7 +99,7 @@ class ServerSettingsUI(ServerSettingsMenuBase):
         else:
             dm_roles = "Dungeon Master, DM, Game Master, or GM"
         embed.add_field(
-            name="Lookup Settings",
+            name="__Lookup Settings__",
             value=f"**DM Roles**: {dm_roles}\n"
             f"**Monsters Require DM**: {self.settings.lookup_dm_required}\n"
             f"**Direct Message DM**: {self.settings.lookup_pm_dm}\n"
@@ -109,7 +109,7 @@ class ServerSettingsUI(ServerSettingsMenuBase):
         embed.add_field(name="Inline Rolling Settings", value=await self.get_inline_rolling_desc(), inline=False)
 
         embed.add_field(
-            name="Custom Stat Roll Settings",
+            name="__Custom Stat Roll Settings__",
             value=f"**Dice**: {self.settings.randchar_dice}\n"
             f"**Number of Sets**: {self.settings.randchar_sets}\n"
             f"**Assign Stats**: {self.settings.randchar_straight}\n"
@@ -127,7 +127,7 @@ class ServerSettingsUI(ServerSettingsMenuBase):
         if nlp_feature_flag:
             nlp_enabled_description = f"\n**Contribute Message Data to NLP Training**: {self.settings.upenn_nlp_opt_in}"
         embed.add_field(
-            name="Miscellaneous Settings",
+            name="__Miscellaneous Settings__",
             value=f"**Show DDB Campaign Message**: {self.settings.show_campaign_cta}\n"
             f"**Critical Damage Type**: {crit_type_desc(self.settings.crit_type)}"
             f"{nlp_enabled_description}",


### PR DESCRIPTION
### Summary
Fixes some issues with the 3.5 patch:

- Fixes an error with operated dice with the new crit damage types
- Adds a 'default' reset option for the dice setting of roll stats
- Increases the max rolls on rollstats, as the limit was lower than the alias it was intended to replace
- Adds underlines to the field titles in the serv/char settings embed to increase readability
- Convert dice constant to Int before sending to DDB Game Log

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
