### PR TITLE
Revert "chore: use weakdict for combat/char memcache"

### DIFF
--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -1,8 +1,8 @@
 import asyncio
-import weakref
 from functools import cached_property
 from typing import List, Literal, Optional, TYPE_CHECKING, Tuple, Union, overload
 
+import cachetools
 import disnake
 from d20 import roll
 from pydantic import BaseModel
@@ -32,11 +32,12 @@ class CombatOptions(BaseModel):
 
 
 class Combat:
+    # we cache up to 500 combats in memory for a short period
     # this makes sure that multiple calls to Combat.from_ctx() in the same invocation or two simultaneous ones
     # retrieve/modify the same Combat state
     # caches based on channel id
     # probably won't encounter any scaling issues, since a combat will be shard-specific
-    _cache: weakref.WeakValueDictionary[str, "Combat"] = weakref.WeakValueDictionary()
+    _cache: cachetools.TTLCache[str, "Combat"] = cachetools.TTLCache(maxsize=500, ttl=10)
 
     def __init__(
         self,


### PR DESCRIPTION
This reverts commit bf2505f9ea395ec972dece6d1a7fc876b1bff8b4, fixing the character shard desync issue that cropped up over the weekend.
