### PR TITLE
2022w17

### DIFF
--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -1,4 +1,5 @@
 import copy
+from functools import cached_property
 
 import d20
 import draconic
@@ -87,16 +88,25 @@ class RollEffectMetaVar:
 
     def __init__(self, simplified_expr: d20.Expression):
         self._expr = simplified_expr
-        self._str = RerollableStringifier().stringify(simplified_expr.roll)
 
+    # cached props
+    @cached_property
+    def _str(self):
+        return RerollableStringifier().stringify(self._expr.roll)
+
+    @cached_property
+    def _total(self):
+        return self._expr.total
+
+    # magic methods
     def __str__(self):
         return self._str
 
     def __int__(self):
-        return int(self._expr)
+        return int(self._total)
 
     def __float__(self):
-        return self._expr.total
+        return float(self._total)
 
     def __eq__(self, other):
-        return self._expr == other
+        return self._total == other

--- a/cogs5e/models/ddbsync.py
+++ b/cogs5e/models/ddbsync.py
@@ -1,3 +1,6 @@
+import asyncio
+
+import ddb.errors
 from cogs5e.models.sheet.integrations import LiveIntegration
 
 _sentinel = object()
@@ -91,6 +94,12 @@ class DDBSheetSync(LiveIntegration):
             fail_count=clamp(0, death_saves.fails, 3),
             character_id=int(self.character.upstream_id),
         )
+
+    async def _run_awaitables(self, awaitables):
+        try:
+            return await asyncio.gather(*awaitables)
+        except ddb.errors.Forbidden:
+            pass
 
     async def commit(self, ctx):
         ddb_user = await ctx.bot.ddb.get_ddb_user(ctx)

--- a/ddb/baseclient.py
+++ b/ddb/baseclient.py
@@ -4,7 +4,7 @@ import logging
 import aiohttp
 
 from .auth import BeyondUser
-from .errors import ClientResponseError, ClientTimeoutError, ClientValueError
+from .errors import ClientResponseError, ClientTimeoutError, ClientValueError, Forbidden
 
 
 class BaseClient(abc.ABC):
@@ -26,7 +26,10 @@ class BaseClient(abc.ABC):
                     self.logger.warning(
                         f"{method} {self.SERVICE_BASE}{route} returned {resp.status} {resp.reason}\n{data}"
                     )
-                    raise ClientResponseError(f"D&D Beyond returned an error: {resp.status}: {resp.reason}")
+                    if resp.status == 403:
+                        raise Forbidden(f"D&D Beyond returned an error: {resp.status}: {resp.reason}")
+                    else:
+                        raise ClientResponseError(f"D&D Beyond returned an error: {resp.status}: {resp.reason}")
                 try:
                     data = await resp.json()
                     self.logger.debug(data)

--- a/ddb/errors.py
+++ b/ddb/errors.py
@@ -19,6 +19,12 @@ class ClientResponseError(ClientException):
     pass
 
 
+class Forbidden(ClientResponseError):
+    """The response is 403 Forbidden"""
+
+    pass
+
+
 class ClientValueError(ClientException):
     """We cannot deserialize the client's response"""
 

--- a/ddb/gamelog/context.py
+++ b/ddb/gamelog/context.py
@@ -2,7 +2,6 @@ import logging
 
 import discord
 
-from cogs5e.models.character import Character
 from cogs5e.models.errors import NoCharacter
 from ddb.gamelog.errors import IgnoreEvent
 from ddb.utils import ddb_id_to_discord_user
@@ -123,6 +122,8 @@ class GameLogEventContext:
 
         :rtype: cogs5e.models.character.Character or None
         """
+        from cogs5e.models.character import Character
+
         if self._character is not _sentinel:
             return self._character
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -311,9 +311,11 @@ Rolls some dice and saves the result in a variable. Displays the roll and its na
 
 **Variables**
 
-- ``(supplied name)`` (:class:`RollEffectMetaVar`) The result of the roll. You can use this in an AnnotatedString to
-  retrieve the simplified result of the roll, or in an IntExpression to retrieve the roll total. Note that using this
-  variable in an AnnotatedString will always return a string that itself can be rolled.
+- ``(supplied name)`` (:class:`RollEffectMetaVar`) The result of the roll.
+    - You can use this in an AnnotatedString to retrieve the simplified result of the roll. Using this variable in an
+      AnnotatedString will always return a string that itself can be rolled.
+    - You can use this in an IntExpression to retrieve the roll total.
+    - You can compare this variable against a number to determine if the total of the roll equals that number.
 - ``lastRoll`` (:class:`int`) The integer total of the roll.
 
 Text

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -2,6 +2,7 @@ import discord.utils
 from discord.ext import commands
 
 from utils import config
+from utils.functions import natural_join
 from utils.aldclient import discord_user_to_dict
 
 
@@ -118,5 +119,17 @@ def feature_flag(flag_name, use_ddb_user=False, default=False):
             return True
 
         raise commands.CheckFailure("This command is currently disabled. Check back later!")
+
+    return commands.check(predicate)
+
+
+def user_permissions(*permissions: str):
+    """The user must have all of the specified permissions granted by `!admin set_user_permissions`"""
+
+    async def predicate(ctx):
+        user_p = await ctx.bot.mdb.user_permissions.find_one({"id": str(ctx.author.id)})
+        if all(user_p.get(p) for p in permissions):
+            return True
+        raise commands.CheckFailure(f"This command requires the {natural_join(permissions, 'and')} permissions.")
 
     return commands.check(predicate)


### PR DESCRIPTION
### Summary
- Fixes an issue where comparing the result of a Roll automation node with a number would always return False
- Added an admin command to run an automated gamedata entity for debugging
- Added the `content-admin` user permission to allow reloading gamedata and debugging content
- Reduced the logging enthusiasm of the DDB sheet syncer (to remove 403 noise)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
