### PR TITLE
Fix Initiative Buttons

### DIFF
--- a/cogs5e/models/automation/__init__.py
+++ b/cogs5e/models/automation/__init__.py
@@ -51,6 +51,7 @@ class Automation:
         ieffect: Optional["InitiativeEffect"] = None,
         allow_caster_ieffects: bool = True,
         allow_target_ieffects: bool = True,
+        from_button: bool = False,
     ) -> AutomationResult:
         """
         Runs automation.
@@ -77,6 +78,7 @@ class Automation:
                                       -d, adv, magical, etc) are considered during execution.
         :param allow_target_ieffects: Whether effects granted by ieffects on a target (usually defensive like
                                       -sb, sadv, -ac, -resist, etc) are considered during execution.
+        :param from_button: Whether this automation is being run from a button or not
         """
         if not targets:
             targets = []
@@ -97,6 +99,7 @@ class Automation:
             ieffect=ieffect,
             allow_caster_ieffects=allow_caster_ieffects,
             allow_target_ieffects=allow_target_ieffects,
+            from_button=from_button,
         )
 
         automation_results = []


### PR DESCRIPTION
### Summary
When adding support for ieffect granted attacks to use the ieffect metavar, I missed a spot where I needed to add `from_button`, which caused all buttons to break.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
