### PR TITLE
Add more things to the IEffect Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ To install the dependencies, run:
 (venv) $ pip install -r requirements.txt
 ```
 
+*Optional* - You can install the `avrae-automation-common` and `draconic` dependencies from your local filesystem
+rather than pip+git, to make working on depended libraries in parallel easier:
+
+```bash
+(venv) $ pip install /path/to/automation-common -e
+(venv) $ pip install /path/to/draconic -e
+```
+
+Any changes to the library will immediately be picked up in avrae without requiring a reinstall of the library.
+
 #### Environment Variables
 
 | Name                             | Description                                                                                                                                                                      | Used For                      | Set By (dev)         | Set By (prod)                     | Required?       |
@@ -101,7 +111,7 @@ To install the dependencies, run:
 | `NUM_CLUSTERS`                   | The number of clusters (ECS tasks) Avrae is running across. Defaults to 1.                                                                                                       | Cluster coordination          | N/A                  | Terraform                         | *prod only*     |
 | `NUM_SHARDS`                     | An explicit override for the number of shards to run across all shards. Defaults to dynamic value from Discord.                                                                  | Cluster coordination          | N/A                  | Terraform (nightly/stg)           | no              |
 | `RELOAD_INTERVAL`                | An interval to automatically reload gamedata at, in seconds. Defaults to 0. This should be set to 0.                                                                             | Loading gamedata              | N/A                  | N/A                               | no              |
-| `ECS_CONTAINER_METADATA_URI`     | <https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v3-fargate.html>                                                                                    | Cluster coordination          | N/A                  | AWS Fargate                       | *prod only*     |
+| `ECS_CONTAINER_METADATA_URI`     | <https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-metadata-endpoint-v3-fargate.html>                                                                                  | Cluster coordination          | N/A                  | AWS Fargate                       | *prod only*     |
 | `DISCORD_OWNER_USER_ID`          | The Discord user ID of the bot administrator.                                                                                                                                    | Admin command checks          | you                  | Terraform                         | **yes**         |
 | `MONSTER_TOKEN_ENDPOINT`         | The base URL that monster token paths defined in monster gamedata are relative to.                                                                                               | `!token`                      | N/A                  | Terraform                         | *prod only*     |
 | `DRACONIC_SIGNATURE_SECRET`      | The secret used to sign signatures in the Draconic API's `signature()` function. Defaults to `secret`.                                                                           | Aliasing                      | optional             | AWS Secrets Manager via Terraform | *prod only*     |

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1000,11 +1000,13 @@ class InitTracker(commands.Cog):
         `-immune <damage type>` - Gives the combatant immunity to the given damage type.
         `-vuln <damage type>` - Gives the combatant vulnerability to the given damage type.
         `-neutral <damage type>` - Removes the combatant's immunity, resistance, or vulnerability to the given damage type.
+        __Checks/Saves__
+        `-sb <save bonus>` - Adds a bonus to all saving throws.
+        `-sadv/sdis <ability>` - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
+        `-cb <check bonus>` - Adds a bonus to all ability checks.
+        `-cadv/cdis <ability>` - Gives advantage/disadvantage on ability checks for the provided ability, or "all" for all checks. If a base ability is passed, affects all skills based on that ability.
         __General__
         `-ac <ac>` - modifies ac temporarily; adds if starts with +/- or sets otherwise.
-        `-sb <save bonus>` - Adds a bonus to all saving throws.
-        `-cb <check bonus>` - Adds a bonus to all ability checks.
-        `-sadv/sdis <ability>` - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
         `-maxhp <hp>` - modifies maximum hp temporarily; adds if starts with +/- or sets otherwise.
         `-desc <description>` - Adds a description of the effect.
         """  # noqa: E501

--- a/cogs5e/models/automation/effects/__init__.py
+++ b/cogs5e/models/automation/effects/__init__.py
@@ -115,6 +115,7 @@ from . import (
     usecounter,
     variable,
     castspell,
+    check,
 )
 
 Target = target.Target
@@ -131,6 +132,7 @@ SetVariable = variable.SetVariable
 Condition = condition.Condition
 UseCounter = usecounter.UseCounter
 CastSpell = castspell.CastSpell
+Check = check.Check
 
 EFFECT_MAP = {
     "target": Target,
@@ -147,4 +149,5 @@ EFFECT_MAP = {
     "condition": Condition,
     "counter": UseCounter,
     "spell": CastSpell,
+    "check": Check,
 }

--- a/cogs5e/models/automation/effects/__init__.py
+++ b/cogs5e/models/automation/effects/__init__.py
@@ -19,6 +19,7 @@ __all__ = (
     "Condition",
     "UseCounter",
     "CastSpell",
+    "Check",
 )
 
 log = logging.getLogger(__name__)

--- a/cogs5e/models/automation/effects/check.py
+++ b/cogs5e/models/automation/effects/check.py
@@ -167,7 +167,7 @@ class Check(Effect):
                 elif check_roll.total == contest_roll.total:
                     success_str = "; Tie!"
                     autoctx.metavars["lastContestDidTie"] = True
-                    if self.contest_tie_behaviour == "fail":
+                    if self.contest_tie_behaviour == "fail" or self.contest_tie_behaviour is None:
                         is_success = False
                     elif self.contest_tie_behaviour == "success":
                         is_success = True

--- a/cogs5e/models/automation/effects/check.py
+++ b/cogs5e/models/automation/effects/check.py
@@ -1,0 +1,220 @@
+from typing import TYPE_CHECKING, Union
+
+import d20
+
+from utils import constants
+from utils.functions import camel_to_title, maybe_mod, reconcile_adv
+from . import Effect
+from ..errors import AutomationException, InvalidIntExpression, TargetException
+from ..results import CheckResult
+from ..utils import stringify_intexpr
+
+if TYPE_CHECKING:
+    from ..runtime import AutomationContext, AutomationTarget
+    from cogs5e.models.sheet.base import Skill
+
+
+class Check(Effect):
+    def __init__(
+        self,
+        ability: str | list[str],
+        dc: str = None,
+        success: list[Effect] = None,
+        fail: list[Effect] = None,
+        **kwargs,
+    ):
+        super().__init__("check", **kwargs)
+        self.ability = ability
+        self.dc = dc
+        self.success = success
+        self.fail = fail
+
+    @classmethod
+    def from_data(cls, data):
+        if data.get("success"):
+            data["success"] = Effect.deserialize(data["success"])
+        if data.get("fail"):
+            data["fail"] = Effect.deserialize(data["fail"])
+        return super().from_data(data)
+
+    def to_dict(self):
+        out = super().to_dict()
+        out.update({"ability": self.ability})
+        if self.dc is not None:
+            out["dc"] = self.dc
+        if self.success:
+            out["success"] = Effect.serialize(self.success)
+        if self.fail:
+            out["fail"] = Effect.serialize(self.fail)
+        return out
+
+    def run(self, autoctx: "AutomationContext"):
+        super().run(autoctx)
+        if autoctx.target is None:
+            raise TargetException(
+                "Tried to make a check without a target! Make sure all Check effects are inside of a Target effect."
+            )
+
+        # ==== args ====
+        ability = autoctx.args.last("ability") or self.ability
+        auto_pass = autoctx.args.last("cpass", type_=bool, ephem=True)
+        auto_fail = autoctx.args.last("cfail", type_=bool, ephem=True)
+        hide = autoctx.args.last("h", type_=bool)
+
+        if ability not in constants.SKILL_NAMES:
+            raise AutomationException(f"{ability!r} is not a valid skill name.")
+
+        # ==== dc ====
+        check_dc = None
+        if self.dc:
+            try:
+                check_dc = autoctx.parse_intexpression(self.dc)
+            except InvalidIntExpression:
+                raise AutomationException(f"{self.dc!r} cannot be interpreted as a DC.")
+
+        if "cdc" in autoctx.args:
+            check_dc = maybe_mod(autoctx.args.last("cdc"), base=check_dc or 0)
+
+        # ==== execution ====
+        skill_name = camel_to_title(ability)
+        check_roll = None
+        is_success = None
+        autoctx.metavars["lastCheckRollTotal"] = 0
+        autoctx.metavars["lastCheckNaturalRoll"] = 0
+        autoctx.metavars["lastCheckAbility"] = skill_name
+        autoctx.metavars["lastCheckDidPass"] = None
+        autoctx.metavars["lastCheckDC"] = check_dc
+
+        if check_dc is not None:
+            autoctx.meta_queue(f"**Check DC**: {check_dc}")
+
+        if not autoctx.target.is_simple:
+            check_blurb = f"{skill_name} Check"
+            if auto_pass:
+                is_success = True
+                autoctx.queue(f"**{check_blurb}:** Automatic success!")
+            elif auto_fail:
+                is_success = False
+                autoctx.queue(f"**{check_blurb}:** Automatic failure!")
+            else:
+                skill = autoctx.target.target.skills[ability]
+                check_dice = get_check_dice_for_statblock(autoctx, statblock_holder=autoctx, skill=skill)
+                check_roll = d20.roll(check_dice)
+
+                # get natural roll
+                d20_value = d20.utils.leftmost(check_roll.expr).total
+
+                autoctx.metavars["lastCheckRollTotal"] = check_roll.total
+                autoctx.metavars["lastCheckNaturalRoll"] = d20_value
+
+                if check_dc is not None:
+                    is_success = check_roll.total >= check_dc
+                    success_str = "; Success!" if is_success else "; Failure!"
+                else:
+                    success_str = ""
+
+                out = f"**{check_blurb}**: {check_roll.result}{success_str}"
+
+                if not hide:
+                    autoctx.queue(out)
+                else:
+                    autoctx.add_pm(str(autoctx.ctx.author.id), out)
+                    autoctx.queue(f"**{check_blurb}**: 1d20...{success_str}")
+        else:
+            autoctx.meta_queue(f"{skill_name} Check")
+            is_success = True
+
+        children = []
+        if check_dc is not None:
+            if is_success:
+                children = self.on_success(autoctx)
+            else:
+                children = self.on_fail(autoctx)
+
+        return CheckResult(
+            skill_name=skill_name, check_roll=check_roll, dc=check_dc, did_succeed=is_success, children=children
+        )
+
+    def on_success(self, autoctx):
+        autoctx.metavars["lastCheckDidPass"] = True
+        if self.success:
+            return self.run_children(self.success, autoctx)
+        return []
+
+    def on_fail(self, autoctx):
+        autoctx.metavars["lastCheckDidPass"] = False
+        if self.fail:
+            return self.run_children(self.fail, autoctx)
+        return []
+
+    def build_str(self, caster, evaluator):
+        super().build_str(caster, evaluator)
+        skill_name = camel_to_title(self.ability)
+        if self.dc is None:
+            return f"{skill_name} Check"
+
+        dc = stringify_intexpr(evaluator, self.dc)
+        out = f"DC {dc} {skill_name} Check"
+        if self.fail:
+            fail_out = self.build_child_str(self.fail, caster, evaluator)
+            if fail_out:
+                out += f". Fail: {fail_out}"
+        if self.success:
+            success_out = self.build_child_str(self.success, caster, evaluator)
+            if success_out:
+                out += f". Success: {success_out}"
+        return out
+
+    @property
+    def children(self):
+        return super().children + (self.fail or []) + (self.success or [])
+
+
+def get_check_dice_for_statblock(
+    autoctx: "AutomationContext", statblock_holder: Union["AutomationContext", "AutomationTarget"], skill: "Skill"
+) -> str:
+    """
+    Resolves the check dice for the given skill, taking into account character settings and ieffects.
+
+    Consumed arguments: -cb, cadv, cdis, -mc
+    """
+
+    # ==== ieffects ====
+    # todo
+    # sadv_effects = autoctx.target_active_effects(
+    #     mapper=lambda effect: effect.effects.save_adv, reducer=lambda saves: set().union(*saves), default=set()
+    # )
+    # sdis_effects = autoctx.target_active_effects(
+    #     mapper=lambda effect: effect.effects.save_dis, reducer=lambda saves: set().union(*saves), default=set()
+    # )
+    # sadv = stat in sadv_effects
+    # sdis = stat in sdis_effects
+
+    # ==== options / ieffects ====
+    # reliable talent, halfling luck
+    reroll = None
+    min_check = None
+    if statblock_holder.character:
+        char_options = statblock_holder.character.options
+        has_talent = bool(char_options.talent and (skill and skill.prof >= 1))
+        min_check = 10 * has_talent
+        reroll = char_options.reroll
+
+    # ieffects
+    cb = []
+    if statblock_holder.combatant and autoctx.allow_target_ieffects:
+        cb = statblock_holder.combatant.active_effects(mapper=lambda effect: effect.effects.check_bonus, default=[])
+
+    # ==== args ====
+    cb.extend(autoctx.args.get("cb", default=[], ephem=True))
+    base_adv = reconcile_adv(
+        adv=autoctx.args.last("cadv", type_=bool, ephem=True),
+        dis=autoctx.args.last("cdis", type_=bool, ephem=True),
+    )
+    min_check = autoctx.args.last("mc", default=min_check, type_=int, ephem=True)
+
+    # build final dice
+    check_dice = skill.d20(base_adv=base_adv, reroll=reroll, min_val=min_check)
+    if cb:
+        check_dice = f"{check_dice}+{'+'.join(cb)}"
+    return check_dice

--- a/cogs5e/models/automation/effects/check.py
+++ b/cogs5e/models/automation/effects/check.py
@@ -24,6 +24,7 @@ class Check(Effect):
         success: list[Effect] = None,
         fail: list[Effect] = None,
         contestTie: str = None,
+        adv: enums.AdvantageType = None,
         **kwargs,
     ):
         super().__init__("check", **kwargs)
@@ -33,6 +34,7 @@ class Check(Effect):
         self.success = success
         self.fail = fail
         self.contest_tie_behaviour = contestTie
+        self.adv = adv
 
     @classmethod
     def from_data(cls, data):
@@ -40,6 +42,8 @@ class Check(Effect):
             data["success"] = Effect.deserialize(data["success"])
         if data.get("fail"):
             data["fail"] = Effect.deserialize(data["fail"])
+        if data.get("adv") is not None:
+            data["adv"] = enums.AdvantageType(data["adv"])
         return super().from_data(data)
 
     def to_dict(self):
@@ -55,6 +59,8 @@ class Check(Effect):
             out["fail"] = Effect.serialize(self.fail)
         if self.contest_tie_behaviour:
             out["contestTie"] = self.contest_tie_behaviour
+        if self.adv:
+            out["adv"] = self.adv.value
         return out
 
     def run(self, autoctx: "AutomationContext"):
@@ -77,8 +83,8 @@ class Check(Effect):
         auto_fail = autoctx.args.last("cfail", type_=bool, ephem=True)
         check_bonus = autoctx.args.get("cb", ephem=True)
         base_adv = reconcile_adv(
-            adv=autoctx.args.last("cadv", type_=bool, ephem=True),
-            dis=autoctx.args.last("cdis", type_=bool, ephem=True),
+            adv=autoctx.args.last("cadv", type_=bool, ephem=True) or self.adv == enums.AdvantageType.ADV,
+            dis=autoctx.args.last("cdis", type_=bool, ephem=True) or self.adv == enums.AdvantageType.DIS,
         )
         min_check = autoctx.args.last("mc", type_=int, ephem=True)
         hide = autoctx.args.last("h", type_=bool)

--- a/cogs5e/models/automation/effects/check.py
+++ b/cogs5e/models/automation/effects/check.py
@@ -118,6 +118,7 @@ class Check(Effect):
         autoctx.metavars["lastCheckDC"] = check_dc
 
         # ==== contest ====
+        contest_skill_name = None
         contest_roll = None
         if self.contest_ability is not None:
             contest_skill, contest_skill_key = get_highest_skill(autoctx.caster, self.contest_ability_list)
@@ -193,7 +194,13 @@ class Check(Effect):
             children = self.on_fail(autoctx)
 
         return CheckResult(
-            skill_name=skill_name, check_roll=check_roll, dc=check_dc, did_succeed=is_success, children=children
+            skill_name=skill_name,
+            check_roll=check_roll,
+            dc=check_dc,
+            did_succeed=is_success,
+            children=children,
+            contest_skill_name=contest_skill_name,
+            contest_roll=contest_roll,
         )
 
     def on_success(self, autoctx):

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 
 import disnake
 
+import aliasing.api.combat
 from cogs5e import initiative as init
 from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.resistance import Resistance
@@ -119,7 +120,7 @@ class LegacyIEffect(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, IEffectMetaVar):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an IEffectMetaVar "
                         f"(got `{type(parent_ref).__name__}`)."
@@ -293,10 +294,10 @@ class IEffect(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, IEffectMetaVar):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
                     raise InvalidArgument(
-                        f"Could not set IEffect parent: The variable `{self.parent}` is not an IEffectMetaVar "
-                        f"(got `{type(parent_ref).__name__}`)."
+                        f"Could not set IEffect parent: The variable `{self.parent}` is not an initiative effect "
+                        f"(expected IEffectMetaVar or SimpleEffect, got `{type(parent_ref).__name__}`)."
                     )
                 # noinspection PyProtectedMember
                 explicit_parent = parent_ref._effect

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -379,6 +379,8 @@ class _PassiveEffectsWrapper:
             save_adv=self.resolve_save_advs(autoctx, "save_adv"),
             save_dis=self.resolve_save_advs(autoctx, "save_dis"),
             check_bonus=self.resolve_annotatedstring(autoctx, "check_bonus"),
+            check_adv=self.resolve_check_advs(autoctx, "check_adv"),
+            check_dis=self.resolve_check_advs(autoctx, "check_dis"),
         )
 
     def resolve_annotatedstring(self, autoctx, attr: str) -> str | None:
@@ -424,6 +426,11 @@ class _PassiveEffectsWrapper:
         """save_adv: a list of AnnotatedString -> a set of str"""
         data = self.resolve_annotatedstring_list(autoctx, attr)
         return init.effects.passive.resolve_save_advs(data)
+
+    def resolve_check_advs(self, autoctx, attr: str) -> set[str]:
+        """check_adv: a list of AnnotatedString -> a set of str"""
+        data = self.resolve_annotatedstring_list(autoctx, attr)
+        return init.effects.passive.resolve_check_advs(data)
 
 
 class _AttackInteractionWrapper:

--- a/cogs5e/models/automation/effects/remove_ieffect.py
+++ b/cogs5e/models/automation/effects/remove_ieffect.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from . import Effect
 from ..errors import AutomationException
+from ..results import RemoveIEffectResult
 
 if TYPE_CHECKING:
     from . import AutomationContext
@@ -29,8 +30,11 @@ class RemoveIEffect(Effect):
         autoctx.meta_queue(f"**Removed Effect**: {autoctx.ieffect.name}")
 
         # remove parent, if applicable
+        removed_parent = None
         if self.remove_parent is not None and (parent_effect := autoctx.ieffect.get_parent_effect()) is not None:
-            self.run_remove_parent(autoctx, parent_effect)
+            removed_parent = self.run_remove_parent(autoctx, parent_effect)
+
+        return RemoveIEffectResult(removed_effect=autoctx.ieffect, removed_parent=removed_parent)
 
     def run_remove_parent(self, autoctx: "AutomationContext", parent_effect: "InitiativeEffect"):
         do_remove = self.remove_parent == "always" or (
@@ -39,6 +43,7 @@ class RemoveIEffect(Effect):
         if do_remove:
             parent_effect.remove()
             autoctx.meta_queue(f"**Removed Effect**: {parent_effect.name}")
+            return parent_effect
 
     def build_str(self, caster, evaluator):
         super().build_str(caster, evaluator)

--- a/cogs5e/models/automation/results.py
+++ b/cogs5e/models/automation/results.py
@@ -18,6 +18,7 @@ __all__ = (
     "DamageResult",
     "TempHPResult",
     "IEffectResult",
+    "RemoveIEffectResult",
     "RollResult",
     "TextResult",
     "SetVariableResult",
@@ -110,6 +111,12 @@ class TempHPResult(EffectResult):
 class IEffectResult(EffectResult):
     effect: "InitiativeEffect"
     conc_conflict: List["InitiativeEffect"]
+
+
+@dataclass(frozen=True)
+class RemoveIEffectResult(EffectResult):
+    removed_effect: "InitiativeEffect"
+    removed_parent: Optional["InitiativeEffect"]
 
 
 @dataclass(frozen=True)

--- a/cogs5e/models/automation/results.py
+++ b/cogs5e/models/automation/results.py
@@ -168,5 +168,7 @@ class CheckResult(EffectResult):
     skill_name: str
     check_roll: Optional[d20.RollResult]  # None if target is simple or automatic fail/pass
     dc: Optional[int]
+    contest_roll: Optional[d20.RollResult]
+    contest_skill_name: Optional[str]
     did_succeed: Optional[bool]
     children: List[EffectResult]

--- a/cogs5e/models/automation/results.py
+++ b/cogs5e/models/automation/results.py
@@ -25,6 +25,7 @@ __all__ = (
     "ConditionResult",
     "UseCounterResult",
     "CastSpellResult",
+    "CheckResult",
 )
 
 
@@ -160,3 +161,12 @@ class CastSpellResult(EffectResult):
     success: bool
     spell: Optional["Spell"] = None
     children: List[EffectResult] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class CheckResult(EffectResult):
+    skill_name: str
+    check_roll: Optional[d20.RollResult]  # None if target is simple or automatic fail/pass
+    dc: Optional[int]
+    did_succeed: Optional[bool]
+    children: List[EffectResult]

--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -1,8 +1,11 @@
 import hashlib
 import logging
 import re
+from typing import List
 
 import aiohttp
+import automation_common
+import pydantic
 import yaml
 from markdownify import markdownify
 from math import floor
@@ -432,19 +435,17 @@ def parse_critterdb_traits(data, key):
                         raise ExternalImportError(f"Monster had an invalid automation YAML ({data['name']}: {name})")
                     if not isinstance(attack_yaml, list):
                         attack_yaml = [attack_yaml]
-                    for atk in attack_yaml:
-                        if isinstance(atk, dict):
-                            atk["name"] = atk_name = atk.get("name") or name
-                            try:
-                                attacks.append(Attack.from_dict(atk))
-                            except Exception:
-                                raise ExternalImportError(
-                                    f"An automation YAML contained an invalid attack ({data['name']}: {atk_name})"
-                                )
-                        else:
-                            raise ExternalImportError(
-                                f"An automation YAML contained an invalid attack ({data['name']}: {name})"
-                            )
+
+                    try:
+                        normalized_obj = pydantic.parse_obj_as(
+                            List[automation_common.validation.models.AttackModel], attack_yaml, type_name="AttackList"
+                        )
+                    except pydantic.ValidationError as e:
+                        raise ExternalImportError(
+                            f"An automation YAML for {data['name']} contained an invalid attack: ```py\n{e!s}\n```"
+                        )
+
+                    attacks.extend(Attack.from_dict(a.dict()) for a in normalized_obj)
                 # else: empty override, so skip this attack.
         elif raw_atks:
             for atk in raw_atks:

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -100,6 +100,14 @@ __Damage Types__
 nopact - Uses a normal spell slot instead of a Pact Magic slot, if applicable.
 -i - Skips using any resources.
 
+**Checks**
+-ability <ability> - Overrides the check roll's ability (e.g. `-ability arcana`, `-ability sleightOfHand`).
+*-cb <bonus>* - Adds a bonus to ability checks.
+-cdc <dc> - Overrides the DC of the ability check.
+-cdc <+X/-X> - Modifies the DC by a certain amount.
+*cadv/cdis* - Gives the target advantage/disadvantage on the ability check.
+*cpass/cfail* - Target automatically succeeds or fails the ability check if a DC is given.
+
 **Other**
 -h - Hides rolled values.
 -phrase <phrase> - Adds flavor text.

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -5,7 +5,31 @@ This page details the structure of Avrae's Automation system, the backbone behin
 
 Basic Structure
 ---------------
-An automation run is made up of a list of *effects*. See below for what each effect does.
+An automation run is made up of a list of *effects* (AKA *automation node*), each of which may have additional *effects*
+that it runs under certain conditions. This recursive structure is called the *automation tree*.
+
+**Glossary**
+
+.. data:: automation engine
+
+    The Automation Engine is the code responsible for reading the automation tree and executing it against the current
+    game state. It handles rolling the dice, checking against your targets' armor classes, modifying hit points, and
+    other game mechanics.
+
+.. data:: automation tree
+          automation
+
+    The automation tree (sometimes just called "automation") is the program that the Automation Engine runs. It's made
+    up of multiple nodes that all link together to make an attack, action, spell, or more.
+
+.. data:: effect
+          node
+
+    A single step of automation - usually, this is a D&D game mechanic like rolling to hit, making a saving throw,
+    or dealing damage, but this can also be used in more programmatic ways to help set up other nodes.
+
+Runtime Variables
+-----------------
 
 All Automation runs provide the following variables:
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -477,7 +477,7 @@ AttackInteraction
 
     {
         attack: Attack;
-        defaultDc?: IntExpression;
+        defaultDC?: IntExpression;
         defaultAttackBonus?: IntExpression;
         defaultCastingMod?: IntExpression;
     }
@@ -505,7 +505,7 @@ Used to specify an attack granted by an initiative effect: some automation that 
                 extra_crit_damage?: string;
             }
 
-    .. attribute:: defaultDc
+    .. attribute:: defaultDC
 
         *optional* - The default saving throw DC to use when running the automation. If not provided, defaults to the
         targeted combatant's default spellcasting DC (or any DC specified in the automation). Use this if the effect's

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -39,6 +39,12 @@ All Automation runs provide the following variables:
 - ``targets`` (list of :class:`~aliasing.api.statblock.AliasStatBlock`, :class:`str`, or None) A list of combatants
   targeted by this automation (i.e. the ``-t`` argument).
 
+Additionally, runs triggered by an initiative effect (such as automation provided in a :ref:`ButtonInteraction`) provide
+the following variables:
+
+- ``ieffect`` (:class:`~aliasing.api.combat.SimpleEffect`) The initiative effect responsible for providing the
+  automation.
+
 Target
 ------
 .. code-block:: typescript

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -373,6 +373,8 @@ PassiveEffects
         save_adv: AnnotatedString[];
         save_dis: AnnotatedString[];
         check_bonus: AnnotatedString;
+        check_adv: AnnotatedString[];
+        check_dis: AnnotatedString[];
     }
 
 Used to specify the passive effects granted by an initiative effect.
@@ -467,6 +469,20 @@ Used to specify the passive effects granted by an initiative effect.
     .. attribute:: check_bonus
 
         *optional* - A bonus that this effect grants to all of the combatant's skill checks.
+
+    .. attribute:: check_adv
+
+        *optional* - A list of skill names (e.g. ``sleightOfHand``, ``strength``) that the combatant should have
+        advantage on for ability checks for while this effect is active. If a base ability is given, the advantage
+        will apply to all skills based on that ability (e.g. ``strength`` gives advantage on ``athletics`` checks).
+        Use ``all`` as a stat name to specify all skills.
+
+    .. attribute:: check_dis
+
+        *optional* - A list of skill names (e.g. ``sleightOfHand``, ``strength``) that the combatant should have
+        disadvantage on for ability checks for while this effect is active. If a base ability is given, the disadvantage
+        will apply to all skills based on that ability (e.g. ``strength`` gives disadvantage on ``athletics`` checks).
+        Use ``all`` as a stat name to specify all skills.
 
 .. _attackinteraction:
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -150,6 +150,7 @@ Save
         fail: Effect[];
         success: Effect[];
         dc?: IntExpression;
+        adv?: -1 | 0 | 1;
     }
 
 A Save effect forces a targeted creature to make a saving throw.
@@ -172,6 +173,11 @@ It must be inside a Target effect.
     .. attribute:: dc
 
         *optional* - An IntExpression that details what DC to use (defaults to caster's spell DC).
+
+    .. attribute:: adv
+
+        *optional, default 0* - Whether the saving throw should have advantage by default (``-1`` = disadvantage,
+        ``1`` = advantage, ``0`` = no advantage).
 
 **Variables**
 
@@ -938,6 +944,7 @@ Ability Check
         success?: Effect[];
         fail?: Effect[];
         contestTie?: "fail" | "success" | "neither";
+        adv?: -1 | 0 | 1;
     }
 
 An Ability Check effect forces a targeted creature to make an ability check, optionally as a contest against the caster.
@@ -1007,6 +1014,11 @@ It must be inside a Target effect.
     .. attribute:: contestTie
 
         *optional, default success* - Which list of effects to run if the ability contest results in a tie.
+
+    .. attribute:: adv
+
+        *optional, default 0* - Whether the check should have advantage by default (``-1`` = disadvantage,
+        ``1`` = advantage, ``0`` = no advantage).
 
 **Variables**
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -989,7 +989,8 @@ It must be inside a Target effect.
 
     .. attribute:: dc
 
-        *optional* - An IntExpression that details what DC to use (defaults to caster's spell DC).
+        *optional* - An IntExpression that specifies the check's DC. If neither ``dc`` nor ``contestAbility`` is given,
+        the check will not run either the ``fail`` or ``success`` nodes.
 
         Mutually exclusive with ``contestAbility``.
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -25,16 +25,19 @@ that it runs under certain conditions. This recursive structure is called the *a
 .. data:: effect
           node
 
-    A single step of automation - usually, this is a D&D game mechanic like rolling to hit, making a saving throw,
-    or dealing damage, but this can also be used in more programmatic ways to help set up other nodes.
+    A single step of automation - usually, this is a D&D game mechanic like :ref:`rolling to hit<Attack>`,
+    :ref:`making a saving throw<Save>`, or :ref:`dealing damage<Damage>`, but this can also be used in more programmatic
+    ways to help set up other nodes.
 
 Runtime Variables
 -----------------
 
 All Automation runs provide the following variables:
 
-- ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The character, combatant, or monster who is running the automation.
-- ``targets`` (list of :class:`~aliasing.api.statblock.AliasStatBlock`, :class:`str`, or None) A list of combatants targeted by this automation (i.e. the ``-t`` argument).
+- ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The character, combatant, or monster who is running the
+  automation.
+- ``targets`` (list of :class:`~aliasing.api.statblock.AliasStatBlock`, :class:`str`, or None) A list of combatants
+  targeted by this automation (i.e. the ``-t`` argument).
 
 Target
 ------
@@ -50,27 +53,29 @@ Target
 A Target effect should only show up as a top-level effect.
 It designates what creatures to affect.
 
-.. attribute:: target
+.. class:: Target
 
-    - ``"all"`` or ``"each"`` (actions only): Affects each of the given (by the ``-t`` argument) targets.
-    - ``int`` (actions only): Affects the Nth target (1-indexed).
-    - ``"self"``: Affects the caster, or the actor the triggering effect is on if run from an IEffect button.
-    - ``"parent"`` (IEffect buttons only): If the triggering effect has a parent effect, affects the actor the parent
-      effect is on.
-    - ``"children"`` (IEffect buttons only): If the triggering effect has any children effects, affects each actor a
-      child effect is on.
+    .. attribute:: target
 
-.. attribute:: effects
+        - ``"all"`` or ``"each"`` (actions only): Affects each of the given (by the ``-t`` argument) targets.
+        - ``int`` (actions only): Affects the Nth target (1-indexed).
+        - ``"self"``: Affects the caster, or the actor the triggering effect is on if run from an IEffect button.
+        - ``"parent"`` (IEffect buttons only): If the triggering effect has a parent effect, affects the actor the
+          parent effect is on.
+        - ``"children"`` (IEffect buttons only): If the triggering effect has any children effects, affects each actor a
+          child effect is on.
 
-    A list of effects that each targeted creature will be subject to.
+    .. attribute:: effects
 
-.. attribute:: sortBy
+        A list of effects that each targeted creature will be subject to.
 
-    *optional* - Whether to sort the target list. If not given, targets are processed in the order the ``-t`` arguments
-    are seen. This does not affect ``self`` targets.
+    .. attribute:: sortBy
 
-    - ``hp_asc``: Sorts the targets in order of remaining hit points ascending (lowest HP first, None last).
-    - ``hp_desc``: Sorts the targets in order of remaining hit points descending (highest HP first, None last).
+        *optional* - Whether to sort the target list. If not given, targets are processed in the order the ``-t``
+        arguments are seen. This does not affect ``self`` targets.
+
+        - ``hp_asc``: Sorts the targets in order of remaining hit points ascending (lowest HP first, None last).
+        - ``hp_desc``: Sorts the targets in order of remaining hit points descending (highest HP first, None last).
 
 **Variables**
 
@@ -80,6 +85,8 @@ It designates what creatures to affect.
   (0-indexed - first target = ``0``, second = ``1``, etc.). Self targets, nth-targets, and parent targets will always
   be ``0``.
 - ``targetNumber`` (:class:`int`) Same as ``targetIndex``, but 1-indexed (equivalent to ``targetIndex + 1``).
+
+.. _Attack:
 
 Attack
 ------
@@ -96,22 +103,24 @@ Attack
 An Attack effect makes an attack roll against a targeted creature.
 It must be inside a Target effect.
 
-.. attribute:: hit
+.. class:: Attack:
 
-     A list of effects to execute on a hit.
+    .. attribute:: hit
 
-.. attribute:: miss
+        A list of effects to execute on a hit.
 
-     A list of effects to execute on a miss.
+    .. attribute:: miss
 
-.. attribute:: attackBonus
+        A list of effects to execute on a miss.
 
-     *optional* - An IntExpression that details what attack bonus to use (defaults to caster's spell attack mod).
+    .. attribute:: attackBonus
 
-.. attribute:: adv
+        *optional* - An IntExpression that details what attack bonus to use (defaults to caster's spell attack mod).
 
-     *optional* - An IntExpression that details whether the attack has inherent advantage or not. ``0`` for flat, ``1``;
-     for Advantage, ``2`` for Elven Accuracy, ``-1`` for Disadvantage (Default is flat).
+    .. attribute:: adv
+
+        *optional* - An IntExpression that details whether the attack has inherent advantage or not. ``0`` for flat,
+        ``1`` for Advantage, ``2`` for Elven Accuracy, ``-1`` for Disadvantage (Default is flat).
 
 **Variables**
 
@@ -123,13 +132,15 @@ It must be inside a Target effect.
 - ``lastAttackHadAdvantage`` (:class:`int`) The advantage type of the last to-hit roll. ``0`` for flat, ``1`` for;
   Advantage, ``2`` for Elven Accuracy, ``-1`` for Disadvantage
 
+.. _Save:
+
 Save
 ----
 .. code-block:: typescript
 
     {
         type: "save";
-        stat: "str"|"dex"|"con"|"int"|"wis"|"cha";
+        stat: "str" | "dex" | "con" | "int" | "wis" | "cha";
         fail: Effect[];
         success: Effect[];
         dc?: IntExpression;
@@ -138,21 +149,23 @@ Save
 A Save effect forces a targeted creature to make a saving throw.
 It must be inside a Target effect.
 
-.. attribute:: stat
+.. class:: Save
 
-     The type of saving throw.
+    .. attribute:: stat
 
-.. attribute:: fail
+        The type of saving throw.
 
-     A list of effects to execute on a failed save.
+    .. attribute:: fail
 
-.. attribute:: success
+        A list of effects to execute on a failed save.
 
-     A list of effects to execute on a successful save.
+    .. attribute:: success
 
-.. attribute:: dc
+        A list of effects to execute on a successful save.
 
-     *optional* - An IntExpression that details what DC to use (defaults to caster's spell DC).
+    .. attribute:: dc
+
+        *optional* - An IntExpression that details what DC to use (defaults to caster's spell DC).
 
 **Variables**
 
@@ -163,6 +176,8 @@ It must be inside a Target effect.
   0 if no roll was made).
 - ``lastSaveAbility`` (:class:`str`) The title-case full name of the ability the save was made with (e.g.
   ``"Strength"``, ``"Wisdom"``, etc).
+
+.. _Damage:
 
 Damage
 ------
@@ -176,25 +191,31 @@ Damage
         cantripScale?: boolean;
     }
 
-Deals damage to a targeted creature. It must be inside a Target effect.
+Deals damage to or heals a targeted creature. It must be inside a Target effect.
 
-.. attribute:: damage
+.. note::
 
-     How much damage to deal. 
+    This node can also be used to heal a target; simply use negative damage to supply healing.
 
-.. attribute:: overheal
+.. class:: Damage
 
-    .. versionadded:: 1.4.1
+    .. attribute:: damage
 
-     *optional* - Whether this damage should allow a target to exceed its hit point maximum.
+        How much damage to deal.
 
-.. attribute:: higher
+    .. attribute:: overheal
 
-     *optional* - How much to add to the damage when a spell is cast at a certain level.
+        .. versionadded:: 1.4.1
 
-.. attribute:: cantripScale
+        *optional* - Whether this damage should allow a target to exceed its hit point maximum.
 
-     *optional* - Whether this roll should scale like a cantrip.
+    .. attribute:: higher
+
+        *optional* - How much to add to the damage when a spell is cast at a certain level.
+
+    .. attribute:: cantripScale
+
+        *optional* - Whether this roll should scale like a cantrip.
 
 **Variables**
 
@@ -213,17 +234,19 @@ TempHP
 
 Sets the target's THP. It must be inside a Target effect.
 
-.. attribute:: amount
+.. class:: TempHP
 
-     How much temp HP the target should have. 
+    .. attribute:: amount
 
-.. attribute:: higher
+        How much temp HP the target should have.
 
-     *optional* - How much to add to the THP when a spell is cast at a certain level.
+    .. attribute:: higher
 
-.. attribute:: cantripScale
+        *optional* - How much to add to the THP when a spell is cast at a certain level.
 
-     *optional* - Whether this roll should scale like a cantrip.
+    .. attribute:: cantripScale
+
+        *optional* - Whether this roll should scale like a cantrip.
 
 **Variables**
 
@@ -251,60 +274,68 @@ IEffect
 Adds an InitTracker Effect to a targeted creature, if the automation target is in combat.
 It must be inside a Target effect.
 
-.. attribute:: name
+.. note::
 
-    The name of the effect to add.
+    If the targeted creature is not in combat, this will display the effects of the initiative effect but not save
+    it on the creature.
 
-.. attribute:: duration
+.. class:: IEffect
 
-    *optional, default infinite* - The duration of the effect, in rounds of combat. If this is negative, creates an
-    effect with infinite duration.
+    .. attribute:: name
 
-.. attribute:: effects
+        The name of the effect to add.
 
-    *optional, default no effects* - The effects to add. See :ref:`passiveeffects`.
+    .. attribute:: duration
 
-.. attribute:: attacks
+        *optional, default infinite* - The duration of the effect, in rounds of combat. If this is negative, creates an
+        effect with infinite duration.
 
-    *optional, default no attacks* - The attacks granted by this effect. See :ref:`attackinteraction`.
+    .. attribute:: effects
 
-.. attribute:: buttons
+        *optional, default no effects* - The effects to add. See :ref:`passiveeffects`.
 
-    *optional, default no buttons* - The buttons granted by this effect. See :ref:`buttoninteraction`.
+    .. attribute:: attacks
 
-.. attribute:: end
+        *optional, default no attacks* - The attacks granted by this effect. See :ref:`attackinteraction`.
 
-    *optional, default false* - Whether the effect timer should tick on the end of the turn, rather than start.
+    .. attribute:: buttons
 
-.. attribute:: conc
+        *optional, default no buttons* - The buttons granted by this effect. See :ref:`buttoninteraction`.
 
-    *optional, default false* - Whether the effect requires concentration.
+    .. attribute:: end
 
-.. attribute:: desc
+        *optional, default false* - Whether the effect timer should tick on the end of the turn, rather than start.
 
-    *optional* - The description of the effect (displays on combatant's turn).
+    .. attribute:: conc
 
-.. attribute:: stacking
+        *optional, default false* - Whether the effect requires concentration.
 
-    *optional, default false* - If true and another effect with the same name is found on the target, instead of
-    overwriting, add a child effect with name ``{name} x{count}`` and no description, duration, concentration,
-    attacks, or buttons.
+    .. attribute:: desc
 
-.. attribute:: save_as
+        *optional* - The description of the effect (displays on combatant's turn).
 
-    *optional, default None* - If supplied, saves an :class:`IEffectMetaVar` to the automation runtime, which can be
-    used in another IEffect's ``parent`` key to set its parent to this effect. Must be a valid identifier.
+    .. attribute:: stacking
 
-.. attribute:: parent
+        *optional, default false* - If true and another effect with the same name is found on the target, instead of
+        overwriting, add a child effect with name ``{name} x{count}`` and no description, duration, concentration,
+        attacks, or buttons.
 
-    *optional, default None* - If supplied, sets the created effect's parent to the given effect. This must be the
-    name of an existing :class:`IEffectMetaVar`.
+    .. attribute:: save_as
 
-    If ``parent`` is supplied but the parent effect does not exist, will not set a parent.
+        *optional, default None* - If supplied, saves an :class:`IEffectMetaVar` to the automation runtime, which can be
+        used in another IEffect's ``parent`` key to set its parent to this effect. Must be a valid identifier.
 
-    If ``conc`` is true, the given parent effect will take priority over the concentration effect.
+    .. attribute:: parent
 
-    If ``stacking`` is true and a valid stack parent exists, the stack parent will take priority over the given parent.
+        *optional, default None* - If supplied, sets the created effect's parent to the given effect. This must be the
+        name of an existing :class:`IEffectMetaVar`.
+
+        If ``parent`` is supplied but the parent effect does not exist, will not set a parent.
+
+        If ``conc`` is true, the given parent effect will take priority over the concentration effect.
+
+        If ``stacking`` is true and a valid stack parent exists, the stack parent will take priority over the given
+        parent.
 
 **Variables**
 
@@ -340,94 +371,96 @@ PassiveEffects
 
 Used to specify the passive effects granted by an initiative effect.
 
-.. attribute:: attack_advantage
+.. class:: PassiveEffects
 
-    *optional, default no advantage* - Whether this effect gives the combatant advantage on all attacks.
-    -1 for dis, 1 for adv, 2 for elven accuracy.
+    .. attribute:: attack_advantage
 
-.. attribute:: to_hit_bonus
+        *optional, default no advantage* - Whether this effect gives the combatant advantage on all attacks.
+        -1 for dis, 1 for adv, 2 for elven accuracy.
 
-    *optional* - A bonus that this effect grants to all of the combatant's to-hit rolls.
+    .. attribute:: to_hit_bonus
 
-.. attribute:: damage_bonus
+        *optional* - A bonus that this effect grants to all of the combatant's to-hit rolls.
 
-    *optional* - A bonus that this effect grants to all of the combatant's damage rolls.
+    .. attribute:: damage_bonus
 
-.. attribute:: magical_damage
+        *optional* - A bonus that this effect grants to all of the combatant's damage rolls.
 
-    *optional, default false* - Whether this effect makes all of the combatant's attacks do magical damage.
-    0 for false, anything else for true.
+    .. attribute:: magical_damage
 
-.. attribute:: silvered_damage
+        *optional, default false* - Whether this effect makes all of the combatant's attacks do magical damage.
+        0 for false, anything else for true.
 
-    *optional, default false* - Whether this effect makes all of the combatant's attacks do silvered damage.
-    0 for false, anything else for true.
+    .. attribute:: silvered_damage
 
-.. attribute:: resistances
+        *optional, default false* - Whether this effect makes all of the combatant's attacks do silvered damage.
+        0 for false, anything else for true.
 
-    *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the combatant
-    should be resistant to while this effect is active.
+    .. attribute:: resistances
 
-.. attribute:: immunities
+        *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the
+        combatant should be resistant to while this effect is active.
 
-    *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the combatant
-    should be immune to while this effect is active.
+    .. attribute:: immunities
 
-.. attribute:: vulnerabilities
+        *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the
+        combatant should be immune to while this effect is active.
 
-    *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the combatant
-    should be vulnerable to while this effect is active.
+    .. attribute:: vulnerabilities
 
-.. attribute:: ignored_resistances
+        *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the
+        combatant should be vulnerable to while this effect is active.
 
-    *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the combatant
-    should *not* be resistant, immune, or vulnerable to while this effect is active.
+    .. attribute:: ignored_resistances
 
-.. attribute:: ac_value
+        *optional* - A list of damage types and optionally modifiers (e.g. "fire", "nonmagical slashing") that the
+        combatant should *not* be resistant, immune, or vulnerable to while this effect is active.
 
-    *optional* - A value to set the combatant's armor class to while this effect is active.
+    .. attribute:: ac_value
 
-    .. note::
-        If both ``ac_value`` and ``ac_bonus`` are specified, the resulting value will be equal to
-        ``ac_value + ac_bonus``.
+        *optional* - A value to set the combatant's armor class to while this effect is active.
 
-        If multiple effects specify ``ac_value``, the highest value will be used.
+        .. note::
+            If both ``ac_value`` and ``ac_bonus`` are specified, the resulting value will be equal to
+            ``ac_value + ac_bonus``.
 
-.. attribute:: ac_bonus
+            If multiple effects specify ``ac_value``, the highest value will be used.
 
-    *optional* - A bonus added to the combatant's armor class while this effect is active.
+    .. attribute:: ac_bonus
 
-.. attribute:: max_hp_value
+        *optional* - A bonus added to the combatant's armor class while this effect is active.
 
-    *optional* - A value to set the combatant's maximum hit points to while this effect is active.
+    .. attribute:: max_hp_value
 
-    .. note::
-        If both ``max_hp_value`` and ``max_hp_bonus`` are specified, the resulting value will be equal to
-        ``max_hp_value + max_hp_bonus``.
+        *optional* - A value to set the combatant's maximum hit points to while this effect is active.
 
-        If multiple effects specify ``max_hp_value``, the highest value will be used.
+        .. note::
+            If both ``max_hp_value`` and ``max_hp_bonus`` are specified, the resulting value will be equal to
+            ``max_hp_value + max_hp_bonus``.
 
-.. attribute:: max_hp_bonus
+            If multiple effects specify ``max_hp_value``, the highest value will be used.
 
-    *optional* - A bonus added to the combatant's maximum hit points while this effect is active.
+    .. attribute:: max_hp_bonus
 
-.. attribute:: save_bonus
+        *optional* - A bonus added to the combatant's maximum hit points while this effect is active.
 
-    *optional* - A bonus that this effect grants to all of the combatant's saving throws.
+    .. attribute:: save_bonus
 
-.. attribute:: save_adv
+        *optional* - A bonus that this effect grants to all of the combatant's saving throws.
 
-    *optional* - A list of stat names (e.g. ``strength``) that the combatant should have advantage on for their
-    respective saving throws while this effect is active. Use ``all`` as a stat name to specify all stats.
+    .. attribute:: save_adv
 
-.. attribute:: save_dis
+        *optional* - A list of stat names (e.g. ``strength``) that the combatant should have advantage on for their
+        respective saving throws while this effect is active. Use ``all`` as a stat name to specify all stats.
 
-    *optional* - A list of stat names (e.g. ``strength``) that the combatant should have disadvantage on for their
-    respective saving throws while this effect is active. Use ``all`` as a stat name to specify all stats.
+    .. attribute:: save_dis
 
-.. attribute:: check_bonus
+        *optional* - A list of stat names (e.g. ``strength``) that the combatant should have disadvantage on for their
+        respective saving throws while this effect is active. Use ``all`` as a stat name to specify all stats.
 
-    *optional* - A bonus that this effect grants to all of the combatant's skill checks.
+    .. attribute:: check_bonus
+
+        *optional* - A bonus that this effect grants to all of the combatant's skill checks.
 
 .. _attackinteraction:
 
@@ -446,41 +479,43 @@ AttackInteraction
 Used to specify an attack granted by an initiative effect: some automation that appears in the combatant's
 ``!action list`` and can be run with a command.
 
-.. attribute:: attack
+.. class:: AttackInteraction
 
-    The Attack model is any valid individual entity as exported by the attack editor on the Avrae Dashboard:
+    .. attribute:: attack
 
-    .. code-block:: typescript
+        The Attack model is any valid individual entity as exported by the attack editor on the Avrae Dashboard:
 
-        {
-            _v: 2;
-            name: string;
-            automation: Effect[];
-            verb?: string;
-            proper?: boolean;
-            criton?: number;
-            phrase?: string;
-            thumb?: string;
-            extra_crit_damage?: string;
-        }
+        .. code-block:: typescript
 
-.. attribute:: defaultDc
+            {
+                _v: 2;
+                name: string;
+                automation: Effect[];
+                verb?: string;
+                proper?: boolean;
+                criton?: number;
+                phrase?: string;
+                thumb?: string;
+                extra_crit_damage?: string;
+            }
 
-    *optional* - The default saving throw DC to use when running the automation. If not provided, defaults to the
-    targeted combatant's default spellcasting DC (or any DC specified in the automation). Use this if the effect's
-    DC depends on the original caster's DC, rather than the target's DC.
+    .. attribute:: defaultDc
 
-.. attribute:: defaultAttackBonus
+        *optional* - The default saving throw DC to use when running the automation. If not provided, defaults to the
+        targeted combatant's default spellcasting DC (or any DC specified in the automation). Use this if the effect's
+        DC depends on the original caster's DC, rather than the target's DC.
 
-    *optional* - The default attack bonus to use when running the automation. If not provided, defaults to the targeted
-    combatant's default attack bonus (or any attack bonus specified in the automation). Use this if the effect's
-    attack bonus depends on the original caster's attack bonus, rather than the target's attack bonus.
+    .. attribute:: defaultAttackBonus
 
-.. attribute:: defaultCastingMod
+        *optional* - The default attack bonus to use when running the automation. If not provided, defaults to the
+        targeted combatant's default attack bonus (or any attack bonus specified in the automation). Use this if the
+        effect's attack bonus depends on the original caster's attack bonus, rather than the target's attack bonus.
 
-    *optional* - The default spellcasting modifier to use when running the automation. If not provided, defaults to the
-    targeted combatant's default spellcasting modifier. Use this if the effect's spellcasting modifier depends on the
-    original caster's spellcasting modifier, rather than the target's spellcasting modifier.
+    .. attribute:: defaultCastingMod
+
+        *optional* - The default spellcasting modifier to use when running the automation. If not provided, defaults to
+        the targeted combatant's default spellcasting modifier. Use this if the effect's spellcasting modifier depends
+        on the original caster's spellcasting modifier, rather than the target's spellcasting modifier.
 
 .. _buttoninteraction:
 
@@ -501,40 +536,42 @@ ButtonInteraction
 
 Used to specify a button that will appear on the targeted combatant's turn and execute some automation when pressed.
 
-.. attribute:: automation
+.. class:: ButtonInteraction
 
-    The automation to run when this button is pressed.
+    .. attribute:: automation
 
-.. attribute:: label
+        The automation to run when this button is pressed.
 
-    The label displayed on the button.
+    .. attribute:: label
 
-.. attribute:: verb
+        The label displayed on the button.
 
-    *optional, default "uses {label}"* - The verb to use for the displayed output when the button is pressed (e.g. "is
-    on fire" would display "NAME is on fire!").
+    .. attribute:: verb
 
-.. attribute:: style
+        *optional, default "uses {label}"* - The verb to use for the displayed output when the button is pressed (e.g.
+        "is on fire" would display "NAME is on fire!").
 
-    *optional, default blurple* - The color of the button (1 = blurple, 2 = grey, 3 = green, 4 = red).
+    .. attribute:: style
 
-.. attribute:: defaultDc
+        *optional, default blurple* - The color of the button (1 = blurple, 2 = grey, 3 = green, 4 = red).
 
-    *optional* - The default saving throw DC to use when running the automation. If not provided, defaults to the
-    targeted combatant's default spellcasting DC (or any DC specified in the automation). Use this if the effect's
-    DC depends on the original caster's DC, rather than the target's DC.
+    .. attribute:: defaultDc
 
-.. attribute:: defaultAttackBonus
+        *optional* - The default saving throw DC to use when running the automation. If not provided, defaults to the
+        targeted combatant's default spellcasting DC (or any DC specified in the automation). Use this if the effect's
+        DC depends on the original caster's DC, rather than the target's DC.
 
-    *optional* - The default attack bonus to use when running the automation. If not provided, defaults to the targeted
-    combatant's default attack bonus (or any attack bonus specified in the automation). Use this if the effect's
-    attack bonus depends on the original caster's attack bonus, rather than the target's attack bonus.
+    .. attribute:: defaultAttackBonus
 
-.. attribute:: defaultCastingMod
+        *optional* - The default attack bonus to use when running the automation. If not provided, defaults to the
+        targeted combatant's default attack bonus (or any attack bonus specified in the automation). Use this if the
+        effect's attack bonus depends on the original caster's attack bonus, rather than the target's attack bonus.
 
-    *optional* - The default spellcasting modifier to use when running the automation. If not provided, defaults to the
-    targeted combatant's default spellcasting modifier. Use this if the effect's spellcasting modifier depends on the
-    original caster's spellcasting modifier, rather than the target's spellcasting modifier.
+    .. attribute:: defaultCastingMod
+
+        *optional* - The default spellcasting modifier to use when running the automation. If not provided, defaults to
+        the targeted combatant's default spellcasting modifier. Use this if the effect's spellcasting modifier depends
+        on the original caster's spellcasting modifier, rather than the target's spellcasting modifier.
 
 Remove IEffect
 --------------
@@ -552,14 +589,16 @@ Removes the initiative effect that triggered this automation.
 Only works when run in execution triggered by an initiative effect, such as a ButtonInteraction
 (see :ref:`buttoninteraction`).
 
-.. attribute:: removeParent
+.. class:: RemoveIEffect
 
-    *optional, default null* - If the removed effect has a parent, whether to remove the parent.
+    .. attribute:: removeParent
 
-    - ``null`` (default) - Do not remove the parent effect.
-    - ``"always"`` - If the removed effect has a parent, remove it too.
-    - ``"if_no_children"`` - If the removed effect has a parent and its only remaining child was the removed effect,
-      remove it too.
+        *optional, default null* - If the removed effect has a parent, whether to remove the parent.
+
+        - ``null`` (default) - Do not remove the parent effect.
+        - ``"always"`` - If the removed effect has a parent, remove it too.
+        - ``"if_no_children"`` - If the removed effect has a parent and its only remaining child was the removed effect,
+          remove it too.
 
 **Variables**
 
@@ -581,25 +620,28 @@ Roll
 Rolls some dice and saves the result in a variable. Displays the roll and its name in a Meta field, unless
 ``hidden`` is ``true``.
 
-.. attribute:: dice
+.. class:: Roll
 
-     An AnnotatedString detailing what dice to roll.
+    .. attribute:: dice
 
-.. attribute:: name
+        An AnnotatedString detailing what dice to roll.
 
-     The variable name to save the result as.
+    .. attribute:: name
 
-.. attribute:: higher
+        The variable name to save the result as.
 
-     *optional* - How much to add to the roll when a spell is cast at a certain level.
+    .. attribute:: higher
 
-.. attribute:: cantripScale
+        *optional* - How much to add to the roll when a spell is cast at a certain level.
 
-     *optional* - Whether this roll should scale like a cantrip.
+    .. attribute:: cantripScale
 
-.. attribute:: hidden
+        *optional* - Whether this roll should scale like a cantrip.
 
-     *optional* - If ``true``, won't display the roll in the Meta field, or apply any bonuses from the ``-d`` argument.
+    .. attribute:: hidden
+
+        *optional* - If ``true``, won't display the roll in the Meta field, or apply any bonuses from the ``-d``
+        argument.
 
 **Variables**
 
@@ -619,12 +661,14 @@ Text
 
 Outputs a short amount of text in the resulting embed.
 
-.. attribute:: text
+.. class:: Text
 
-    Either:
+    .. attribute:: text
 
-    - An AnnotatedString (the text to display).
-    - An AbilityReference (see :ref:`AbilityReference`). Displays the ability's description in whole.
+        Either:
+
+        - An AnnotatedString (the text to display).
+        - An AbilityReference (see :ref:`AbilityReference`). Displays the ability's description in whole.
 
 Set Variable
 ------------
@@ -642,24 +686,26 @@ Set Variable
 
 Saves the result of an ``IntExpression`` to a variable without displaying anything.
 
-.. attribute:: name
+.. class:: SetVariable
 
-     The name of the variable to save.
+    .. attribute:: name
 
-.. attribute:: value
+        The name of the variable to save.
 
-     The value to set the variable to.
+    .. attribute:: value
 
-.. attribute:: higher
+        The value to set the variable to.
 
-     *optional* - What to set the variable to instead when a spell is cast at a higher level.
+    .. attribute:: higher
 
-.. attribute:: onError
+        *optional* - What to set the variable to instead when a spell is cast at a higher level.
 
-     *optional* - If provided, what to set the variable to if the normal value would throw an error.
+    .. attribute:: onError
 
-Condition
----------
+        *optional* - If provided, what to set the variable to if the normal value would throw an error.
+
+Condition (Branch)
+------------------
 .. versionadded:: 2.7.0
 
 .. code-block:: typescript
@@ -672,29 +718,31 @@ Condition
         errorBehaviour?: "true" | "false" | "both" | "neither" | "raise";
     }
 
-Run certain effects if a special condition is met, or other effects otherwise.
+Run certain effects if a certain condition is met, or other effects otherwise. AKA "branch" or "if-else".
 
-.. attribute:: condition
+.. class:: Condition
 
-     The condition to check.
+    .. attribute:: condition
 
-.. attribute:: onTrue
+        The condition to check.
 
-     The effects to run if ``condition`` is ``True`` or any non-zero value.
+    .. attribute:: onTrue
 
-.. attribute:: onFalse
+        The effects to run if ``condition`` is ``True`` or any non-zero value.
 
-     The effects to run if ``condition`` is ``False`` or ``0``.
+    .. attribute:: onFalse
 
-.. attribute:: errorBehaviour
+        The effects to run if ``condition`` is ``False`` or ``0``.
 
-     How to behave if the condition raises an error:
+    .. attribute:: errorBehaviour
 
-    - ``"true"``: Run the ``onTrue`` effects.
-    - ``"false"``: Run the ``onFalse`` effects. (*default*)
-    - ``"both"``: Run both the ``onTrue`` and ``onFalse`` effects, in that order.
-    - ``"neither"``: Skip this effect.
-    - ``"raise"``: Raise the error and halt execution.
+        How to behave if the condition raises an error:
+
+        - ``"true"``: Run the ``onTrue`` effects.
+        - ``"false"``: Run the ``onFalse`` effects. (*default*)
+        - ``"both"``: Run both the ``onTrue`` and ``onFalse`` effects, in that order.
+        - ``"neither"``: Skip this effect.
+        - ``"raise"``: Raise the error and halt execution.
 
 Use Counter
 -----------
@@ -715,33 +763,35 @@ Uses a number of charges of the given counter, and displays the remaining amount
 .. note::
     Regardless of the current target, this effect will always use the *caster's* counter/spell slots!
 
-.. attribute:: counter
+.. class:: UseCounter
 
-    The name of the counter to use (case-sensitive, full match only), or a reference to a spell slot
-    (see :ref:`SpellSlotReference`).
+    .. attribute:: counter
 
-.. attribute:: amount
+        The name of the counter to use (case-sensitive, full match only), or a reference to a spell slot
+        (see :ref:`SpellSlotReference`).
 
-     The number of charges to use. If negative, will add charges instead of using them.
+    .. attribute:: amount
 
-.. attribute:: allowOverflow
+        The number of charges to use. If negative, will add charges instead of using them.
 
-     *optional, default False* - If False, attempting to overflow/underflow a counter (i.e. use more charges than
-     available or add charges exceeding max) will error instead of clipping to bounds.
+    .. attribute:: allowOverflow
 
-.. attribute:: errorBehaviour
+        *optional, default False* - If False, attempting to overflow/underflow a counter (i.e. use more charges than
+        available or add charges exceeding max) will error instead of clipping to bounds.
 
-     *optional, default "warn"* - How to behave if modifying the counter raises an error:
+    .. attribute:: errorBehaviour
 
-    - ``null``: All errors are silently consumed.
-    - ``"warn"``: Automation will continue to run, and any errors will appear in the output. (*default*)
-    - ``"raise"``: Raise the error and halt execution.
+        *optional, default "warn"* - How to behave if modifying the counter raises an error:
 
-    Some, but not all, possible error conditions are:
+        - ``null``: All errors are silently consumed.
+        - ``"warn"``: Automation will continue to run, and any errors will appear in the output. (*default*)
+        - ``"raise"``: Raise the error and halt execution.
 
-    - The target does not have counters (e.g. they are a monster)
-    - The counter does not exist
-    - ``allowOverflow`` is false and the new value is out of bounds
+        Some, but not all, possible error conditions are:
+
+        - The target does not have counters (e.g. they are a monster)
+        - The counter does not exist
+        - ``allowOverflow`` is false and the new value is out of bounds
 
 **Variables**
 
@@ -762,9 +812,11 @@ SpellSlotReference
         slot: number | IntExpression;
     }
 
-.. attribute:: slot
+.. class:: SpellSlotReference
 
-    The level of the spell slot to reference (``[1..9]``).
+    .. attribute:: slot
+
+        The level of the spell slot to reference (``[1..9]``).
 
 .. _AbilityReference:
 
@@ -790,13 +842,15 @@ ability instead. A list of valid abilities can be retrieved from the API at ``/g
     - Choosing ``Breath Weapon (Gold)`` may discover a counter for a breath weapon of a different color
     - Choosing ``Sorcery Points (Sorcerer)`` may discover a counter granted by the Metamagic Adept feat
 
-.. attribute:: id
+.. class:: AbilityReference
 
-    The ID of the ability referenced.
+    .. attribute:: id
 
-.. attribute:: typeId
+        The ID of the ability referenced.
 
-    The DDB entity type ID of the ability referenced.
+    .. attribute:: typeId
+
+        The DDB entity type ID of the ability referenced.
 
 Cast Spell
 ----------
@@ -818,28 +872,31 @@ slot to cast the spell. Can only be used at the root of automation. Cannot be us
 
 This is usually used in features that cast spells using alternate resources (i.e. Use Counter, Cast Spell).
 
-.. attribute:: id
+.. class:: CastSpell
 
-    The DDB entity id of the spell to cast. Use the ``/gamedata/spells`` API endpoint to retrieve a list of valid IDs.
+    .. attribute:: id
 
-.. attribute:: level
+        The DDB entity id of the spell to cast. Use the Automation Editor to select a spell or the
+        ``/gamedata/spells`` API endpoint to retrieve a list of valid spell IDs.
 
-    *optional* - The (slot) level to cast the spell at.
+    .. attribute:: level
 
-.. attribute:: dc
+        *optional* - The (slot) level to cast the spell at.
 
-    *optional* - The saving throw DC to use when casting the spell. If not provided, defaults to the caster's default
-    spellcasting DC (or any DC specified in the spell automation).
+    .. attribute:: dc
 
-.. attribute:: attackBonus
+        *optional* - The saving throw DC to use when casting the spell. If not provided, defaults to the caster's
+        default spellcasting DC (or any DC specified in the spell automation).
 
-    *optional* - The spell attack bonus to use when casting the spell. If not provided, defaults to the caster's
-    default spell attack bonus (or any attack bonus specified in the spell automation).
+    .. attribute:: attackBonus
 
-.. attribute:: castingMod
+        *optional* - The spell attack bonus to use when casting the spell. If not provided, defaults to the caster's
+        default spell attack bonus (or any attack bonus specified in the spell automation).
 
-    *optional* - The spellcasting modifier to use when casting the spell. If not provided, defaults to the caster's
-    default spellcasting modifier.
+    .. attribute:: castingMod
+
+        *optional* - The spellcasting modifier to use when casting the spell. If not provided, defaults to the caster's
+        default spellcasting modifier.
 
 **Variables**
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -908,6 +908,171 @@ This is usually used in features that cast spells using alternate resources (i.e
 
 No variables are exposed.
 
+Ability Check
+-------------
+.. versionadded:: 3.6.0
+
+.. code-block:: typescript
+
+    {
+        type: "check";
+        ability: string | string[];
+        dc?: IntExpression;
+        success?: Effect[];
+        fail?: Effect[];
+    }
+
+An Ability Check effect forces a targeted creature to make an ability check.
+It must be inside a Target effect.
+
+.. class:: Check
+
+    .. attribute:: ability
+
+        The ability to make a check for. Must be one of or a list of the following:
+
+        .. code-block:: text
+
+            "acrobatics"
+            "animalHandling"
+            "arcana"
+            "athletics"
+            "deception"
+            "history"
+            "initiative"
+            "insight"
+            "intimidation"
+            "investigation"
+            "medicine"
+            "nature"
+            "perception"
+            "performance"
+            "persuasion"
+            "religion"
+            "sleightOfHand"
+            "stealth"
+            "survival"
+            "strength"
+            "dexterity"
+            "constitution"
+            "intelligence"
+            "wisdom"
+            "charisma"
+
+        If multiple skills are specified, uses the highest modifier of all the specified skills.
+
+    .. attribute:: dc
+
+        *optional* - An IntExpression that details what DC to use (defaults to caster's spell DC).
+
+    .. attribute:: success
+
+        *optional* - A list of effects to execute on a successful check. Requires the *dc* attribute to be set.
+
+    .. attribute:: fail
+
+        *optional* - A list of effects to execute on a failed check. Requires the *dc* attribute to be set.
+
+**Variables**
+
+- ``lastCheckRollTotal`` (:class:`int`) The result of the last check roll (0 if no roll was made).
+- ``lastCheckNaturalRoll`` (:class:`int`) The natural roll of the last check roll (e.g. ``10`` in
+  ``1d20 (10) + 5 = 15``; 0 if no roll was made).
+- ``lastCheckAbility`` (:class:`str`) The title-case full name of the rolled skill (e.g. ``"Animal Handling"``,
+  ``"Arcana"``).
+- ``lastCheckDidPass`` (:class:`bool` or ``None``) If a DC was given, whether the target succeeded the check. ``None``
+  if no DC given.
+- ``lastCheckDC`` (:class:`int` or ``None``) If a DC was given, the DC of the last save roll. ``None`` if no DC given.
+
+.. todo: ability contests
+    Ability Contest
+    ---------------
+    .. versionadded:: 3.6.0
+
+    .. code-block:: typescript
+
+        {
+            type: "contest";
+            casterAbility: string | string[];
+            targetAbility: string | string[];
+            success: Effect[];
+            fail: Effect[];
+            tie?: "fail" | "success" | "neither";
+        }
+
+    An Ability Contest effect roll compares an ability check performed by the caster to an ability check performed by the
+    current target. It must be inside a Target effect.
+
+    .. class:: Contest
+
+        .. attribute:: casterAbility
+
+            The ability to make a check for. Must be one of the or a list of valid ability names (see below).
+
+            If multiple skills are specified, uses the highest modifier of all the specified skills.
+
+        .. attribute:: targetAbility
+
+            The ability to make a check for. Must be one of the or a list of valid ability names:
+
+            .. code-block:: text
+
+                "acrobatics"
+                "animalHandling"
+                "arcana"
+                "athletics"
+                "deception"
+                "history"
+                "initiative"
+                "insight"
+                "intimidation"
+                "investigation"
+                "medicine"
+                "nature"
+                "perception"
+                "performance"
+                "persuasion"
+                "religion"
+                "sleightOfHand"
+                "stealth"
+                "survival"
+                "strength"
+                "dexterity"
+                "constitution"
+                "intelligence"
+                "wisdom"
+                "charisma"
+
+            If multiple skills are specified, uses the highest modifier of all the specified skills.
+
+        .. attribute:: success
+
+            A list of effects to execute if the **caster** wins the ability contest.
+
+        .. attribute:: fail
+
+            A list of effects to execute if the **caster** loses the ability contest.
+
+        .. attribute:: tie
+
+            *optional, default fail* - Which list of effects to run if the ability contest results in a tie.
+
+    **Variables**
+
+    - ``lastContestCasterRollTotal`` (:class:`int`) The result of the caster's contest roll.
+    - ``lastContestTargetRollTotal`` (:class:`int`) The result of the target's contest roll.
+    - ``lastContestCasterNaturalRoll`` (:class:`int`) The natural roll of the caster's contest roll (e.g. ``10`` in
+      ``1d20 (10) + 5 = 15``; 0 if no roll was made).
+    - ``lastContestTargetNaturalRoll`` (:class:`int`) The natural roll of the target's contest roll (e.g. ``10`` in
+      ``1d20 (10) + 5 = 15``; 0 if no roll was made).
+    - ``lastContestCasterAbility`` (:class:`str`) The title-case full name of the skill the caster rolled
+      (e.g. ``"Animal Handling"``, ``"Arcana"``).
+    - ``lastContestTargetAbility`` (:class:`str`) The title-case full name of the skill the target rolled
+      (e.g. ``"Animal Handling"``, ``"Arcana"``).
+    - ``lastContestDidWin`` (:class:`bool`) Whether the caster won the ability contest, or tied and the tie behaviour was
+      "win".
+    - ``lastContestDidTie`` (:class:`bool`) Whether the ability contest resulted in a tie.
+
 AnnotatedString
 ---------------
 An AnnotatedString is a string that can access saved variables.

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -564,6 +564,14 @@ ButtonInteraction
 
 Used to specify a button that will appear on the targeted combatant's turn and execute some automation when pressed.
 
+.. note::
+
+    Any initiative effects applying an offensive effect to the caster will not be considered when a ButtonInteraction
+    is run, to prevent scenarios where an effect granting a damage bonus to the caster increases the damage done by
+    a damage over time effect and other similar scenarios.
+
+    You may think of this as a ButtonInteraction's caster being a temporary actor without any active initiative effects.
+
 .. class:: ButtonInteraction
 
     .. attribute:: automation

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -917,12 +917,14 @@ Ability Check
     {
         type: "check";
         ability: string | string[];
+        contestAbility?: string | string[];
         dc?: IntExpression;
         success?: Effect[];
         fail?: Effect[];
+        contestTie?: "fail" | "success" | "neither";
     }
 
-An Ability Check effect forces a targeted creature to make an ability check.
+An Ability Check effect forces a targeted creature to make an ability check, optionally as a contest against the caster.
 It must be inside a Target effect.
 
 .. class:: Check
@@ -961,17 +963,33 @@ It must be inside a Target effect.
 
         If multiple skills are specified, uses the highest modifier of all the specified skills.
 
+    .. attribute:: contestAbility
+
+        *optional* - Which ability of the caster's to make a contest against.
+        Must be one of or a list of the valid skills listed above.
+        If multiple skills are specified, uses the highest modifier of all the specified skills.
+
+        Mutually exclusive with ``dc``.
+
     .. attribute:: dc
 
         *optional* - An IntExpression that details what DC to use (defaults to caster's spell DC).
 
+        Mutually exclusive with ``contestAbility``.
+
     .. attribute:: success
 
-        *optional* - A list of effects to execute on a successful check. Requires the *dc* attribute to be set.
+        *optional* - A list of effects to execute on a successful check or if the **target** wins the contest.
+        Requires the *contestAbility* or *dc* attribute to be set.
 
     .. attribute:: fail
 
-        *optional* - A list of effects to execute on a failed check. Requires the *dc* attribute to be set.
+        *optional* - A list of effects to execute on a failed check or if the **target** loses the contest.
+        Requires the *contestAbility* or *dc* attribute to be set.
+
+    .. attribute:: contestTie
+
+        *optional, default success* - Which list of effects to run if the ability contest results in a tie.
 
 **Variables**
 
@@ -980,98 +998,20 @@ It must be inside a Target effect.
   ``1d20 (10) + 5 = 15``; 0 if no roll was made).
 - ``lastCheckAbility`` (:class:`str`) The title-case full name of the rolled skill (e.g. ``"Animal Handling"``,
   ``"Arcana"``).
-- ``lastCheckDidPass`` (:class:`bool` or ``None``) If a DC was given, whether the target succeeded the check. ``None``
-  if no DC given.
+- ``lastCheckDidPass`` (:class:`bool` or ``None``) If a DC was given, whether the target succeeded the check.
+  If a contest was specified, whether the target won the contest.
+  ``None`` if no or contest given.
 - ``lastCheckDC`` (:class:`int` or ``None``) If a DC was given, the DC of the last save roll. ``None`` if no DC given.
 
-.. todo: ability contests
-    Ability Contest
-    ---------------
-    .. versionadded:: 3.6.0
+*Contest Variables*
 
-    .. code-block:: typescript
-
-        {
-            type: "contest";
-            casterAbility: string | string[];
-            targetAbility: string | string[];
-            success: Effect[];
-            fail: Effect[];
-            tie?: "fail" | "success" | "neither";
-        }
-
-    An Ability Contest effect roll compares an ability check performed by the caster to an ability check performed by the
-    current target. It must be inside a Target effect.
-
-    .. class:: Contest
-
-        .. attribute:: casterAbility
-
-            The ability to make a check for. Must be one of the or a list of valid ability names (see below).
-
-            If multiple skills are specified, uses the highest modifier of all the specified skills.
-
-        .. attribute:: targetAbility
-
-            The ability to make a check for. Must be one of the or a list of valid ability names:
-
-            .. code-block:: text
-
-                "acrobatics"
-                "animalHandling"
-                "arcana"
-                "athletics"
-                "deception"
-                "history"
-                "initiative"
-                "insight"
-                "intimidation"
-                "investigation"
-                "medicine"
-                "nature"
-                "perception"
-                "performance"
-                "persuasion"
-                "religion"
-                "sleightOfHand"
-                "stealth"
-                "survival"
-                "strength"
-                "dexterity"
-                "constitution"
-                "intelligence"
-                "wisdom"
-                "charisma"
-
-            If multiple skills are specified, uses the highest modifier of all the specified skills.
-
-        .. attribute:: success
-
-            A list of effects to execute if the **caster** wins the ability contest.
-
-        .. attribute:: fail
-
-            A list of effects to execute if the **caster** loses the ability contest.
-
-        .. attribute:: tie
-
-            *optional, default fail* - Which list of effects to run if the ability contest results in a tie.
-
-    **Variables**
-
-    - ``lastContestCasterRollTotal`` (:class:`int`) The result of the caster's contest roll.
-    - ``lastContestTargetRollTotal`` (:class:`int`) The result of the target's contest roll.
-    - ``lastContestCasterNaturalRoll`` (:class:`int`) The natural roll of the caster's contest roll (e.g. ``10`` in
-      ``1d20 (10) + 5 = 15``; 0 if no roll was made).
-    - ``lastContestTargetNaturalRoll`` (:class:`int`) The natural roll of the target's contest roll (e.g. ``10`` in
-      ``1d20 (10) + 5 = 15``; 0 if no roll was made).
-    - ``lastContestCasterAbility`` (:class:`str`) The title-case full name of the skill the caster rolled
-      (e.g. ``"Animal Handling"``, ``"Arcana"``).
-    - ``lastContestTargetAbility`` (:class:`str`) The title-case full name of the skill the target rolled
-      (e.g. ``"Animal Handling"``, ``"Arcana"``).
-    - ``lastContestDidWin`` (:class:`bool`) Whether the caster won the ability contest, or tied and the tie behaviour was
-      "win".
-    - ``lastContestDidTie`` (:class:`bool`) Whether the ability contest resulted in a tie.
+- ``lastContestRollTotal`` (:class:`int` or ``None``) The result of the caster's contest roll; ``None`` if no contest
+  was made.
+- ``lastContestNaturalRoll`` (:class:`int` or ``None``) The natural roll of the caster's contest roll (e.g. ``10`` in
+  ``1d20 (10) + 5 = 15``; ``None`` if no contest was made).
+- ``lastContestAbility`` (:class:`str` or ``None``) The title-case full name of the skill the caster rolled
+  (e.g. ``"Animal Handling"``, ``"Arcana"``). ``None`` if no contest was made.
+- ``lastContestDidTie`` (:class:`bool`) Whether a ability contest resulted in a tie.
 
 AnnotatedString
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
+git+https://github.com/avrae/automation-common@v3.6.4
 d20==1.1.2
 
 # top-level deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v3.6.4
+git+https://github.com/avrae/automation-common@v3.6.5
 d20==1.1.2
 
 # top-level deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v3.6.5
+git+https://github.com/avrae/automation-common@v3.6.6
 d20==1.1.2
 
 # top-level deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v3.6.7
+git+https://github.com/avrae/automation-common@v3.6.8
 d20==1.1.2
 
 # top-level deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v3.6.6
+git+https://github.com/avrae/automation-common@v3.6.7
 d20==1.1.2
 
 # top-level deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ markdownify==0.9.4
 motor==2.3.1
 Pillow==9.0.1
 psutil==5.8.0
-pydantic==1.8.2
+pydantic~=1.9.0
 pyjwt==2.1.0
 python-meteor==0.1.6
 pyyaml==5.4.1

--- a/tests/cogs5e/models/automation/effects_test.py
+++ b/tests/cogs5e/models/automation/effects_test.py
@@ -559,3 +559,163 @@ async def test_usecounter_build_str(counter, amount):
     result = usecounter.build_str(DEFAULT_CASTER, DEFAULT_EVALUATOR)
     log.info(f"UseCounter str: ({counter=!r}, {amount=!r}) -> {result}")
     assert result
+
+
+# ==== Check ====
+async def import_check_actions(avrae, dhttp):
+    avrae.message(
+        textwrap.dedent(
+            """
+            !a import {
+              "_v": 2,
+              "name": "Check Test",
+              "automation": [
+                {
+                  "type": "target",
+                  "target": "each",
+                  "effects": [
+                    {
+                      "type": "check",
+                      "ability": [
+                        "arcana",
+                        "dexterity",
+                        "animalHandling"
+                      ],
+                      "dc": 15,
+                      "success": [
+                        {
+                          "type": "text",
+                          "text": "yay you passed"
+                        }
+                      ],
+                      "fail": [
+                        {
+                          "type": "text",
+                          "text": "you failed :("
+                        }
+                      ]
+                    },
+                    {
+                      "type": "check",
+                      "ability": "arcana"
+                    },
+                    {
+                      "type": "text",
+                      "text": "after arcana"
+                    }
+                  ]
+                }
+              ]
+            }
+            """
+        ).strip()
+    )
+    avrae.message(
+        textwrap.dedent(
+            """
+            !a import {
+              "_v": 2,
+              "name": "Contest Check Test",
+              "automation": [
+                {
+                  "type": "target",
+                  "target": "each",
+                  "effects": [
+                    {
+                      "type": "check",
+                      "ability": [
+                        "arcana",
+                        "dexterity",
+                        "animalHandling"
+                      ],
+                      "contestAbility": [
+                        "athletics",
+                        "acrobatics"
+                      ],
+                      "success": [
+                        {
+                          "type": "text",
+                          "text": "the target wins"
+                        }
+                      ],
+                      "fail": [
+                        {
+                          "type": "text",
+                          "text": "the caster wins"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """
+        ).strip()
+    )
+    await dhttp.drain()
+
+
+async def test_check_e2e(character, avrae, dhttp):
+    await import_check_actions(avrae, dhttp)
+    await start_init(avrae, dhttp)
+    avrae.message("!init join")
+    await dhttp.drain()
+
+    avrae.message(f'!a "Check Test" -t "{character.name}"')
+    await dhttp.drain()
+
+    avrae.message(f'!a "Contest Check Test" -t "{character.name}"')
+    await dhttp.drain()
+
+    await end_init(avrae, dhttp)
+
+
+async def test_check_deserialize():
+    data = {"type": "check", "ability": "arcana"}
+    result = automation.Check.from_data(data)
+    assert result
+    assert result.ability_list == ["arcana"]
+    assert result.contest_ability_list == []
+    assert result.dc is None
+    assert result.contest_tie_behaviour is None
+
+    data = {"type": "check", "ability": ["arcana", "acrobatics"]}
+    result = automation.Check.from_data(data)
+    assert result
+    assert result.ability_list == ["arcana", "acrobatics"]
+
+    data = {"type": "check", "ability": ["arcana", "acrobatics"], "dc": "15"}
+    result = automation.Check.from_data(data)
+    assert result
+    assert result.dc == "15"
+
+    data = {"type": "check", "ability": ["arcana", "acrobatics"], "contestAbility": "athletics"}
+    result = automation.Check.from_data(data)
+    assert result
+    assert result.contest_ability_list == ["athletics"]
+
+
+async def test_check_serialize():
+    result = automation.Check("acrobatics").to_dict()
+    assert json.dumps(result)  # result should be JSON-encodable
+
+    result = automation.Check(["acrobatics", "arcana"]).to_dict()
+    assert json.dumps(result)
+
+
+async def test_check_build_str():
+    check = automation.Check(ability="arcana")
+    result = check.build_str(DEFAULT_CASTER, DEFAULT_EVALUATOR)
+    assert result == "Arcana Check"
+
+    check = automation.Check(ability=["arcana", "acrobatics"])
+    result = check.build_str(DEFAULT_CASTER, DEFAULT_EVALUATOR)
+    assert result == "Arcana or Acrobatics Check"
+
+    check = automation.Check(ability="arcana", dc="15")
+    result = check.build_str(DEFAULT_CASTER, DEFAULT_EVALUATOR)
+    assert result == "DC 15 Arcana Check"
+
+    check = automation.Check(ability="arcana", contestAbility="arcana")
+    result = check.build_str(DEFAULT_CASTER, DEFAULT_EVALUATOR)
+    assert result == "Arcana Check vs. caster's Arcana Check"

--- a/tests/cogs5e/models/automation/effects_test.py
+++ b/tests/cogs5e/models/automation/effects_test.py
@@ -675,7 +675,7 @@ async def test_check_deserialize():
     result = automation.Check.from_data(data)
     assert result
     assert result.ability_list == ["arcana"]
-    assert result.contest_ability_list == []
+    assert result.contest_ability_list is None
     assert result.dc is None
     assert result.contest_tie_behaviour is None
 

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -16,6 +16,7 @@ from cogs5e.models.errors import NoSelectionElements, SelectionCancelled
 from utils import constants, enums
 
 log = logging.getLogger(__name__)
+sentinel = object()
 
 
 def list_get(index, default, l):
@@ -500,3 +501,13 @@ def maybe_http_url(url: str):
     """Returns a url if one found, otherwise blank string."""
     # Mainly used for embed.set_thumbnail(url=url)
     return url if "http" in url else ""
+
+
+def exactly_one(iterable):
+    """If the iterable yields exactly one element, return it; otherwise return None"""
+    # I got nerdsniped and compared this to checking len(list(iterable)) == 1 instead, and this is only 70ns faster
+    # but it's much more memory efficient if the iterator is large so, cool, I guess
+    retval = next(iterable, None)
+    if next(iterable, sentinel) is sentinel:
+        return retval
+    return None


### PR DESCRIPTION
### Summary
Because that PR wasn't already large enough.

*Documentation*
- Rewrote the introduction to Automation Reference to provide a glossary
- Added documentation for the Check automation node

*Automation*
- Added the `ieffect` metavar to the runtime builtins when executing automation granted by an initiative effect
- Added the Check node to make ability checks, optionally against a DC or as a contest against the caster
- Fixed the Remove IEffect node not returning anything
- Added the `adv` key to Check and Save nodes

*IEffects*
- Added `-cadv` and `-cdis` to specify advantage/disadvantage on certain checks

*Other*
- Use the `automation-common` org lib to add additional validation to `!a import` and `!bestiary import`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
