### PR TITLE
Enable Black preview

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -41,3 +41,7 @@ jobs:
           git diff -u origin/master HEAD | flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --diff
           # exit-zero treats all errors as warnings. We use a line length of 120
           git diff -u origin/master HEAD | flake8 . --count --exit-zero --max-line-length=120 --statistics --diff
+
+      - name: Ensure code is blackified
+        run: |
+          black . --check

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -30,7 +30,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
-          pip install flake8 black
+          pip install -r tests/requirements.txt
+          pip install flake8
 
       - name: Setup flake8 annotations
         uses: rbialon/flake8-annotations@v1

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt
-          pip install flake8
+          pip install flake8 black
 
       - name: Setup flake8 annotations
         uses: rbialon/flake8-annotations@v1

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -45,4 +45,4 @@ jobs:
 
       - name: Ensure code is blackified
         run: |
-          black . --check
+          black . --check --diff

--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -485,8 +485,7 @@ class AliasSkill:
 
     def __repr__(self):
         return (
-            f"<{self.__class__.__name__} value={self.value!r} prof={self.prof!r} bonus={self.bonus!r} "
-            f"adv={self.adv!r}>"
+            f"<{self.__class__.__name__} value={self.value!r} prof={self.prof!r} bonus={self.bonus!r} adv={self.adv!r}>"
         )
 
     def __gt__(self, other):

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -157,14 +157,14 @@ async def get_collectable_named(
             f"I found both a personal {obj_name} and {len(subscribed_obj_ids)} workshop {obj_name}(es) "
             f"named {ctx.prefix}{name}. Use `{ctx.prefix}{obj_command_name} autofix` to automatically assign "
             f"all conflicting {obj_name_pl} unique names, or `{ctx.prefix}{obj_command_name} rename {name} <new name>` "
-            f"to manually rename it."
+            "to manually rename it."
         )
     if len(subscribed_obj_ids) > 1:
         raise AliasNameConflict(
             f"I found {len(subscribed_obj_ids)} workshop {obj_name_pl} "
             f"named {ctx.prefix}{name}. Use `{ctx.prefix}{obj_command_name} autofix` to automatically assign "
             f"all conflicting {obj_name_pl} unique names, or `{ctx.prefix}{obj_command_name} rename {name} <new name>` "
-            f"to manually rename it."
+            "to manually rename it."
         )
     # otherwise return the subscribed
     return await workshop_cls.from_id(ctx, subscribed_obj_ids[0])
@@ -231,7 +231,7 @@ def set_cvar(character, name, value):
     value = str(value)
     if not name.isidentifier():
         raise InvalidArgument(
-            "Cvar names must be identifiers " "(only contain a-z, A-Z, 0-9, _, and not start with a number)."
+            "Cvar names must be identifiers (only contain a-z, A-Z, 0-9, _, and not start with a number)."
         )
     elif len(name) > VAR_NAME_LIMIT:
         raise InvalidArgument(f"Cvar name must be shorter than {VAR_NAME_LIMIT} characters.")
@@ -255,7 +255,7 @@ async def set_uvar(ctx, name, value):
     value = str(value)
     if not name.isidentifier():
         raise InvalidArgument(
-            "Uvar names must be valid identifiers " "(only contain a-z, A-Z, 0-9, _, and not start with a number)."
+            "Uvar names must be valid identifiers (only contain a-z, A-Z, 0-9, _, and not start with a number)."
         )
     elif len(name) > VAR_NAME_LIMIT:
         raise InvalidArgument(f"Uvar name must be shorter than {VAR_NAME_LIMIT} characters.")
@@ -301,7 +301,7 @@ async def set_svar(ctx, name, value):
     value = str(value)
     if not name.isidentifier():
         raise InvalidArgument(
-            "Svar names must be valid identifiers " "(only contain a-z, A-Z, 0-9, _, and not start with a number)."
+            "Svar names must be valid identifiers (only contain a-z, A-Z, 0-9, _, and not start with a number)."
         )
     elif len(name) > VAR_NAME_LIMIT:
         raise InvalidArgument(f"Svar name must be shorter than {VAR_NAME_LIMIT} characters.")
@@ -436,10 +436,10 @@ async def handle_alias_exception(ctx, err):
     if not isinstance(e, AliasException) or e.pm_user:
         with suppress(disnake.HTTPException):
             await ctx.author.send(
-                f"```py\n"
+                "```py\n"
                 f"{''.join(tb)}"
-                f"```"
-                f"This is an issue in a user-created command; do *not* report this on the official bug tracker."
+                "```"
+                "This is an issue in a user-created command; do *not* report this on the official bug tracker."
             )
 
     # send error message to channel
@@ -469,10 +469,10 @@ async def send_warnings(ctx, warns: List["evaluators.ScriptingWarning"]):
     warn_strs = "\n".join(out)
     with suppress(disnake.HTTPException):
         await ctx.author.send(
-            f"One or more aliases or snippets raised warnings:\n"
+            "One or more aliases or snippets raised warnings:\n"
             f"{warn_strs}"
-            f"This is an issue in a user-created command; please contact the author. Do *not* report this on the "
-            f"official bug tracker."
+            "This is an issue in a user-created command; please contact the author. Do *not* report this on the "
+            "official bug tracker."
         )
 
 
@@ -529,7 +529,7 @@ async def handle_alias_required_licenses(ctx, err):
         if blocked_by_ff:
             embed.title = "D&D Beyond is currently unavailable"
             embed.description = (
-                f"I was unable to communicate with D&D Beyond to confirm access to:\n"
+                "I was unable to communicate with D&D Beyond to confirm access to:\n"
                 f"{', '.join(e.name for e in err.entities)}"
             )
         else:
@@ -542,7 +542,7 @@ async def handle_alias_required_licenses(ctx, err):
                 "[here](https://www.dndbeyond.com/account)."
             )
             embed.set_footer(
-                text="Already linked your account? It may take up to a minute for Avrae to recognize the " "link."
+                text="Already linked your account? It may take up to a minute for Avrae to recognize the link."
             )
     else:
         missing_source_ids = {e.source for e in err.entities}
@@ -569,5 +569,5 @@ async def handle_alias_required_licenses(ctx, err):
         )
         embed.url = marketplace_url
 
-        embed.set_footer(text="Already unlocked? It may take up to a minute for Avrae to recognize the " "purchase.")
+        embed.set_footer(text="Already unlocked? It may take up to a minute for Avrae to recognize the purchase.")
     await ctx.send(embed=embed)

--- a/cogs5e/dice/cog.py
+++ b/cogs5e/dice/cog.py
@@ -96,9 +96,9 @@ class Dice(commands.Cog):
         dice, adv = string_search_adv(dice)
 
         res = d20.roll(dice, advantage=adv, allow_comments=True, stringifier=VerboseMDStringifier())
-        out = f"{ctx.author.mention}  :game_die:\n" f"{str(res)}"
+        out = f"{ctx.author.mention}  :game_die:\n{str(res)}"
         if len(out) > 1999:
-            out = f"{ctx.author.mention}  :game_die:\n" f"{str(res)[:100]}...\n" f"**Total**: {res.total}"
+            out = f"{ctx.author.mention}  :game_die:\n{str(res)[:100]}...\n**Total**: {res.total}"
 
         await try_delete(ctx.message)
         await ctx.send(out, allowed_mentions=discord.AllowedMentions(users=[ctx.author]))

--- a/cogs5e/dice/inline.py
+++ b/cogs5e/dice/inline.py
@@ -137,17 +137,21 @@ class InlineRoller:
         embed.description = f"Hi {user.mention}, it looks like this is your first time using inline rolling with me!"
         embed.add_field(
             name="What is Inline Rolling?",
-            value="Whenever you send a message with some dice in between double brackets (e.g. `[[1d20]]`), I'll reply "
-            "to it with a roll for each one. You can send messages with multiple, too, like this: ```\n"
-            "I attack the goblin with my shortsword [[1d20 + 6]] for a total of [[1d6 + 3]] piercing damage.\n"
-            "```",
+            value=(
+                "Whenever you send a message with some dice in between double brackets (e.g. `[[1d20]]`), I'll reply "
+                "to it with a roll for each one. You can send messages with multiple, too, like this: ```\n"
+                "I attack the goblin with my shortsword [[1d20 + 6]] for a total of [[1d6 + 3]] piercing damage.\n"
+                "```"
+            ),
             inline=False,
         )
         # noinspection DuplicatedCode
         embed.add_field(
             name="Learn More",
-            value="You can learn more about Inline Rolling in [the Avrae cheatsheets]"
-            "(https://avrae.readthedocs.io/en/latest/cheatsheets/inline_rolling.html).",
+            value=(
+                "You can learn more about Inline Rolling in [the Avrae cheatsheets]"
+                "(https://avrae.readthedocs.io/en/latest/cheatsheets/inline_rolling.html)."
+            ),
             inline=False,
         )
         embed.set_footer(text="You won't see this message again.")
@@ -167,16 +171,20 @@ class InlineRoller:
         embed.description = f"Hi {user.mention}, it looks like this is your first time using inline rolling with me!"
         embed.add_field(
             name="What is Inline Rolling?",
-            value="Whenever you send a message with some dice in between double brackets (e.g. `[[1d20]]`), I'll react "
-            f"with the {INLINE_ROLLING_EMOJI} emoji. You can click it to have me roll all of the dice in your "
-            "message, and I'll reply with my own message!",
+            value=(
+                "Whenever you send a message with some dice in between double brackets (e.g. `[[1d20]]`), I'll react "
+                f"with the {INLINE_ROLLING_EMOJI} emoji. You can click it to have me roll all of the dice in your "
+                "message, and I'll reply with my own message!"
+            ),
             inline=False,
         )
         # noinspection DuplicatedCode
         embed.add_field(
             name="Learn More",
-            value="You can learn more about Inline Rolling in [the Avrae cheatsheets]"
-            "(https://avrae.readthedocs.io/en/latest/cheatsheets/inline_rolling.html).",
+            value=(
+                "You can learn more about Inline Rolling in [the Avrae cheatsheets]"
+                "(https://avrae.readthedocs.io/en/latest/cheatsheets/inline_rolling.html)."
+            ),
             inline=False,
         )
         embed.set_footer(text="You won't see this message again.")

--- a/cogs5e/gamelog/cog.py
+++ b/cogs5e/gamelog/cog.py
@@ -90,15 +90,17 @@ class GameLog(commands.Cog):
         embed.title = f"Linked {result.campaign_name}!"
         embed.description = (
             f"Linked {result.campaign_name} to this channel! Your players' rolls from D&D Beyond "
-            f"will show up here, and checks, saves, and attacks made by characters in your campaign "
-            f"here will appear in D&D Beyond!"
+            "will show up here, and checks, saves, and attacks made by characters in your campaign "
+            "here will appear in D&D Beyond!"
         )
         embed.add_field(
             name="Not Seeing Rolls?",
-            value=f"Not seeing one or more of your players' rolls? Make sure their [D&D Beyond "
-            f"and Discord accounts are linked](https://www.dndbeyond.com/account) and their "
-            f"[characters are imported](https://avrae.readthedocs.io/en/stable/cheatsheets/get_started.html#step-2-add-a-character)! "
-            f"You can check your players' link status with `{ctx.prefix}ddb`.",
+            value=(
+                "Not seeing one or more of your players' rolls? Make sure their [D&D Beyond and Discord accounts are"
+                " linked](https://www.dndbeyond.com/account) and their [characters are"
+                " imported](https://avrae.readthedocs.io/en/stable/cheatsheets/get_started.html#step-2-add-a-character)!"
+                f" You can check your players' link status with `{ctx.prefix}ddb`."
+            ),
         )
         await ctx.send(embed=embed)
 
