### PR TITLE
Jokeen/2022w23

### DIFF
--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -18,6 +18,7 @@ class AliasContext:
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with
+        self._message = ctx.message.id
 
     @property
     def guild(self):
@@ -69,10 +70,22 @@ class AliasContext:
         """
         return self._alias
 
+    @property
+    def message(self):
+        """
+        The ID of the message the alias was invoked with.
+
+        >>> !test {{ctx.message}}
+        982495360129847306
+
+        :rtype: int
+        """
+        return self._message
+
     def __repr__(self):
         return (
             f"<{self.__class__.__name__} guild={self.guild!r} channel={self.channel!r} author={self.author!r} "
-            f"prefix={self.prefix!r} alias={self.alias!r}>"
+            f"prefix={self.prefix!r} alias={self.alias!r} message={self.message!r}>"
         )
 
 

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -18,7 +18,7 @@ class AliasContext:
         self._author = AliasAuthor(ctx.author)
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with
-        self._message = ctx.message.id
+        self._message_id = ctx.message.id
 
     @property
     def guild(self):
@@ -71,16 +71,16 @@ class AliasContext:
         return self._alias
 
     @property
-    def message(self):
+    def message_id(self):
         """
         The ID of the message the alias was invoked with.
 
-        >>> !test {{ctx.message}}
+        >>> !test {{ctx.message_id}}
         982495360129847306
 
         :rtype: int
         """
-        return self._message
+        return self._message_id
 
     def __repr__(self):
         return (

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -85,7 +85,7 @@ class AliasContext:
     def __repr__(self):
         return (
             f"<{self.__class__.__name__} guild={self.guild!r} channel={self.channel!r} author={self.author!r} "
-            f"prefix={self.prefix!r} alias={self.alias!r} message={self.message!r}>"
+            f"prefix={self.prefix!r} alias={self.alias!r} message={self.message_id!r}>"
         )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,7 @@ import pytest
 from cogs5e.initiative import Combat
 from cogs5e.models.character import Character
 from gamedata.compendium import compendium
-from tests.setup import DEFAULT_USER_ID, TEST_CHANNEL_ID, TEST_GUILD_ID
+from tests.setup import DEFAULT_USER_ID, TEST_CHANNEL_ID, TEST_GUILD_ID, MESSAGE_ID
 from utils.settings import ServerSettings
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -131,4 +131,4 @@ class ContextBotProxy:
 
 class MessageProxy:
     def __init__(self):
-        self.id = 112358132134
+        self.id = MESSAGE_ID

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -114,6 +114,7 @@ class ContextBotProxy:
         # to make draconic tests work
         self.prefix = "!"
         self.invoked_with = "foo"
+        self.message = MessageProxy()
 
     @property
     def channel(self):
@@ -126,3 +127,8 @@ class ContextBotProxy:
     @property
     def author(self):
         return self.guild.get_member(int(DEFAULT_USER_ID))
+
+
+class MessageProxy:
+    def __init__(self):
+        self.id = 112358132134

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -131,4 +131,4 @@ class ContextBotProxy:
 
 class MessageProxy:
     def __init__(self):
-        self.id = MESSAGE_ID
+        self.id = int(MESSAGE_ID)

--- a/tests/utiltests/reconcile_adv_test.py
+++ b/tests/utiltests/reconcile_adv_test.py
@@ -1,0 +1,28 @@
+from utils.enums import AdvantageType
+from utils.functions import reconcile_adv
+
+
+def test_reconcile_adv():
+    """
+    8 cases: (adv, dis, ea)
+
+    a d e | out
+    =======+====
+    0 0 0 | 0
+    1 0 0 | 1
+    1 1 0 | 0
+    1 1 1 | 0
+    1 0 1 | 2
+    0 1 0 | -1
+    0 1 1 | 0
+    0 0 1 | 2
+
+    """
+    assert reconcile_adv(adv=False, dis=False, eadv=False) == AdvantageType.NONE
+    assert reconcile_adv(adv=True, dis=False, eadv=False) == AdvantageType.ADV
+    assert reconcile_adv(adv=True, dis=True, eadv=False) == AdvantageType.NONE
+    assert reconcile_adv(adv=True, dis=True, eadv=True) == AdvantageType.NONE
+    assert reconcile_adv(adv=True, dis=False, eadv=True) == AdvantageType.ELVEN
+    assert reconcile_adv(adv=False, dis=True, eadv=False) == AdvantageType.DIS
+    assert reconcile_adv(adv=False, dis=True, eadv=True) == AdvantageType.NONE
+    assert reconcile_adv(adv=False, dis=False, eadv=True) == AdvantageType.ELVEN

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -490,7 +490,7 @@ def reconcile_adv(adv=False, dis=False, eadv=False) -> enums.AdvantageType:
     :return: The combined advantage result
     """
     result = 0
-    if adv:
+    if adv or eadv:
         result += 1
     if dis:
         result += -1


### PR DESCRIPTION
### Summary
Implements AFR-953 - Adds `ctx.message_id` to Draconic to give access to the ID of the issuing command message.
Fixes #1803 - Fixes an edge case where the user had `dis` and `eadv` args, where it would apply disadvantage.
Adds unit tests for reconcile_adv()

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
