### PR TITLE
Add the 'ieffect' metavar to attacks granted by ieffects

### DIFF
--- a/cogs5e/initiative/buttons.py
+++ b/cogs5e/initiative/buttons.py
@@ -88,6 +88,7 @@ class ButtonHandler:
             spell_override=button_interaction.override_default_casting_mod,
             spell=spell,
             spell_level_override=button_interaction.granting_spell_cast_level,
+            from_button=True,
         )
 
         # and send the result

--- a/cogs5e/initiative/effects/interaction.py
+++ b/cogs5e/initiative/effects/interaction.py
@@ -90,6 +90,7 @@ class AttackInteraction(InitEffectInteraction):
             spell_override=self.override_default_casting_mod,
             spell=spell,
             spell_level_override=self.granting_spell_cast_level,
+            ieffect=self.effect,
         )
         return attack
 

--- a/cogs5e/models/automation/effects/target.py
+++ b/cogs5e/models/automation/effects/target.py
@@ -63,7 +63,7 @@ class Target(Effect):
 
     # --- action target types ---
     def run_all_target(self, autoctx, targets):
-        if autoctx.ieffect is not None:
+        if autoctx.ieffect is not None and autoctx.from_button:
             raise TargetException("You can only use the `self`, `parent`, or `children` target on an IEffect button.")
 
         result_pairs = []
@@ -73,7 +73,7 @@ class Target(Effect):
         return result_pairs
 
     def run_indexed_target(self, autoctx, targets, idx):
-        if autoctx.ieffect is not None:
+        if autoctx.ieffect is not None and autoctx.from_button:
             raise TargetException("You can only use the `self`, `parent`, or `children` target on an IEffect button.")
 
         targets = self.sorted_targets(targets)

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -40,6 +40,7 @@ class AutomationContext:
         ieffect: Optional["InitiativeEffect"] = None,
         allow_caster_ieffects: bool = True,
         allow_target_ieffects: bool = True,
+        from_button: bool = False,
     ):
         # runtime options
         self.ctx = ctx
@@ -72,6 +73,7 @@ class AutomationContext:
         self.ieffect = ieffect
         if ieffect is not None:
             self.metavars["ieffect"] = aliasing.api.combat.SimpleEffect(ieffect)
+        self.from_button = from_button
         self.allow_caster_ieffects = allow_caster_ieffects
         self.allow_target_ieffects = allow_target_ieffects
 


### PR DESCRIPTION
### Summary
Adds the 'ieffect' metavar to attacks granted by ieffects. 
Adds an parameter to determine if the automation was from a button or not.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