@@ -110,9 +112,9 @@ class GameLog(commands.Cog):
         existing_links = await CampaignLink.get_channel_links(ctx)
         if not existing_links:
             return await ctx.send(
-                f"This channel is not linked to any D&D Beyond campaigns. "
+                "This channel is not linked to any D&D Beyond campaigns. "
                 f"Use `{ctx.prefix}campaign https://www.dndbeyond.com/campaigns/...` to have "
-                f"your and your players' rolls show up here in real time!"
+                "your and your players' rolls show up here in real time!"
             )
         embed = embeds.EmbedWithAuthor(ctx)
         embed.title = "D&D Beyond Campaign Links"
@@ -123,10 +125,12 @@ class GameLog(commands.Cog):
         )
         embed.add_field(
             name="Not Seeing Rolls?",
-            value=f"Not seeing one or more of your players' rolls? Make sure their [D&D Beyond "
-            f"and Discord accounts are linked](https://www.dndbeyond.com/account) and their "
-            f"[characters are imported](https://avrae.readthedocs.io/en/stable/cheatsheets/get_started.html#step-2-add-a-character)! "
-            f"You can check your players' link status with `{ctx.prefix}ddb`.",
+            value=(
+                "Not seeing one or more of your players' rolls? Make sure their [D&D Beyond and Discord accounts are"
+                " linked](https://www.dndbeyond.com/account) and their [characters are"
+                " imported](https://avrae.readthedocs.io/en/stable/cheatsheets/get_started.html#step-2-add-a-character)!"
+                f" You can check your players' link status with `{ctx.prefix}ddb`."
+            ),
         )
         await ctx.send(embed=embed)
 
@@ -142,9 +146,9 @@ class GameLog(commands.Cog):
         existing_links = await CampaignLink.get_channel_links(ctx)
         if not existing_links:
             return await ctx.send(
-                f"This channel is not linked to any D&D Beyond campaigns. "
+                "This channel is not linked to any D&D Beyond campaigns. "
                 f"Use `{ctx.prefix}campaign https://www.dndbeyond.com/campaigns/...` to have "
-                f"your and your players' rolls show up here in real time!"
+                "your and your players' rolls show up here in real time!"
             )
         the_link = await search_and_select(ctx, existing_links, name, key=lambda cl: cl.campaign_name)
 

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -78,9 +78,7 @@ class GameTrack(commands.Cog):
         if level is None and value is None:  # show remaining
             embed.description = f"__**Remaining Spell Slots**__\n{character.spellbook.slots_str()}"
         elif value is None:
-            embed.description = (
-                f"__**Remaining Level {level} Spell Slots**__\n" f"{character.spellbook.slots_str(level)}"
-            )
+            embed.description = f"__**Remaining Level {level} Spell Slots**__\n{character.spellbook.slots_str(level)}"
         else:
             old_slots = character.spellbook.get_slots(level)
             value = maybe_mod(value, old_slots)
@@ -94,8 +92,10 @@ class GameTrack(commands.Cog):
         # footer - pact vs non pact
         if character.spellbook.max_pact_slots is not None:
             embed.set_footer(
-                text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used\n"
-                f"{constants.FILLED_BUBBLE_ALT} / {constants.EMPTY_BUBBLE_ALT} = Pact Slot"
+                text=(
+                    f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used\n"
+                    f"{constants.FILLED_BUBBLE_ALT} / {constants.EMPTY_BUBBLE_ALT} = Pact Slot"
+                )
             )
         else:
             embed.set_footer(text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used")
@@ -801,7 +801,7 @@ class GameTrack(commands.Cog):
                 spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.name in char.spellbook)
             except NoSelectionElements:
                 return await ctx.send(
-                    f"No matching spells found. Make sure this spell is in your "
+                    "No matching spells found. Make sure this spell is in your "
                     f"`{ctx.prefix}spellbook`, or cast with the `-i` argument to ignore restrictions!"
                 )
         else:

--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -99,8 +99,7 @@ class Homebrew(commands.Cog):
             )
         ):
             return await ctx.send(
-                "This is not a valid CritterDB link. Ensure the link is to the "
-                "bestiary and not an individual creature."
+                "This is not a valid CritterDB link. Ensure the link is to the bestiary and not an individual creature."
             )
 
         loading = await ctx.send("Importing bestiary (this may take a while for large bestiaries)...")
@@ -263,9 +262,7 @@ class Homebrew(commands.Cog):
 
         await pack.subscribe(ctx)
         pack_owner = await user_from_id(ctx, pack.owner)
-        await ctx.send(
-            f"Subscribed to {pack.name} by {pack_owner}. " f"Use `{ctx.prefix}pack {pack.name}` to select it."
-        )
+        await ctx.send(f"Subscribed to {pack.name} by {pack_owner}. Use `{ctx.prefix}pack {pack.name}` to select it.")
 
     @pack.command(name="unsubscribe", aliases=["unsub"])
     async def pack_unsub(self, ctx, name):
@@ -388,9 +385,7 @@ class Homebrew(commands.Cog):
 
         await tome.subscribe(ctx)
         tome_owner = await user_from_id(ctx, tome.owner)
-        await ctx.send(
-            f"Subscribed to {tome.name} by {tome_owner}. " f"Use `{ctx.prefix}tome {tome.name}` to select it."
-        )
+        await ctx.send(f"Subscribed to {tome.name} by {tome_owner}. Use `{ctx.prefix}tome {tome.name}` to select it.")
 
     @tome.command(name="unsubscribe", aliases=["unsub"])
     async def tome_unsub(self, ctx, name):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1390,7 +1390,7 @@ class InitTracker(commands.Cog):
             except NoSelectionElements:
                 return await ctx.send(
                     f"No matching spells found in {combatant.name}'s spellbook. Cast again "
-                    f"with the `-i` argument to ignore restrictions!"
+                    "with the `-i` argument to ignore restrictions!"
                 )
         else:
             spell = await select_spell_full(ctx, spell_name)

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -129,7 +129,7 @@ class InitTracker(commands.Cog):
         with suppress(disnake.HTTPException):
             await temp_summary_msg.pin()
         out = (
-            f"Everyone roll for initiative!\n"
+            "Everyone roll for initiative!\n"
             f"If you have a character set up with SheetManager: `{ctx.clean_prefix}init join`\n"
             f"If it's a 5e monster: `{ctx.clean_prefix}init madd <monster name>`\n"
             f"Otherwise: `{ctx.clean_prefix}init add <modifier> <name>`"
@@ -137,7 +137,7 @@ class InitTracker(commands.Cog):
         if guild_settings.upenn_nlp_opt_in and await utils.nlp_feature_flag_enabled(self.bot):
             out = (
                 f"{out}\nMessages sent in this channel during combat will be recorded for research purposes. "
-                f"By sending messages in this channel during this combat, you agree to participate in the Avrae NLP "
+                "By sending messages in this channel during this combat, you agree to participate in the Avrae NLP "
                 f"study. See `{ctx.clean_prefix}init nlp` for more information."
             )
             combat.nlp_record_session_id = utils.create_nlp_record_session_id()
@@ -1442,7 +1442,7 @@ class InitTracker(commands.Cog):
         combat = await ctx.get_combat()
 
         with suppress(disnake.HTTPException):
-            await ctx.author.send(f"End of combat report: {combat.round_num} rounds " f"{combat.get_summary(True)}")
+            await ctx.author.send(f"End of combat report: {combat.round_num} rounds {combat.get_summary(True)}")
             summary = combat.get_summary_msg()
             await summary.edit(content=combat.get_summary() + " ```-----COMBAT ENDED-----```")
             await summary.unpin()
@@ -1469,28 +1469,36 @@ class InitTracker(commands.Cog):
             )
             embed.add_field(
                 name="To Opt Out",
-                value="To opt out, you may choose not to participate in any recorded channel. You may also ask a "
-                f"server moderator to use the `{ctx.clean_prefix}init nlp stopall` command, or ask a server "
-                "administrator to disable `Contribute Message Data to Natural Language AI Training` in the "
-                f"`{ctx.clean_prefix}servsettings` command.",
+                value=(
+                    "To opt out, you may choose not to participate in any recorded channel. You may also ask a "
+                    f"server moderator to use the `{ctx.clean_prefix}init nlp stopall` command, or ask a server "
+                    "administrator to disable `Contribute Message Data to Natural Language AI Training` in the "
+                    f"`{ctx.clean_prefix}servsettings` command."
+                ),
                 inline=False,
             )
             embed.add_field(
                 name="Learn More",
-                value="You can learn more about the Avrae NLP project "
-                "[here](https://www.cis.upenn.edu/~ccb/language-to-avrae.html).",
+                value=(
+                    "You can learn more about the Avrae NLP project "
+                    "[here](https://www.cis.upenn.edu/~ccb/language-to-avrae.html)."
+                ),
                 inline=False,
             )
             embed.add_field(
                 name="Subcommands",
-                value="**list** - List all channels in this server currently recording message data.\n"
-                "**stopall** - Stop all message recording currently active on this server. "
-                "Requires *Manage Messages* Discord permissions.",
+                value=(
+                    "**list** - List all channels in this server currently recording message data.\n"
+                    "**stopall** - Stop all message recording currently active on this server. "
+                    "Requires *Manage Messages* Discord permissions."
+                ),
             )
             embed.add_field(
                 name="Links",
-                value="[Project Description](https://www.cis.upenn.edu/~ccb/language-to-avrae.html) "
-                "\u2022 [Privacy Policy](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy)",
+                value=(
+                    "[Project Description](https://www.cis.upenn.edu/~ccb/language-to-avrae.html) "
+                    "\u2022 [Privacy Policy](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy)"
+                ),
                 inline=False,
             )
             await ctx.send(embed=embed)
@@ -1545,7 +1553,7 @@ class InitTracker(commands.Cog):
         stopped_recordings = await self.nlp.stop_all_recordings(ctx.guild)
         await ctx.send(
             f"Ok, I have stopped recording messages in {stopped_recordings} channels.\n"
-            f"Starting new combats will still begin a new recording - to opt out of contributing data to this project, "
-            f"ask a server administrator to disable `Contribute Message Data to Natural Language AI Training` in the "
+            "Starting new combats will still begin a new recording - to opt out of contributing data to this project, "
+            "ask a server administrator to disable `Contribute Message Data to Natural Language AI Training` in the "
             f"`{ctx.clean_prefix}servsettings` command."
         )

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -341,9 +341,9 @@ class Lookup(commands.Cog):
                 proper_name = f"The {monster.name}" if not monster.proper else monster.name
                 legendary = [
                     f"{proper_name} can take {monster.la_per_round} legendary actions, choosing from "
-                    f"the options below. Only one legendary action can be used at a time and only at the "
+                    "the options below. Only one legendary action can be used at a time and only at the "
                     f"end of another creature's turn. {proper_name} regains spent legendary actions at "
-                    f"the start of its turn."
+                    "the start of its turn."
                 ]
                 for a in monster.legactions:
                     if a.name:
@@ -524,7 +524,7 @@ class Lookup(commands.Cog):
             if spell.level > 0
             else f"{spell.get_school().lower()} cantrip"
         )
