### PR TITLE
Use initials for combatant names

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -22,7 +22,7 @@ from cogsmisc.stats import Stats
 from gamedata.lookuputils import select_monster_full, select_spell_full
 from utils import checks, constants
 from utils.argparser import argparse
-from utils.functions import confirm, get_guild_member, search_and_select, try_delete
+from utils.functions import confirm, get_guild_member, search_and_select, try_delete, get_initials
 from . import (
     Combat,
     CombatOptions,
@@ -281,7 +281,7 @@ class InitTracker(commands.Cog):
         ac = args.last("ac", type_=int)
         n = args.last("n", 1)
         note = args.last("note")
-        name_template = args.last("name", monster.name[:2].upper() + "#")
+        name_template = args.last("name", get_initials(monster.name) + "#")
         init_skill = monster.skills.initiative
 
         combat = await ctx.get_combat()

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -528,9 +528,4 @@ def get_initials(name: str) -> str:
         return name[:2].upper()
 
     # Multiple words, find initials
-    initials = ""
-    for word in split_name:
-        if word:
-            initials += word[0]
-
-    return initials
+    return "".join(word[0] for word in split_name if word)

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -511,3 +511,26 @@ def exactly_one(iterable):
     if next(iterable, sentinel) is sentinel:
         return retval
     return None
+
+
+split_regex = re.compile(r"\W+")
+
+
+def get_initials(name: str) -> str:
+    """
+    Returns the initials for a given string if its multiple words, otherwise returns the first two letters in uppercase.
+    """
+    # Mainly used for monster combatants in initiative
+    split_name = split_regex.split(name)
+
+    # Single word, return first two letters, uppercase
+    if len(split_name) == 1:
+        return name[:2].upper()
+
+    # Multiple words, find initials
+    initials = ""
+    for word in split_name:
+        if word:
+            initials += word[0]
+
+    return initials


### PR DESCRIPTION
### Summary
This changes how monster combatants are named when they are added to combat. There are two scenarios:

1. If the monster's name has multiple words/phrases, it will join together the first letter of each word, appending a number to make it unique: 
- ``Will-o'-Wisp`` -> ``WoW1``
- ``Monastery of the Distressed Body, Grand Master`` -> ``MotDBGM1``
 
2. If the monsters name only contains a single word, it will take the first two letters of their name, capitalize it, and then append a number to make it unique:
- ``Goblin`` -> ``GO1``
- ``Orc`` -> ``OR1``

This should help reduce ambiguity when adding groups of similar monsters together. For instance, in the old system, fighting a group of 10 Goblins and a Goblin Boss left you with ``GO1`` - ``GO11``. With this new system, it'll be ``GO1`` - ``GO10`` and a ``GB1``.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
