### PR TITLE
Handle auto hit and no damage old -attack ieffects

### DIFF
--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -167,10 +167,10 @@ def old_to_automation(bonus=None, damage=None, details=None):
     """Returns an Automation instance representing an old attack."""
     from cogs5e.models import automation
 
-    if damage is not None:
+    if damage:
         damage = automation.Damage(damage)
 
-    if bonus is not None:
+    if bonus:
         hit = [damage] if damage else []
         attack_eff = [automation.Attack(hit=hit, miss=[], attackBonus=str(bonus).strip("{}<>"))]
     else:

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -163,7 +163,7 @@ class AttackList:
         return bool(self.attacks)
 
 
-def old_to_automation(bonus=None, damage=None, details=None):
+def old_to_automation(bonus: str | None = None, damage: str | None = None, details: str | None = None):
     """Returns an Automation instance representing an old attack."""
     from cogs5e.models import automation
 


### PR DESCRIPTION
### Summary
Currently, LegacyIEffects using the `-attack` format fails to create auto-hit (`-attack '|<damage>|<details>'`) or no damage (`-attack '<to hit>||<details>'`) attacks. This broke many spells/actions/monster attacks as well as a lot of user effects that haven't been updated to IEffect2

Resolves #1799

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