-        embed.description = f"*{school_level}. " f"({', '.join(itertools.chain(spell.classes, spell.subclasses))})*"
+        embed.description = f"*{school_level}. ({', '.join(itertools.chain(spell.classes, spell.subclasses))})*"
         if spell.ritual:
             time = f"{spell.time} (ritual)"
         else:

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -37,8 +37,7 @@ class Attack(Effect):
         super().run(autoctx)
         if autoctx.target is None:
             raise TargetException(
-                "Tried to make an attack without a target! Make sure all Attack effects are inside "
-                "of a Target effect."
+                "Tried to make an attack without a target! Make sure all Attack effects are inside of a Target effect."
             )
 
         # ==== arguments ====

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -34,7 +34,7 @@ class Damage(Effect):
         super().run(autoctx)
         if autoctx.target is None:
             raise TargetException(
-                "Tried to do damage without a target! Make sure all Damage effects are inside " "of a Target effect."
+                "Tried to do damage without a target! Make sure all Damage effects are inside of a Target effect."
             )
         # general arguments
         args = autoctx.args

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -61,8 +61,7 @@ class LegacyIEffect(Effect):
         super().run(autoctx)
         if autoctx.target is None:
             raise TargetException(
-                "Tried to add an effect without a target! Make sure all IEffect effects are inside "
-                "of a Target effect."
+                "Tried to add an effect without a target! Make sure all IEffect effects are inside of a Target effect."
             )
 
         if isinstance(self.duration, str):
@@ -227,8 +226,7 @@ class IEffect(Effect):
         super().run(autoctx)
         if autoctx.target is None:
             raise TargetException(
-                "Tried to add an effect without a target! Make sure all IEffect effects are inside "
-                "of a Target effect."
+                "Tried to add an effect without a target! Make sure all IEffect effects are inside of a Target effect."
             )
 
         if isinstance(self.duration, str):

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -41,7 +41,7 @@ class Save(Effect):
         super().run(autoctx)
         if autoctx.target is None:
             raise TargetException(
-                "Tried to make a save without a target! Make sure all Save effects are inside " "of a Target effect."
+                "Tried to make a save without a target! Make sure all Save effects are inside of a Target effect."
             )
 
         # ==== args ====

--- a/cogs5e/models/automation/effects/temphp.py
+++ b/cogs5e/models/automation/effects/temphp.py
@@ -29,7 +29,7 @@ class TempHP(Effect):
         super().run(autoctx)
         if autoctx.target is None:
             raise TargetException(
-                "Tried to add temp HP without a target! Make sure all TempHP effects are inside " "of a Target effect."
+                "Tried to add temp HP without a target! Make sure all TempHP effects are inside of a Target effect."
             )
         args = autoctx.args
         amount = self.amount

--- a/cogs5e/models/automation/effects/variable.py
+++ b/cogs5e/models/automation/effects/variable.py
@@ -48,7 +48,7 @@ class SetVariable(Effect):
             final_value = int(value)
         except (TypeError, ValueError):
             raise AutomationException(
-                f"{value} cannot be interpreted as an integer " f"(in `{self.name} = {level_value}`)."
+                f"{value} cannot be interpreted as an integer (in `{self.name} = {level_value}`)."
             )
 
         # bind

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -644,8 +644,10 @@ class Character(StatBlock):
         # sheet url?
         if self._import_version < SHEET_VERSION:
             embed.set_footer(
-                text=f"You are using an old sheet version ({self.sheet_type} v{self._import_version}). "
-                f"Please run !update."
+                text=(
+                    f"You are using an old sheet version ({self.sheet_type} v{self._import_version}). "
+                    "Please run !update."
+                )
             )
 
         return embed

--- a/cogs5e/models/sheet/base.py
+++ b/cogs5e/models/sheet/base.py
@@ -172,7 +172,7 @@ class Skills:
     def from_dict(cls, d):
         if set(d.keys()) != set(SKILL_NAMES):
             raise ValueError(
-                f"Some skills are missing. " f"Difference: {set(d.keys()).symmetric_difference(set(SKILL_NAMES))}"
+                f"Some skills are missing. Difference: {set(d.keys()).symmetric_difference(set(SKILL_NAMES))}"
             )
         skills = {k: Skill.from_dict(v) for k, v in d.items()}
         return cls(skills)
@@ -250,7 +250,7 @@ class Saves:
     def from_dict(cls, d):
         if set(d.keys()) != set(SAVE_NAMES):
             raise ValueError(
-                f"Some saves are missing. " f"Difference: {set(d.keys()).symmetric_difference(set(SAVE_NAMES))}"
+                f"Some saves are missing. Difference: {set(d.keys()).symmetric_difference(set(SAVE_NAMES))}"
             )
         saves = {k: Skill.from_dict(v) for k, v in d.items()}
         return cls(saves)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -580,8 +580,7 @@ class SheetManager(commands.Cog):
 
         if not out:
             return await ctx.send(
-                f"No valid settings found. Try `{ctx.prefix}csettings` with no arguments to use an "
-                f"interactive menu!"
+                f"No valid settings found. Try `{ctx.prefix}csettings` with no arguments to use an interactive menu!"
             )
 
         await char.options.commit(ctx.bot.mdb, char)
@@ -594,8 +593,8 @@ class SheetManager(commands.Cog):
         if conflict:
             return await confirm(
                 ctx,
-                f"Warning: This will overwrite a character with the same ID. Do you wish to continue "
-                f"(Reply with yes/no)?\n"
+                "Warning: This will overwrite a character with the same ID. Do you wish to continue "
+                "(Reply with yes/no)?\n"
                 f"If you only wanted to update your character, run `{ctx.prefix}update` instead.",
             )
         return True
@@ -704,7 +703,7 @@ class SheetManager(commands.Cog):
 
         desc = (
             f"Your current active character is {active_character.name}. "
-            f"All of your checks, saves and actions will use this character's stats."
+            "All of your checks, saves and actions will use this character's stats."
         )
         if (link := active_character.get_sheet_url()) is not None:
             desc = f"{desc}\n[Go to Character Sheet]({link})"
@@ -720,23 +719,29 @@ class SheetManager(commands.Cog):
             global_character: Character = await ctx.get_character(ignore_guild=True)
         except NoCharacter:
             embed.set_footer(
-                text=f"{active_character.name} is only active on {ctx.guild.name}. You have no global "
-                f"active character. To set one, use {ctx.prefix}character <name>."
+                text=(
+                    f"{active_character.name} is only active on {ctx.guild.name}. You have no global "
+                    f"active character. To set one, use {ctx.prefix}character <name>."
+                )
             )
             return embed
 
         # global active character is server active
         if global_character.upstream == active_character.upstream:
             embed.set_footer(
-                text=f"{active_character.name} is active on {ctx.guild.name} and globally. "
-                f"To change active characters, use {ctx.prefix}character <name>."
+                text=(
+                    f"{active_character.name} is active on {ctx.guild.name} and globally. "
+                    f"To change active characters, use {ctx.prefix}character <name>."
+                )
             )
             return embed
 
         # global and server active differ
         embed.set_footer(
-            text=f"{active_character.name} is active on {ctx.guild.name}, overriding your global active "
-            f"character. To change active characters, use {ctx.prefix}character <name>."
+            text=(
+                f"{active_character.name} is active on {ctx.guild.name}, overriding your global active "
+                f"character. To change active characters, use {ctx.prefix}character <name>."
+            )
         )
         return embed
 
@@ -770,8 +775,10 @@ async def send_ddb_ctas(ctx, character):
     if ddb_user is None:
         embed.add_field(
             name="Connect Your D&D Beyond Account",
-            value="Visit your [Account Settings](https://www.dndbeyond.com/account) page in D&D Beyond to link your "
-            "D&D Beyond and Discord accounts. This lets you use all your D&D Beyond content in Avrae for free!",
+            value=(
+                "Visit your [Account Settings](https://www.dndbeyond.com/account) page in D&D Beyond to link your "
+                "D&D Beyond and Discord accounts. This lets you use all your D&D Beyond content in Avrae for free!"
+            ),
             inline=False,
         )
     # game log
@@ -781,10 +788,12 @@ async def send_ddb_ctas(ctx, character):
         except NoCampaignLink:
             embed.add_field(
                 name="Link Your D&D Beyond Campaign",
-                value=f"Sync rolls between a Discord channel and your D&D Beyond character sheet by linking your "
-                f"campaign! Use `{ctx.prefix}campaign https://www.dndbeyond.com/campaigns/"
-                f"{character.ddb_campaign_id}` in the Discord channel you want to link it to.\n"
-                f"This message can be disabled in `{ctx.prefix}server_settings`.",
+                value=(
+                    "Sync rolls between a Discord channel and your D&D Beyond character sheet by linking your "
+                    f"campaign! Use `{ctx.prefix}campaign https://www.dndbeyond.com/campaigns/"
+                    f"{character.ddb_campaign_id}` in the Discord channel you want to link it to.\n"
+                    f"This message can be disabled in `{ctx.prefix}server_settings`."
+                ),
                 inline=False,
             )
 

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -166,7 +166,7 @@ class BeyondSheetParser(SheetLoaderABC):
                 elif resp.status == 403:
                     if ddb_user is None:
                         raise ExternalImportError(
-                            "This character is private. Link your D&D Beyond and Discord accounts" " to import it!"
+                            "This character is private. Link your D&D Beyond and Discord accounts to import it!"
                         )
                     else:
                         raise ExternalImportError("You do not have permission to view this character.")
@@ -174,7 +174,7 @@ class BeyondSheetParser(SheetLoaderABC):
                     raise ExternalImportError("This character does not exist. Are you using the right link?")
                 elif resp.status == 429:
                     raise ExternalImportError(
-                        "Too many people are trying to import characters! Please try again in " "a few minutes."
+                        "Too many people are trying to import characters! Please try again in a few minutes."
                     )
                 else:
                     raise ExternalImportError(f"Beyond returned an error: {resp.status} - {resp.reason}")

