### PR TITLE
fix: use max(map(...)) instead of max(..., key=...) in randchoices

### DIFF
--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -180,7 +180,7 @@ def randchoice(seq):
 def randchoices(population, weights=None, cum_weights=None, k=1):
     if k > MAX_ITER_LENGTH:
         draconic._raise_in_context(draconic.IterableTooLong, "The length of the output is too large.")
-    if max(population, key=approx_len_of) * k > MAX_ITER_LENGTH:
+    if max(map(approx_len_of, population)) * k > MAX_ITER_LENGTH:
         draconic._raise_in_context(draconic.IterableTooLong, "The length of your input is too large.")
     return random.choices(population, weights=weights, cum_weights=cum_weights, k=k)
 


### PR DESCRIPTION
Fixes #1757

### Summary
Changes the line using `max(..., key=...)` to `max(map(..., ...)`, because the former does not return the list of lengths, while the latter does.

I have not pulled this down to test it, however given how simple of a change it is, I don't expect it to run into issues.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
