### PR TITLE
Handle Monster Name Exceptions

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -282,7 +282,13 @@ class InitTracker(commands.Cog):
         ac = args.last("ac", type_=int)
         n = args.last("n", 1)
         note = args.last("note")
-        name_template = args.last("name", get_initials(monster.name) + "#")
+        name_template = args.last(
+            "name",
+            get_name(
+                monster,
+            )
+            + "#",
+        )
         init_skill = monster.skills.initiative
 
         combat = await ctx.get_combat()
@@ -1557,3 +1563,18 @@ class InitTracker(commands.Cog):
             "ask a server administrator to disable `Contribute Message Data to Natural Language AI Training` in the "
             f"`{ctx.clean_prefix}servsettings` command."
         )
+
+
+monster_name_exceptions = (294945, 2059697)
+
+
+def get_name(monster):
+    """
+    Checks if a monster's ID is in the list of exceptions (bad words, etc), returning the first two letters
+    if it is, otherwise grabs its initials.
+    """
+
+    if monster.entity_id in monster_name_exceptions:
+        return monster.name[:2].upper()
+
+    return get_initials(monster.name)

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -282,13 +282,7 @@ class InitTracker(commands.Cog):
         ac = args.last("ac", type_=int)
         n = args.last("n", 1)
         note = args.last("note")
-        name_template = args.last(
-            "name",
-            get_name(
-                monster,
-            )
-            + "#",
-        )
+        name_template = args.last("name", f"{get_name(monster)}#")
         init_skill = monster.skills.initiative
 
         combat = await ctx.get_combat()


### PR DESCRIPTION
### Summary
Adds a new function to check if the monster id is in a set of specific exceptions, returning the first two letters if it is.

This is to handle cases where certain monster names, when initialized, results in unfortunate phrases.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