--- a/cogs5e/sheets/errors.py
+++ b/cogs5e/sheets/errors.py
@@ -21,7 +21,7 @@ class AttackSyntaxError(ExternalImportError):
         self.sheet = sheet
         self.error = error
         super().__init__(
-            f"Attack syntax issue for attack '{attack_name}' in cell {cell} on sheet '{sheet}':\n" f"> {error}"
+            f"Attack syntax issue for attack '{attack_name}' in cell {cell} on sheet '{sheet}':\n> {error}"
         )
 
 

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -199,14 +199,14 @@ async def cast_spell(
                 # don't know spell
                 err = (
                     f"You don't know this spell! Use `{ctx.prefix}sb add {spell.name}` to add it to your "
-                    f"spellbook, or pass `-i` to ignore restrictions."
+                    "spellbook, or pass `-i` to ignore restrictions."
                 )
             else:
                 # ?
                 err = (
                     "Not enough spell slots remaining, or spell not in known spell list!\n"
                     f"Use `{ctx.prefix}game longrest` to restore all spell slots if this is a character, "
-                    f"or pass `-i` to ignore restrictions."
+                    "or pass `-i` to ignore restrictions."
                 )
             embed.description = err
             if cast_level > 0:
@@ -224,8 +224,10 @@ async def cast_spell(
                 embed = embeds.EmbedWithAuthor(
                     ctx,
                     title=f"Cannot cast spell!",
-                    description=f"{spell.name} is not prepared! Prepare it on your character sheet and use "
-                    f"`{ctx.prefix}update` to mark it as prepared, or use `-i` to ignore restrictions.",
+                    description=(
+                        f"{spell.name} is not prepared! Prepare it on your character sheet and use "
+                        f"`{ctx.prefix}update` to mark it as prepared, or use `-i` to ignore restrictions."
+                    ),
                 )
                 return CastResult(embed=embed, success=False, automation_result=None)
 
@@ -524,7 +526,7 @@ async def send_action_list(
         if not has_ddb_link:
             description = (
                 f"{description}\nItalicized actions are for display only and cannot be run. "
-                f"Connect your D&D Beyond account to unlock the full potential of these actions!"
+                "Connect your D&D Beyond account to unlock the full potential of these actions!"
             )
         else:
             source_names = natural_join([lookuputils.long_source_name(s) for s in source_names], "and")
@@ -543,8 +545,10 @@ async def send_action_list(
     if not verbose and actions:
         if non_automated_count:
             ep.set_footer(
-                value=f"Use the -v argument to view each action's full description "
-                f"and {non_automated_count} display-only actions."
+                value=(
+                    "Use the -v argument to view each action's full description "
+                    f"and {non_automated_count} display-only actions."
+                )
             )
         else:
             ep.set_footer(value=f"Use the -v argument to view each action's full description.")

--- a/cogsmisc/adminUtils.py
+++ b/cogsmisc/adminUtils.py
@@ -245,7 +245,7 @@ class AdminUtils(commands.Cog):
         entitlement_entity = compendium.lookup_entity(e.entitlement_entity_type, e.entitlement_entity_id)
         entitlement_entity_name = entitlement_entity.name if entitlement_entity is not None else "unknown entity!"
         await ctx.send(
-            f"```py\n"
+            "```py\n"
             f"# {e.entity_id=}, {e.type_id=}\n"
             f"# {e.entitlement_entity_id=}, {e.entitlement_entity_type=} ({entitlement_entity_name})\n"
             f"{e!r}\n```"

--- a/cogsmisc/core.py
+++ b/cogsmisc/core.py
@@ -51,7 +51,7 @@ class Core(commands.Cog):
     @commands.command()
     async def invite(self, ctx):
         """Prints a link to invite Avrae to your server."""
-        await ctx.send("You can invite Avrae to your server here:\n" "<https://invite.avrae.io>")
+        await ctx.send("You can invite Avrae to your server here:\n<https://invite.avrae.io>")
 
     @commands.group(invoke_without_command=True)
     async def changelog(self, ctx):
@@ -102,9 +102,11 @@ class Core(commands.Cog):
             stats[k] = await Stats.get_statistic(ctx, k)
 
         embed = discord.Embed(
-            description="Avrae, a bot to streamline D&D 5e online.\n"
-            "Check out the latest release notes "
-            "[here](https://github.com/avrae/avrae/releases/latest)."
+            description=(
+                "Avrae, a bot to streamline D&D 5e online.\n"
+                "Check out the latest release notes "
+                "[here](https://github.com/avrae/avrae/releases/latest)."
+            )
         )
         embed.title = "Invite Avrae to your server!"
         embed.url = "https://invite.avrae.io"
@@ -132,14 +134,16 @@ class Core(commands.Cog):
         embed.add_field(name="Commands Run", value=commands_run)
         embed.add_field(
             name="Servers",
-            value=f"{len(self.bot.guilds):,} on this cluster\n" f"{await Stats.get_guild_count(self.bot):,} total",
+            value=f"{len(self.bot.guilds):,} on this cluster\n{await Stats.get_guild_count(self.bot):,} total",
         )
         memory_usage = psutil.Process().memory_full_info().uss / 1024**2
         embed.add_field(name="Memory Usage", value="{:.2f} MiB".format(memory_usage))
         embed.add_field(
             name="About",
-            value="Made with :heart: by zhu.exe#4211 and the D&D Beyond team\n"
-            "Join the official development server [here](https://discord.gg/pQbd4s6)!",
+            value=(
+                "Made with :heart: by zhu.exe#4211 and the D&D Beyond team\n"
+                "Join the official development server [here](https://discord.gg/pQbd4s6)!"
+            ),
             inline=False,
         )
 
@@ -162,18 +166,18 @@ class Core(commands.Cog):
             embed.add_field(
                 name="Having trouble?",
                 value=(
-                    f"On occasion, the first time you link your Discord and D&D Beyond accounts, "
-                    f"Discord may use a temporary account that differs from your actual account. "
-                    f"If your accounts appear linked, but this command says they are not, compare "
-                    f"the numbers at the end of your Discord username to the numbers displayed in "
-                    f"the [D&D Beyond Account Settings](https://www.dndbeyond.com/account). For "
+                    "On occasion, the first time you link your Discord and D&D Beyond accounts, "
+                    "Discord may use a temporary account that differs from your actual account. "
+                    "If your accounts appear linked, but this command says they are not, compare "
+                    "the numbers at the end of your Discord username to the numbers displayed in "
+                    "the [D&D Beyond Account Settings](https://www.dndbeyond.com/account). For "
                     f"this account, `{ctx.author!s}`, they should be `{ctx.author.discriminator}`. "
-                    f"If they do not match, unlink the account, and try again."
+                    "If they do not match, unlink the account, and try again."
                 ),
             )
 
             embed.set_footer(
-                text="Already linked your account? It may take up to 15 minutes for Avrae to recognize " "the link."
+                text="Already linked your account? It may take up to 15 minutes for Avrae to recognize the link."
             )
             return await ctx.send(embed=embed)
 

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -126,8 +126,10 @@ class CollectableManagementGroup(commands.Group):
         if not self.is_server:
             self.serve = self.command(
                 name="serve",
-                help=f"Sets {a_or_an(self.obj_name)} as a server {self.obj_name} or subscribes the server to the "
-                f"workshop collection it is found in.",
+                help=(
+                    f"Sets {a_or_an(self.obj_name)} as a server {self.obj_name} or subscribes the server to the "
+                    "workshop collection it is found in."
+                ),
             )(self.serve)
 
     # we override the Group copy command since we register commands in __init__
@@ -155,12 +157,11 @@ class CollectableManagementGroup(commands.Group):
         await obj.commit(ctx.bot.mdb)
 
         out = (
-            f"{self.obj_name.capitalize()} `{name}` added."
-            f"```py\n{ctx.prefix}{self.obj_copy_command} {name} {code}\n```"
+            f"{self.obj_name.capitalize()} `{name}` added.```py\n{ctx.prefix}{self.obj_copy_command} {name} {code}\n```"
         )
 
         if len(out) > 2000:
-            out = f"{self.obj_name.capitalize()} `{name}` added.\n" f"Command output too long to display."
+            out = f"{self.obj_name.capitalize()} `{name}` added.\nCommand output too long to display."
 
         await ctx.send(out)
 
@@ -191,7 +192,7 @@ class CollectableManagementGroup(commands.Group):
             the_collection = await collectable.load_collection(ctx)
             owner = await user_from_id(ctx, the_collection.owner)
             embed.title = f"{ctx.prefix}{name}" if self.is_alias else name
-            embed.description = f"From {the_collection.name} by {owner}.\n" f"[View on Workshop]({the_collection.url})"
+            embed.description = f"From {the_collection.name} by {owner}.\n[View on Workshop]({the_collection.url})"
             embeds.add_fields_from_long_text(embed, "Help", collectable.docs or "No documentation.")
 
             if isinstance(collectable, workshop.WorkshopAlias):
@@ -248,7 +249,7 @@ class CollectableManagementGroup(commands.Group):
         if obj is None:
             return await ctx.send(
                 f"{self.obj_name.capitalize()} not found. If this is a workshop {self.obj_name}, you "
-                f"can unsubscribe on the Avrae Dashboard at <https://avrae.io/dashboard/workshop/my-subscriptions> "
+                "can unsubscribe on the Avrae Dashboard at <https://avrae.io/dashboard/workshop/my-subscriptions> "
                 f"or by using `{ctx.prefix}{self.name} unsubscribe <collection name>`."
             )
         await obj.delete(ctx.bot.mdb)
@@ -357,7 +358,7 @@ class CollectableManagementGroup(commands.Group):
         response = await confirm(
             ctx,
             f"This will rename {len(rename_tris)} {self.obj_name_pl}. "
-            f"Do you want to continue? (Reply with yes/no)\n"
+            "Do you want to continue? (Reply with yes/no)\n"
             f"{changes}",
         )
         if not response:
@@ -455,7 +456,7 @@ class CollectableManagementGroup(commands.Group):
         if existing_server_obj is not None and not await confirm(
             ctx,
             f"There is already an existing server {self.obj_name} named `{name}`. Do you want to overwrite it? "
-            f"(Reply with yes/no)",
+            "(Reply with yes/no)",
         ):
             return await ctx.send("Ok, aborting.")
 
@@ -466,7 +467,7 @@ class CollectableManagementGroup(commands.Group):
         )
 
         if len(out) > 2000:
-            out = f"Server {self.obj_name} `{server_obj.name}` added." f"Command output too long to display."
+            out = f"Server {self.obj_name} `{server_obj.name}` added.Command output too long to display."
 
         await ctx.send(out)
 
@@ -519,14 +520,20 @@ async def _snippet_before_edit(ctx, name=None, delete=False):
         return
     name = name.lower()
     if name in SPECIAL_ARGS or name.startswith("-"):
-        confirmation = f"**Warning:** Creating a snippet named `{name}` will prevent you from using the built-in `{name}` argument in Avrae commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
+        confirmation = (
+            f"**Warning:** Creating a snippet named `{name}` will prevent you from using the built-in `{name}` argument"
+            " in Avrae commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
+        )
     # roll string checking
     try:
         d20.parse(name)
     except d20.RollSyntaxError:
         pass
     else:
-        confirmation = f"**Warning:** Creating a snippet named `{name}` might cause hidden problems if you try to use the same roll in other commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
+        confirmation = (
+            f"**Warning:** Creating a snippet named `{name}` might cause hidden problems if you try to use the same"
+            " roll in other commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
+        )
 
     if confirmation is not None:
         if not await confirm(ctx, confirmation):
@@ -584,7 +591,7 @@ class Customization(commands.Cog):
             if not await confirm(
                 ctx,
                 f"Are you sure you want to set my prefix to `{prefix}`? This will affect "
-                f"everyone on this server! (Reply with yes/no)",
+                "everyone on this server! (Reply with yes/no)",
             ):
                 return await ctx.send("Ok, cancelling.")
 
@@ -696,7 +703,7 @@ class Customization(commands.Cog):
             ctx,
             f"This will delete **ALL** of your personal user snippets (it will not affect workshop subscriptions). "
             f"Are you *absolutely sure* you want to continue?\n"
-            "Type `Yes, I am sure` to confirm.",
+            f"Type `Yes, I am sure` to confirm.",
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -870,8 +877,8 @@ class Customization(commands.Cog):
         if not await confirm(
             ctx,
             f"This will delete **ALL** of your user variables (uvars). "
-            "Are you *absolutely sure* you want to continue?\n"
-            "Type `Yes, I am sure` to confirm.",
+            f"Are you *absolutely sure* you want to continue?\n"
+            f"Type `Yes, I am sure` to confirm.",
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -955,9 +962,11 @@ class Customization(commands.Cog):
             ctx,
             outside_codeblock=f"**{name}**:\n*Owner: {gvar['owner_name']}*",
             inside_codeblock=gvar["value"],
-            too_long_message=f"This gvar is too long to display in a single message. I've "
-            f"attached it here, but you can also view it at "
-            f"<https://avrae.io/dashboard/gvars?lookup={name}>.",
+            too_long_message=(
+                "This gvar is too long to display in a single message. I've "
+                "attached it here, but you can also view it at "
+                f"<https://avrae.io/dashboard/gvars?lookup={name}>."
+            ),
         )
 
     @globalvar.command(name="create")

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -54,7 +54,7 @@ class Tutorials(commands.Cog):
             tutorial, state = self.get_tutorial_and_state(user_state)
             if tutorial is None or state is None:
                 await ctx.send(
-                    f"The tutorial you were running no longer exists. "
+                    "The tutorial you were running no longer exists. "
                     f"Please run `{ctx.prefix}tutorial end` to start a new tutorial!"
                 )
                 return
@@ -93,7 +93,7 @@ class Tutorials(commands.Cog):
         tutorial, state = self.get_tutorial_and_state(user_state)
         if tutorial is None or state is None:
             return await ctx.send(
-                f"The tutorial you were running no longer exists. "
+                "The tutorial you were running no longer exists. "
                 f"Please run `{ctx.prefix}tutorial end` to start a new tutorial!"
             )
         # confirm
@@ -182,69 +182,83 @@ class Tutorials(commands.Cog):
             embed.add_field(
                 name="Prefix",
                 inline=False,
-                value=f"Looks like you've added me to {guild.name} in the past before. On {guild.name}, my prefix is "
-                f"`{prefix}`, but by default, it's `{config.DEFAULT_PREFIX}`. You can reset it with "
-                f"`{prefix}prefix {config.DEFAULT_PREFIX}`, or roll with it using the examples below!",
+                value=(
+                    f"Looks like you've added me to {guild.name} in the past before. On {guild.name}, my prefix is "
+                    f"`{prefix}`, but by default, it's `{config.DEFAULT_PREFIX}`. You can reset it with "
+                    f"`{prefix}prefix {config.DEFAULT_PREFIX}`, or roll with it using the examples below!"
+                ),
             )
 
         embed.add_field(
             name="Rolling Dice",
             inline=False,
-            value=f"Want to get rolling as soon as possible? Just use the `{prefix}roll` command to get started! "
-            f"Here's some examples: ```\n"
-            f"{prefix}roll 1d20\n"
-            f"{prefix}roll 4d6kh3\n"
-            f"{prefix}roll 1d20+1 adv\n"
-            f"{prefix}r 1d10[cold]+2d6[piercing]\n"
-            f"```",
+            value=(
+                f"Want to get rolling as soon as possible? Just use the `{prefix}roll` command to get started! "
+                "Here's some examples: ```\n"
+                f"{prefix}roll 1d20\n"
+                f"{prefix}roll 4d6kh3\n"
+                f"{prefix}roll 1d20+1 adv\n"
+                f"{prefix}r 1d10[cold]+2d6[piercing]\n"
+                "```"
+            ),
         )
 
         embed.add_field(
             name="Quickstart",
             inline=False,
-            value=f"I can do more than just roll dice, too! If you'd like to learn more about importing a "
-            f"character and rolling checks, saves, and attacks, try out the Quickstart tutorial!"
-            f"```\n{prefix}tutorial quickstart\n```",
+            value=(
+                "I can do more than just roll dice, too! If you'd like to learn more about importing a "
+                "character and rolling checks, saves, and attacks, try out the Quickstart tutorial!"
+                f"```\n{prefix}tutorial quickstart\n```"
+            ),
         )
 
         embed.add_field(
             name="Content Lookup",
             inline=False,
-            value=f"You can look up any spell, item, creature, and more right in Discord! Just use the `{prefix}spell`"
-            f", `{prefix}item`, `{prefix}monster`, or other lookup command! You can see a full list with "
-            f"`{prefix}help Lookup`.\n\n"
-            f"I'll even link with your D&D Beyond account to give you access to everything you've unlocked, "
-            f"all for free! To get started, try out the D&D Beyond tutorial."
-            f"```\n{prefix}tutorial beyond\n```\n"
-            f"\u203b By default, for servers with less than 250 members, a monster's full stat block will be "
-            f"hidden unless you have a Discord role named `Dungeon Master`. You can turn this off or change the "
-            f"DM role with `{prefix}servsettings`.",
+            value=(
+                f"You can look up any spell, item, creature, and more right in Discord! Just use the `{prefix}spell`"
+                f", `{prefix}item`, `{prefix}monster`, or other lookup command! You can see a full list with "
+                f"`{prefix}help Lookup`.\n\n"
+                "I'll even link with your D&D Beyond account to give you access to everything you've unlocked, "
+                "all for free! To get started, try out the D&D Beyond tutorial."
+                f"```\n{prefix}tutorial beyond\n```\n"
+                "\u203b By default, for servers with less than 250 members, a monster's full stat block will be "
+                "hidden unless you have a Discord role named `Dungeon Master`. You can turn this off or change the "
+                f"DM role with `{prefix}servsettings`."
+            ),
         )
 
         embed.add_field(
             name="Initiative Tracking",
             inline=False,
-            value=f"Once you're familiar with the basics, to learn how to get started with initiative tracking, "
-            f"try out the initiative tutorial! You can choose between a Dungeon Master's or a player's "
-            f"perspective."
-            f"```\n{prefix}tutorial initiative\n```",
+            value=(
+                "Once you're familiar with the basics, to learn how to get started with initiative tracking, "
+                "try out the initiative tutorial! You can choose between a Dungeon Master's or a player's "
+                "perspective."
+                f"```\n{prefix}tutorial initiative\n```"
+            ),
         )
 
         embed.add_field(
             name="Custom Commands",
             inline=False,
-            value=f"Want to do even more? Check out the list of user-made commands at "
-            f"https://avrae.io/dashboard/workshop, and add them to Discord with one click!",
+            value=(
+                f"Want to do even more? Check out the list of user-made commands at "
+                f"https://avrae.io/dashboard/workshop, and add them to Discord with one click!"
+            ),
         )
 
         embed.add_field(
             name="More Resources",
             inline=False,
-            value=f"If you ever want a refresher on a command or feature, use the `{prefix}help` command for help on a "
-            f"command, or `{prefix}tutorial` for a list of available tutorials.\n\n"
-            f"For even more resources, come join us in the development Discord at <https://support.avrae.io>!\n\n"
-            f"[Privacy Policy](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy) "
-            f"| [Terms of Use](https://company.wizards.com/en/legal/terms)",
+            value=(
+                f"If you ever want a refresher on a command or feature, use the `{prefix}help` command for help on a "
+                f"command, or `{prefix}tutorial` for a list of available tutorials.\n\n"
+                "For even more resources, come join us in the development Discord at <https://support.avrae.io>!\n\n"
+                "[Privacy Policy](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy) "
+                "| [Terms of Use](https://company.wizards.com/en/legal/terms)"
+            ),
         )
 
         try:

--- a/cogsmisc/tutorials/init_dm.py
+++ b/cogsmisc/tutorials/init_dm.py
@@ -224,7 +224,7 @@ class DMInitiative(Tutorial):
                 woofer = get_the_woofer(the_combat)
                 if woofer is None:
                     await ctx.send(
-                        f"Uh oh, looks like I can't find the Death Dog. "
+                        "Uh oh, looks like I can't find the Death Dog. "
                         f'Try readding it with `{ctx.prefix}i madd "Death Dog"`'
                     )
                     return
@@ -257,7 +257,7 @@ class DMInitiative(Tutorial):
                 woofer = get_the_woofer(the_combat)
                 if woofer is None:
                     await ctx.send(
-                        f"Uh oh, looks like I can't find the Death Dog. "
+                        "Uh oh, looks like I can't find the Death Dog. "
                         f'Try readding it with `{ctx.prefix}i madd "Death Dog"`'
                     )
                     return
@@ -293,7 +293,7 @@ class DMInitiative(Tutorial):
                 woofer = get_the_woofer(the_combat)
                 if woofer is None:
                     await ctx.send(
-                        f"Uh oh, looks like I can't find the Death Dog. "
+                        "Uh oh, looks like I can't find the Death Dog. "
                         f'Try readding it with `{ctx.prefix}i madd "Death Dog"`'
                     )
                     return
@@ -359,7 +359,7 @@ class DMInitiative(Tutorial):
                         await ctx.send("Ok. I've added her back to the fight - try again!")
                     else:
                         await ctx.send(
-                            f"Ok. If you'd like to continue this tutorial later, "
+                            "Ok. If you'd like to continue this tutorial later, "
                             f"run `{ctx.prefix}tutorial` to add Orkira back and continue."
                         )
                         return

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -43,7 +43,7 @@ class Tutorial(abc.ABC):
                 if value.first:
                     if self.first_state is not None:
                         raise ValueError(
-                            f"Found 2 first states in tutorial {self.name!r}: " f"({self.first_state.key}, {value.key})"
+                            f"Found 2 first states in tutorial {self.name!r}: ({self.first_state.key}, {value.key})"
                         )
                     self.first_state = value
         if self.first_state is None:

--- a/cogsmisc/tutorials/playingthegame.py
+++ b/cogsmisc/tutorials/playingthegame.py
@@ -19,7 +19,7 @@ class PlayingTheGame(Tutorial):
             except NoCharacter:
                 await state_map.end_tutorial(ctx)
                 raise PrerequisiteFailed(
-                    f"You need an active character to run this tutorial. Switch to one using "
+                    "You need an active character to run this tutorial. Switch to one using "
                     f"`{ctx.prefix}character <name>`, or try out the quickstart tutorial to learn how to import one!"
                 )
 

--- a/cogsmisc/tutorials/runningthegame.py
+++ b/cogsmisc/tutorials/runningthegame.py
@@ -46,7 +46,8 @@ class RunningTheGame(Tutorial):
                             state_map.data.get("has_check"),
                         ),
                         (
-                            f"Make an ability save for a monster with `{ctx.prefix}monsave <name of monster> <ability>`.",
+                            f"Make an ability save for a monster with `{ctx.prefix}monsave <name of monster>"
+                            " <ability>`.",
                             state_map.data.get("has_save"),
                         ),
                     ]

--- a/cogsmisc/tutorials/spellcasting.py
+++ b/cogsmisc/tutorials/spellcasting.py
@@ -126,12 +126,12 @@ class Spellcasting(Tutorial):
                     [
                         (
                             f"Manually lose a spell slot using `{ctx.prefix}game spellslot <level of spell slot> "
-                            f"-<number of spell slots>`.",
+                            "-<number of spell slots>`.",
                             state_map.data.get("has_removed"),
                         ),
                         (
                             f"Manually gain a spell slot using `{ctx.prefix}game spellslot <level of spell slot> "
-                            f"+<number of spell slots>`.",
+                            "+<number of spell slots>`.",
                             state_map.data.get("has_added"),
                         ),
                     ]
@@ -165,7 +165,10 @@ class Spellcasting(Tutorial):
                     if character.sheet_type == "beyond":
                         warlock_info = "Since you're a Warlock, your pact slots will reset on a Short Rest, too!"
                     elif warlock_level == character.levels.total_level:
-                        warlock_info = f"By the way, since you're a Warlock, you can also set your spell slots to recover on a Short Rest with `{ctx.prefix}csettings srslots true`."
+                        warlock_info = (
+                            "By the way, since you're a Warlock, you can also set your spell slots to recover on a"
+                            f" Short Rest with `{ctx.prefix}csettings srslots true`."
+                        )
             except NoCharacter:
                 pass
 

--- a/dbot.py
+++ b/dbot.py
@@ -207,12 +207,12 @@ class Avrae(commands.AutoShardedBot):
 
 
 desc = (
-    "Play D&D over Discord! Featuring advanced dice, initiative tracking, D&D Beyond integration, and more, you'll "
-    "never need another D&D bot.\n"
-    "View the full list of commands [here](https://avrae.io/commands)!\n"
-    "Invite Avrae to your server [here](https://invite.avrae.io)!\n"
-    "Join the official development server [here](https://support.avrae.io)!\n"
-    "[Privacy Policy](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy) | [Terms of Use](https://company.wizards.com/en/legal/terms)"
+    "Play D&D over Discord! Featuring advanced dice, initiative tracking, D&D Beyond integration, and more, you'll"
+    " never need another D&D bot.\nView the full list of commands [here](https://avrae.io/commands)!\nInvite Avrae to"
+    " your server [here](https://invite.avrae.io)!\nJoin the official development server"
+    " [here](https://support.avrae.io)!\n[Privacy"
+    " Policy](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy) | [Terms of"
+    " Use](https://company.wizards.com/en/legal/terms)"
 )
 intents = discord.Intents(
     guilds=True,
@@ -304,7 +304,7 @@ async def on_command_error(ctx, error):
         elif isinstance(original, Forbidden):
             try:
                 return await ctx.author.send(
-                    f"Error: I am missing permissions to run this command. "
+                    "Error: I am missing permissions to run this command. "
                     f"Please make sure I have permission to send messages to <#{ctx.channel.id}>."
                 )
             except HTTPException:
@@ -333,7 +333,7 @@ async def on_command_error(ctx, error):
 
     await ctx.send(
         f"Error: {str(error)}\nUh oh, that wasn't supposed to happen! "
-        f"Please join <https://support.avrae.io> and let us know about the error!"
+        "Please join <https://support.avrae.io> and let us know about the error!"
     )
 
     log.warning("Error caused by message: `{}`".format(ctx.message.content))

--- a/gamedata/compendium.py
+++ b/gamedata/compendium.py
@@ -280,7 +280,7 @@ class Compendium:
                 return
             elif entity.name != self._entity_lookup[k].name:
                 log.debug(
-                    f"Overwriting existing entity lookup key: {k} " f"({self._entity_lookup[k].name} -> {entity.name})"
+                    f"Overwriting existing entity lookup key: {k} ({self._entity_lookup[k].name} -> {entity.name})"
                 )
             else:
                 log.debug(

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -107,7 +107,7 @@ async def handle_required_license(ctx, err):
                 "[here](https://www.dndbeyond.com/account)."
             )
             embed.set_footer(
-                text="Already linked your account? It may take up to a minute for Avrae to recognize the " "link."
+                text="Already linked your account? It may take up to a minute for Avrae to recognize the link."
             )
     else:
         embed.title = f"Unlock {result.name} on D&D Beyond to view it here!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [tool.black]
 line-length = 120
+preview = true

--- a/tests/aliasing/evaluators_test.py
+++ b/tests/aliasing/evaluators_test.py
@@ -326,10 +326,12 @@ async def test_naughty_yaml(draconic_evaluator):
          +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC\
          AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
         """: {
-            "canonical": "         R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5"
-            "         OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+"
-            "         +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC"
-            "         AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
+            "canonical": (
+                "         R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J+fn5"
+                "         OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/+"
+                "         +f/++f/++f/++f/++f/++SH+Dk1hZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLC"
+                "         AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs="
+            )
         },
         """
         # pyYAML types

--- a/tests/cogs5e/dice_test.py
+++ b/tests/cogs5e/dice_test.py
@@ -42,8 +42,7 @@ async def test_ma(avrae, dhttp):
     avrae.message("!ma kobold dagger -h")
     await dhttp.receive_delete()
     await dhttp.receive_message(
-        f"An unknown creature attacks with a Dagger!\n"
-        f"{TO_HIT_PATTERN}\n({DAMAGE_PATTERN}\n)?\*Melee Weapon Attack:.+",
+        f"An unknown creature attacks with a Dagger!\n{TO_HIT_PATTERN}\n({DAMAGE_PATTERN}\n)?\*Melee Weapon Attack:.+",
         dm=True,
     )
     atk_embed = discord.Embed(title="An unknown creature attacks with a Dagger!")

--- a/tests/cogs5e/models/automation/effects_test.py
+++ b/tests/cogs5e/models/automation/effects_test.py
@@ -331,7 +331,8 @@ class TestIEffect:
 class TestText:
     async def test_valid_entityreference(self, character, avrae, dhttp):
         avrae.message(
-            '!a import {"name":"Text Test","automation":[{"type": "text", "text": {"id": 75, "typeId": 12168134}}],"_v":2}'
+            '!a import {"name":"Text Test","automation":[{"type": "text", "text": {"id": 75, "typeId":'
+            ' 12168134}}],"_v":2}'
         )
         await dhttp.drain()
         avrae.message('!a "Text Test"')
@@ -339,7 +340,8 @@ class TestText:
 
     async def test_missing_entitlement_entityreference(self, character, avrae, dhttp):
         avrae.message(
-            '!a import {"name":"Text Test2","automation":[{"type": "text", "text": {"id": -75, "typeId": 12168134}}],"_v":2}'
+            '!a import {"name":"Text Test2","automation":[{"type": "text", "text": {"id": -75, "typeId":'
+            ' 12168134}}],"_v":2}'
         )
         await dhttp.drain()
         avrae.message('!a "Text Test2"')
@@ -347,7 +349,8 @@ class TestText:
 
     async def test_invalid_entityreference(self, character, avrae, dhttp):
         avrae.message(
-            '!a import {"name":"Text Test3","automation":[{"type": "text", "text": {"id": -9999999, "typeId": 12168134}}],"_v":2}'
+            '!a import {"name":"Text Test3","automation":[{"type": "text", "text": {"id": -9999999, "typeId":'
+            ' 12168134}}],"_v":2}'
         )
         await dhttp.drain()
         avrae.message('!a "Text Test3"')
@@ -355,7 +358,8 @@ class TestText:
 
     async def test_invalid2_entityreference(self, character, avrae, dhttp):
         avrae.message(
-            '!a import {"name":"Text Test4","automation":[{"type": "text", "text": {"id": 2102, "typeId": 1118725998}}],"_v":2}'
+            '!a import {"name":"Text Test4","automation":[{"type": "text", "text": {"id": 2102, "typeId":'
+            ' 1118725998}}],"_v":2}'
         )
         await dhttp.drain()
         avrae.message('!a "Text Test4"')

--- a/tests/cogsmisc/customization_test.py
+++ b/tests/cogsmisc/customization_test.py
@@ -118,6 +118,4 @@ async def servering_aliases(avrae, dhttp):
     await dhttp.receive_message(r"Server alias `foobar` added\.\n```py\n.foobar echo foobar\n?```", regex=True)
 
     avrae.message("!alias serve")
-    await dhttp.receive_message(
-        "Error: name is a required argument that is missing.\n" "Use !help alias serve for help."
-    )
+    await dhttp.receive_message("Error: name is a required argument that is missing.\nUse !help alias serve for help.")

--- a/tests/mixed/aliasing_mixed_test.py
+++ b/tests/mixed/aliasing_mixed_test.py
@@ -131,7 +131,7 @@ class TestCharacterAliases:
     async def test_echo_attributes(self, avrae, dhttp):
         character = await active_character(avrae)
         avrae.message(
-            "!alias foobar echo {charismaMod} {proficiencyBonus} {charismaMod+proficiencyBonus}\n" "<name> <color>"
+            "!alias foobar echo {charismaMod} {proficiencyBonus} {charismaMod+proficiencyBonus}\n<name> <color>"
         )
         await dhttp.receive_message()
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,4 +5,4 @@ pytest-cov==3.0.0
 
 # pre-commit & formatting deps
 pre-commit==2.17.0
-black==22.1.0
+black==22.3.0

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -103,20 +103,24 @@ class CharacterSettingsUI(CharacterSettingsMenuBase):
         embed = embeds.EmbedWithCharacter(self.character, title=f"Character Settings for {self.character.name}")
         embed.add_field(
             name="__Cosmetic Settings__",
-            value=f"**Embed Color**: {color_setting_desc(self.settings.color)}\n"
-            f"**Show Character Image**: {self.settings.embed_image}\n"
-            f"**Use Compact Coin Display:** {self.settings.compact_coins}\n"
-            f"**Coin Conversion Mode**: {autoconvert_coins_desc(self.settings.autoconvert_coins)}",
+            value=(
+                f"**Embed Color**: {color_setting_desc(self.settings.color)}\n"
+                f"**Show Character Image**: {self.settings.embed_image}\n"
+                f"**Use Compact Coin Display:** {self.settings.compact_coins}\n"
+                f"**Coin Conversion Mode**: {autoconvert_coins_desc(self.settings.autoconvert_coins)}"
+            ),
             inline=False,
         )
         embed.add_field(
             name="__Gameplay Settings__",
-            value=f"**Crit Range**: {crit_range_desc(self.settings.crit_on)}\n"
-            f"**Extra Crit Dice**: {self.settings.extra_crit_dice}\n"
-            f"**Reroll**: {self.settings.reroll}\n"
-            f"**Ignore Crits**: {self.settings.ignore_crit}\n"
-            f"**Reliable Talent**: {self.settings.talent}\n"
-            f"**Reset All Spell Slots on Short Rest**: {self.settings.srslots}",
+            value=(
+                f"**Crit Range**: {crit_range_desc(self.settings.crit_on)}\n"
+                f"**Extra Crit Dice**: {self.settings.extra_crit_dice}\n"
+                f"**Reroll**: {self.settings.reroll}\n"
+                f"**Ignore Crits**: {self.settings.ignore_crit}\n"
+                f"**Reliable Talent**: {self.settings.talent}\n"
+                f"**Reset All Spell Slots on Short Rest**: {self.settings.srslots}"
+            ),
             inline=False,
         )
 
@@ -195,29 +199,37 @@ class _CosmeticSettingsUI(CharacterSettingsMenuBase):
         )
         embed.add_field(
             name="Embed Color",
-            value=f"**{color_setting_desc(self.settings.color)}**\n"
-            f"*This color will appear on the left side of your character's check, save, actions, and some "
-            f"other embeds (like this one!).*",
+            value=(
+                f"**{color_setting_desc(self.settings.color)}**\n"
+                "*This color will appear on the left side of your character's check, save, actions, and some "
+                "other embeds (like this one!).*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Show Character Image",
-            value=f"**{self.settings.embed_image}**\n"
-            f"*If this is disabled, your character's portrait will not appear on the right side of their "
-            f"checks, saves, actions, and some other embeds.*",
+            value=(
+                f"**{self.settings.embed_image}**\n"
+                "*If this is disabled, your character's portrait will not appear on the right side of their "
+                "checks, saves, actions, and some other embeds.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Compact Coin Display",
-            value=f"**{self.settings.compact_coins}**\n"
-            f"*If this is enabled, your coins will be displayed in decimal gold format.*",
+            value=(
+                f"**{self.settings.compact_coins}**\n"
+                "*If this is enabled, your coins will be displayed in decimal gold format.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Coin Conversion Mode",
-            value=f"**{autoconvert_coins_desc(self.settings.autoconvert_coins)}**\n"
-            f"*If a coin transaction would cause you to have a negative number of a certain currency, "
-            f"whether to automatically convert other coins to cover the transaction.*",
+            value=(
+                f"**{autoconvert_coins_desc(self.settings.autoconvert_coins)}**\n"
+                "*If a coin transaction would cause you to have a negative number of a certain currency, "
+                "whether to automatically convert other coins to cover the transaction.*"
+            ),
             inline=False,
         )
         return {"embed": embed}
@@ -285,37 +297,47 @@ class _GameplaySettingsUI(CharacterSettingsMenuBase):
         )
         embed.add_field(
             name="Crit Range",
-            value=f"**{crit_range_desc(self.settings.crit_on)}**\n"
-            f"*If an attack roll's natural roll (the value on the d20 before modifiers) lands in this range, "
-            f"the attack will be counted as a crit.*",
+            value=(
+                f"**{crit_range_desc(self.settings.crit_on)}**\n"
+                "*If an attack roll's natural roll (the value on the d20 before modifiers) lands in this range, "
+                "the attack will be counted as a crit.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Extra Crit Dice",
-            value=f"**{self.settings.extra_crit_dice}**\n"
-            f"*How many additional dice to add to a weapon's damage dice on a crit (in addition to doubling the "
-            f"dice).*",
+            value=(
+                f"**{self.settings.extra_crit_dice}**\n"
+                "*How many additional dice to add to a weapon's damage dice on a crit (in addition to doubling the "
+                "dice).*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Reroll",
-            value=f"**{self.settings.reroll}**\n"
-            f"*If an attack, save, or ability check's natural roll lands on this number, the die will be "
-            f"rerolled up to once.*",
+            value=(
+                f"**{self.settings.reroll}**\n"
+                "*If an attack, save, or ability check's natural roll lands on this number, the die will be "
+                "rerolled up to once.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Ignore Crits",
-            value=f"**{self.settings.ignore_crit}**\n"
-            f"*If this is enabled, any attack against your character will not have its damage dice doubled on a "
-            f"critical hit.*",
+            value=(
+                f"**{self.settings.ignore_crit}**\n"
+                "*If this is enabled, any attack against your character will not have its damage dice doubled on a "
+                "critical hit.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Reliable Talent",
-            value=f"**{self.settings.talent}**\n"
-            f"*If this is enabled, any d20 roll on an ability check that lets you add your proficiency bonus "
-            f"will be treated as a 10 if it rolls 9 or lower.*",
+            value=(
+                f"**{self.settings.talent}**\n"
+                "*If this is enabled, any d20 roll on an ability check that lets you add your proficiency bonus "
+                "will be treated as a 10 if it rolls 9 or lower.*"
+            ),
             inline=False,
         )
         sr_slot_note = ""
@@ -323,9 +345,11 @@ class _GameplaySettingsUI(CharacterSettingsMenuBase):
             sr_slot_note = " Note that your pact slots will reset on a short rest even if this setting is disabled."
         embed.add_field(
             name="Reset All Spell Slots on Short Rest",
-            value=f"**{self.settings.srslots}**\n"
-            f"*If this is enabled, all of your spell slots (including non-pact slots) will reset on a short "
-            f"rest.{sr_slot_note}*",
+            value=(
+                f"**{self.settings.srslots}**\n"
+                "*If this is enabled, all of your spell slots (including non-pact slots) will reset on a short "
+                f"rest.{sr_slot_note}*"
+            ),
             inline=False,
         )
         return {"embed": embed}
@@ -366,17 +390,21 @@ class _CharacterSyncSettingsUI(CharacterSettingsMenuBase):
         if outbound:
             embed.add_field(
                 name="Outbound Sync",
-                value=f"**{self.settings.sync_outbound}**\n"
-                f"*If this is enabled, updates to your character's HP, spell slots, custom counters, and more "
-                f"will be sent to your sheet provider live.*",
+                value=(
+                    f"**{self.settings.sync_outbound}**\n"
+                    "*If this is enabled, updates to your character's HP, spell slots, custom counters, and more "
+                    "will be sent to your sheet provider live.*"
+                ),
                 inline=False,
             )
         if inbound:
             embed.add_field(
                 name="Inbound Sync",
-                value=f"**{self.settings.sync_inbound}**\n"
-                f"*If this is enabled, if you change your character's HP, spell slots, custom counters, or more "
-                f"on your sheet provider, they will be updated here as well.*",
+                value=(
+                    f"**{self.settings.sync_inbound}**\n"
+                    "*If this is enabled, if you change your character's HP, spell slots, custom counters, or more "
+                    "on your sheet provider, they will be updated here as well.*"
+                ),
                 inline=False,
             )
         if not (outbound or inbound):

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -87,24 +87,28 @@ class ServerSettingsUI(ServerSettingsMenuBase):
             dm_roles = "Dungeon Master, DM, Game Master, or GM"
         embed.add_field(
             name="__Lookup Settings__",
-            value=f"**DM Roles**: {dm_roles}\n"
-            f"**Monsters Require DM**: {self.settings.lookup_dm_required}\n"
-            f"**Direct Message DM**: {self.settings.lookup_pm_dm}\n"
-            f"**Direct Message Results**: {self.settings.lookup_pm_result}\n"
-            f"**Prefer Legacy Content**: {legacy_preference_desc(self.settings.legacy_preference)}",
+            value=(
+                f"**DM Roles**: {dm_roles}\n"
+                f"**Monsters Require DM**: {self.settings.lookup_dm_required}\n"
+                f"**Direct Message DM**: {self.settings.lookup_pm_dm}\n"
+                f"**Direct Message Results**: {self.settings.lookup_pm_result}\n"
+                f"**Prefer Legacy Content**: {legacy_preference_desc(self.settings.legacy_preference)}"
+            ),
             inline=False,
         )
         embed.add_field(name="Inline Rolling Settings", value=await self.get_inline_rolling_desc(), inline=False)
 
         embed.add_field(
             name="__Custom Stat Roll Settings__",
-            value=f"**Dice**: {self.settings.randchar_dice}\n"
-            f"**Number of Sets**: {self.settings.randchar_sets}\n"
-            f"**Assign Stats**: {self.settings.randchar_straight}\n"
-            f"**Stat Names:** {stat_names_desc(self.settings.randchar_stat_names)}\n"
-            f"**Minimum Total**: {self.settings.randchar_min}\n"
-            f"**Maximum Total**: {self.settings.randchar_max}\n"
-            f"**Over/Under Rules**: {get_over_under_desc(self.settings.randchar_rules)}",
+            value=(
+                f"**Dice**: {self.settings.randchar_dice}\n"
+                f"**Number of Sets**: {self.settings.randchar_sets}\n"
+                f"**Assign Stats**: {self.settings.randchar_straight}\n"
+                f"**Stat Names:** {stat_names_desc(self.settings.randchar_stat_names)}\n"
+                f"**Minimum Total**: {self.settings.randchar_min}\n"
+                f"**Maximum Total**: {self.settings.randchar_max}\n"
+                f"**Over/Under Rules**: {get_over_under_desc(self.settings.randchar_rules)}"
+            ),
             inline=False,
         )
 
@@ -116,9 +120,11 @@ class ServerSettingsUI(ServerSettingsMenuBase):
             nlp_enabled_description = f"\n**Contribute Message Data to NLP Training**: {self.settings.upenn_nlp_opt_in}"
         embed.add_field(
             name="__Miscellaneous Settings__",
-            value=f"**Show DDB Campaign Message**: {self.settings.show_campaign_cta}\n"
-            f"**Critical Damage Type**: {crit_type_desc(self.settings.crit_type)}"
-            f"{nlp_enabled_description}",
+            value=(
+                f"**Show DDB Campaign Message**: {self.settings.show_campaign_cta}\n"
+                f"**Critical Damage Type**: {crit_type_desc(self.settings.crit_type)}"
+                f"{nlp_enabled_description}"
+            ),
             inline=False,
         )
 
@@ -247,49 +253,61 @@ class _LookupSettingsUI(ServerSettingsMenuBase):
         if not self.settings.dm_roles:
             embed.add_field(
                 name="DM Roles",
-                value=f"**Dungeon Master, DM, Game Master, or GM**\n"
-                f"*Any user with a role named one of these will be considered a DM. This lets them look up a "
-                f"monster's full stat block if `Monsters Require DM` is enabled, skip other players' turns in "
-                f"initiative, and more.*",
+                value=(
+                    f"**Dungeon Master, DM, Game Master, or GM**\n"
+                    f"*Any user with a role named one of these will be considered a DM. This lets them look up a "
+                    f"monster's full stat block if `Monsters Require DM` is enabled, skip other players' turns in "
+                    f"initiative, and more.*"
+                ),
                 inline=False,
             )
         else:
             dm_roles = natural_join([f"<@&{role_id}>" for role_id in self.settings.dm_roles], "or")
             embed.add_field(
                 name="DM Roles",
-                value=f"**{dm_roles}**\n"
-                f"*Any user with at least one of these roles will be considered a DM. This lets them look up a "
-                f"monster's full stat block if `Monsters Require DM` is enabled, skip turns in initiative, and "
-                f"more.*",
+                value=(
+                    f"**{dm_roles}**\n"
+                    "*Any user with at least one of these roles will be considered a DM. This lets them look up a "
+                    "monster's full stat block if `Monsters Require DM` is enabled, skip turns in initiative, and "
+                    "more.*"
+                ),
                 inline=False,
             )
         embed.add_field(
             name="Monsters Require DM",
-            value=f"**{self.settings.lookup_dm_required}**\n"
-            f"*If this is enabled, monster lookups will display hidden stats for any user without "
-            f"a role named DM, GM, Dungeon Master, Game Master, or the DM role configured above.*",
+            value=(
+                f"**{self.settings.lookup_dm_required}**\n"
+                "*If this is enabled, monster lookups will display hidden stats for any user without "
+                "a role named DM, GM, Dungeon Master, Game Master, or the DM role configured above.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Direct Message DMs",
-            value=f"**{self.settings.lookup_pm_dm}**\n"
-            f"*If this is enabled, the result of monster lookups will be direct messaged to the user who looked "
-            f"it up, rather than being printed to the channel, if the user is a DM.*",
+            value=(
+                f"**{self.settings.lookup_pm_dm}**\n"
+                "*If this is enabled, the result of monster lookups will be direct messaged to the user who looked "
+                "it up, rather than being printed to the channel, if the user is a DM.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Direct Message Results",
-            value=f"**{self.settings.lookup_pm_result}**\n"
-            f"*If this is enabled, the result of all lookups will be direct messaged to the user who looked "
-            f"it up, rather than being printed to the channel.*",
+            value=(
+                f"**{self.settings.lookup_pm_result}**\n"
+                "*If this is enabled, the result of all lookups will be direct messaged to the user who looked "
+                "it up, rather than being printed to the channel.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Prefer Legacy Content",
-            value=f"**{legacy_preference_desc(self.settings.legacy_preference)}**\n"
-            f"*If the only two options found in a content search are a legacy and non-legacy version of the same "
-            f"thing, whether to prefer the latest version, the legacy version, or always ask the user to select "
-            f"between the two.*",
+            value=(
+                f"**{legacy_preference_desc(self.settings.legacy_preference)}**\n"
+                "*If the only two options found in a content search are a legacy and non-legacy version of the same "
+                "thing, whether to prefer the latest version, the legacy version, or always ask the user to select "
+                "between the two.*"
+            ),
         )
         return {"embed": embed}
 
@@ -395,23 +413,27 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         )
         embed.add_field(
             name="Show DDB Campaign Message",
-            value=f"**{self.settings.show_campaign_cta}**\n"
-            f"*If this is enabled, you will receive occasional reminders to link your D&D Beyond campaign when "
-            f"you import a character in an unlinked campaign.*",
+            value=(
+                f"**{self.settings.show_campaign_cta}**\n"
+                "*If this is enabled, you will receive occasional reminders to link your D&D Beyond campaign when "
+                "you import a character in an unlinked campaign.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Crit Damage Type",
-            value=f"**{crit_type_desc(self.settings.crit_type)}**\n"
-            f"_This affects how critical damage is treated on the server._\n"
-            f" ● Add Max Dice Value\n"
-            f"> _This type adds the maximum value of each die to the total._\n> `2d8 + 4` -> `2d8 + 16 + 4`\n"
-            f" ● Double Dice Amount (Default)\n"
-            f"> _This type doubles the amount of dice rolled._\n> `2d8 + 4` -> `4d8 + 4`\n"
-            f" ● Double Dice Total\n"
-            f"> _This type doubles the total value of the dice rolled._\n> `2d8 + 4` -> `(2d8) * 2 + 4`\n"
-            f" ● Double Total\n"
-            f"> _This type doubles the total, including modifiers._\n> `2d8 + 4` -> `(2d8 + 4) * 2`",
+            value=(
+                f"**{crit_type_desc(self.settings.crit_type)}**\n"
+                "_This affects how critical damage is treated on the server._\n"
+                " ● Add Max Dice Value\n"
+                "> _This type adds the maximum value of each die to the total._\n> `2d8 + 4` -> `2d8 + 16 + 4`\n"
+                " ● Double Dice Amount (Default)\n"
+                "> _This type doubles the amount of dice rolled._\n> `2d8 + 4` -> `4d8 + 4`\n"
+                " ● Double Dice Total\n"
+                "> _This type doubles the total value of the dice rolled._\n> `2d8 + 4` -> `(2d8) * 2 + 4`\n"
+                " ● Double Total\n"
+                "> _This type doubles the total, including modifiers._\n> `2d8 + 4` -> `(2d8 + 4) * 2`"
+            ),
             inline=False,
         )
 
@@ -421,13 +443,15 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
         if nlp_feature_flag:
             embed.add_field(
                 name="Contribute Message Data to Natural Language AI Training",
-                value=f"**{self.settings.upenn_nlp_opt_in}**\n"
-                f"*If this is enabled, the contents of messages, displayed nicknames, character names, and snapshots "
-                f"of a character's sheet will be recorded in channels **with an active combat.***\n"
-                f"*This data will be used in a project to make advances in interactive fiction and text "
-                f"generation using artificial intelligence at the University of Pennsylvania.*\n"
-                f"*Read more about the project [here](https://www.cis.upenn.edu/~ccb/language-to-avrae.html), "
-                f"and our data handling and Privacy Policy [here](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy).*",
+                value=(
+                    f"**{self.settings.upenn_nlp_opt_in}**\n*If this is enabled, the contents of messages, displayed"
+                    " nicknames, character names, and snapshots of a character's sheet will be recorded in channels"
+                    " **with an active combat.***\n*This data will be used in a project to make advances in"
+                    " interactive fiction and text generation using artificial intelligence at the University of"
+                    " Pennsylvania.*\n*Read more about the project"
+                    " [here](https://www.cis.upenn.edu/~ccb/language-to-avrae.html), and our data handling and Privacy"
+                    " Policy [here](https://company.wizards.com/en/legal/wizards-coasts-privacy-policy).*"
+                ),
                 inline=False,
             )
 
@@ -531,7 +555,8 @@ class _RollStatsSettingsUI(ServerSettingsMenuBase):
                     stat_names = randchar_stat_names.replace(", ", ",").split(",")
                 if len(stat_names) != self.settings.randchar_num:
                     await interaction.send(
-                        f"Number of stat names does not match the number of stats. Press `{button.label}` to try again.",
+                        f"Number of stat names does not match the number of stats. Press `{button.label}` to try"
+                        " again.",
                         ephemeral=True,
                     )
                     self.settings.randchar_straight = False
@@ -661,50 +686,64 @@ class _RollStatsSettingsUI(ServerSettingsMenuBase):
         )
         embed.add_field(
             name="Dice Rolled",
-            value=f"**{self.settings.randchar_dice}**\n"
-            f"*This is the dice string that will be rolled six times for "
-            f"each stat set.*",
+            value=(
+                f"**{self.settings.randchar_dice}**\n"
+                "*This is the dice string that will be rolled six times for "
+                "each stat set.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Number of Sets",
-            value=f"**{self.settings.randchar_sets}**\n"
-            f"*This is how many sets of stat rolls it will return, "
-            f"allowing your players to choose between them.*",
+            value=(
+                f"**{self.settings.randchar_sets}**\n"
+                "*This is how many sets of stat rolls it will return, "
+                "allowing your players to choose between them.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Number of Stats",
-            value=f"**{self.settings.randchar_num}**\n"
-            f"*This is how many stat rolls it will return per set, "
-            f"allowing your players to choose between them.*",
+            value=(
+                f"**{self.settings.randchar_num}**\n"
+                "*This is how many stat rolls it will return per set, "
+                "allowing your players to choose between them.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Assign Stats Directly",
-            value=f"**{self.settings.randchar_straight}**\n"
-            f"**Stat Names:** {stat_names_desc(self.settings.randchar_stat_names)}\n"
-            f"*If this is enabled, stats will automatically be assigned to stats in the order "
-            f"they are rolled.*",
+            value=(
+                f"**{self.settings.randchar_straight}**\n"
+                f"**Stat Names:** {stat_names_desc(self.settings.randchar_stat_names)}\n"
+                "*If this is enabled, stats will automatically be assigned to stats in the order "
+                "they are rolled.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Minimum Total Score Required",
-            value=f"**{self.settings.randchar_min}**\n"
-            f"*This is the minimum combined score required. Standard array is 72 total.*",
+            value=(
+                f"**{self.settings.randchar_min}**\n"
+                "*This is the minimum combined score required. Standard array is 72 total.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Maximum Total Score Required",
-            value=f"**{self.settings.randchar_max}**\n"
-            f"*This is the maximum combined score required. Standard array is 72 total.*",
+            value=(
+                f"**{self.settings.randchar_max}**\n"
+                "*This is the maximum combined score required. Standard array is 72 total.*"
+            ),
             inline=False,
         )
         embed.add_field(
             name="Over/Under Rules",
-            value=f"**{get_over_under_desc(self.settings.randchar_rules)}**\n"
-            f"*This is a list of how many of the stats you require to be over/under a certain value, "
-            f"such as having at least one stat over 17, or two stats under 10.*",
+            value=(
+                f"**{get_over_under_desc(self.settings.randchar_rules)}**\n"
+                "*This is a list of how many of the stats you require to be over/under a certain value, "
+                "such as having at least one stat over 17, or two stats under 10.*"
+            ),
             inline=False,
         )
 

--- a/utils/datadog.py
+++ b/utils/datadog.py
@@ -32,11 +32,13 @@ def start_profiler():
 # ==== monkey-patches ====
 def _patch_logging():
     logging.basicConfig(
-        format="%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
-        "[dd.service=%(dd.service)s dd.env=%(dd.env)s "
-        "dd.version=%(dd.version)s "
-        "dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]"
-        "- %(message)s",
+        format=(
+            "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
+            "[dd.service=%(dd.service)s dd.env=%(dd.env)s "
+            "dd.version=%(dd.version)s "
+            "dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s]"
+            "- %(message)s"
+        ),
         level=logging.INFO,
     )
 

--- a/utils/dice.py
+++ b/utils/dice.py
@@ -3,7 +3,7 @@ import d20
 
 class VerboseMDStringifier(d20.MarkdownStringifier):
     def _str_expression(self, node):
-        return f"**{node.comment or 'Result'}**: {self._stringify(node.roll)}\n" f"**Total**: {int(node.total)}"
+        return f"**{node.comment or 'Result'}**: {self._stringify(node.roll)}\n**Total**: {int(node.total)}"
 
 
 class PersistentRollContext(d20.RollContext):

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -161,8 +161,10 @@ async def get_selection(
         else:
             embed.add_field(
                 name="Instructions",
-                value="Type your response in the channel you called the command. This message was PMed to "
-                "you to hide the monster name.",
+                value=(
+                    "Type your response in the channel you called the command. This message was PMed to "
+                    "you to hide the monster name."
+                ),
                 inline=False,
             )
             select_msg = await ctx.author.send(embed=embed)

--- a/utils/help.py
+++ b/utils/help.py
@@ -21,7 +21,7 @@ class AvraeHelp(HelpCommand):
         """Returns help command's ending note. This is mainly useful to override for i18n purposes."""
         command_name = self.invoked_with
         return (
-            f"An underlined command signifies that the command has subcommands.\n"
+            "An underlined command signifies that the command has subcommands.\n"
             f"Type {self.context.clean_prefix}{command_name} <command> for more info on a command.\n"
             f"You can also type {self.context.clean_prefix}{command_name} <category> for more info on a category."
         )
@@ -74,9 +74,11 @@ class AvraeHelp(HelpCommand):
 
     def add_help_footer(self):
         self.embed_paginator.set_footer(
-            value="Arguments surrounded in angled brackets (<args>) are mandatory,"
-            " while those surrounded in square brackets ([args]) are optional."
-            " In either case, don't include the brackets."
+            value=(
+                "Arguments surrounded in angled brackets (<args>) are mandatory,"
+                " while those surrounded in square brackets ([args]) are optional."
+                " In either case, don't include the brackets."
+            )
         )
 
     # ===== HelpCommand overrides =====
@@ -228,7 +230,7 @@ class AvraeHelp(HelpCommand):
         # metadata
         self.embed_paginator.add_field(name=f"{ctx.prefix}{' '.join(fqp)}")
         self.embed_paginator.extend_field(
-            f"From {the_collection.name} by {owner}.\n" f"[View on Workshop]({the_collection.url})"
+            f"From {the_collection.name} by {owner}.\n[View on Workshop]({the_collection.url})"
         )
 
         # docs
@@ -250,9 +252,11 @@ class AvraeHelp(HelpCommand):
 help_command = AvraeHelp(
     verify_checks=False,  # allows guild-only commands to be shown in PMs
     command_attrs=dict(
-        help="Shows the help for the bot or a specific command.\n"
-        "__Valid Arguments__\n"
-        "-here - Sends help to the channel instead of PMs.",
+        help=(
+            "Shows the help for the bot or a specific command.\n"
+            "__Valid Arguments__\n"
+            "-here - Sends help to the channel instead of PMs."
+        ),
         brief="Shows this message.",
     ),
 )

--- a/utils/img.py
+++ b/utils/img.py
@@ -74,7 +74,7 @@ async def generate_token(img_url, is_subscriber=False, token_args=None):
             async with session.get(img_url) as resp:
                 if not 199 < resp.status < 300:
                     raise ExternalImportError(
-                        f"I was unable to download the image to tokenize. " f"({resp.status} {resp.reason})"
+                        f"I was unable to download the image to tokenize. ({resp.status} {resp.reason})"
                     )
                 # get the image type from the content type header
                 content_type = resp.headers.get("Content-Type", "")
@@ -106,9 +106,7 @@ async def fetch_monster_image(img_url: str):
     async with aiohttp.ClientSession() as session:
         async with session.get(img_url) as resp:
             if not 199 < resp.status < 300:
-                raise ExternalImportError(
-                    f"I was unable to retrieve the monster token. " f"({resp.status} {resp.reason})"
-                )
+                raise ExternalImportError(f"I was unable to retrieve the monster token. ({resp.status} {resp.reason})")
             img_bytes = await resp.read()
 
     # cache

--- a/utils/settings/character.py
+++ b/utils/settings/character.py
@@ -181,9 +181,11 @@ CHARACTER_SETTINGS = {
     "autoconvertcoins": CSetting(
         "autoconvert_coins",
         "number",
-        description=f"auto convert coins mode, {CoinsAutoConvert.ASK.value} for ask everytime, "
-        f"{CoinsAutoConvert.ALWAYS.value} for always convert, "
-        f"{CoinsAutoConvert.NEVER.value} for never convert",
+        description=(
+            f"auto convert coins mode, {CoinsAutoConvert.ASK.value} for ask everytime, "
+            f"{CoinsAutoConvert.ALWAYS.value} for always convert, "
+            f"{CoinsAutoConvert.NEVER.value} for never convert"
+        ),
         default="ask everytime",
         display_func=lambda val: "ask everytime" if val == 0 else "always convert" if val == 1 else "never convert",
     ),


### PR DESCRIPTION
### Summary
Enable the `--preview` arg for Black CLI. This adds an additional formatting pass that ensures strings conform to the line length, splitting them across multiple lines (or merging them) where necessary. It also removes unnecessary string specifiers (like f-strings with no templates).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
