### PR TITLE
Allow change of Combat DM

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -650,8 +650,9 @@ class InitTracker(commands.Cog):
                 member = await self.member_converter.convert(ctx, combat_dm)
             except commands.BadArgument:
                 raise commands.UserInputError("You must pass a valid member mention as an argument.")
-            combat.dm_id = member.id
-            out += f"This combat's DM has been set to {member.mention}.\n"
+            else:
+                combat.dm_id = member.id
+                out += f"Current combat DM has been set to {member.mention}.\n"
 
         combat.options = options
         await combat.commit()

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -55,7 +55,6 @@ class InitTracker(commands.Cog):
         self.bot = bot
         self.nlp = NLPRecorder(bot)
         self.buttons = ButtonHandler(bot)
-        self.member_converter = commands.MemberConverter()
 
     # ==== special methods ====
     async def cog_load(self):
@@ -620,7 +619,7 @@ class InitTracker(commands.Cog):
         `turnnotif` - Notifies the controller of the next combatant in initiative.
         `deathdelete` - Toggles removing monsters below 0 HP.
         `-name <name>` - Sets a name for the combat instance.
-        `-combatdm <@mention>` - Changes this combat's dm. You must be a DM or the combat's current DM.
+        `-combatdm <@mention>` - Changes this combat's DM.
         """
         args = argparse(settings)
         combat = await ctx.get_combat()
@@ -640,14 +639,8 @@ class InitTracker(commands.Cog):
             options.deathdelete = not options.deathdelete
             out += f"Monsters at 0 HP will be {'removed' if options.deathdelete else 'left'}.\n"
         if combat_dm := args.last("combatdm"):
-            # check: is the user a dm/the dm
-            servsettings = await ctx.get_server_settings()
-            author_id = ctx.author.id
-            allowed_to_pass = author_id == combat.dm_id or servsettings.is_dm(ctx.author)
-            if not allowed_to_pass:
-                raise commands.UserInputError("You are not allowed to change this Combat's DM.")
             try:
-                member = await self.member_converter.convert(ctx, combat_dm)
+                member = await commands.MemberConverter().convert(ctx, combat_dm)
             except commands.BadArgument:
                 raise commands.UserInputError("You must pass a valid member mention as an argument.")
             else:


### PR DESCRIPTION
### Summary
Adds an option to `!init meta` to allow for a DM to change the combat's dm_id, which is used in `!i n`

Resolves #1775 (AFR-939)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
