### PR TITLE
Target which effect to remove with remove_ieffect

### DIFF
--- a/cogs5e/models/automation/effects/remove_ieffect.py
+++ b/cogs5e/models/automation/effects/remove_ieffect.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING
 
+import aliasing.api.combat
+from cogs5e.models.errors import InvalidArgument
 from . import Effect
+from .ieffect import IEffectMetaVar
 from ..errors import AutomationException
 from ..results import RemoveIEffectResult
 
@@ -10,31 +13,48 @@ if TYPE_CHECKING:
 
 
 class RemoveIEffect(Effect):
-    def __init__(self, removeParent: str = None, **kwargs):
+    def __init__(self, removeParent: str = None, target: str = None, **kwargs):
         super().__init__("remove_ieffect", **kwargs)
         self.remove_parent = removeParent
+        self.target = target
 
     def to_dict(self):
         out = super().to_dict()
         if self.remove_parent is not None:
             out["removeParent"] = self.remove_parent
+        if self.target is not None:
+            out["target"] = self.target
         return out
 
     def run(self, autoctx: "AutomationContext"):
         super().run(autoctx)
-        if autoctx.ieffect is None:
+        ieffect = None
+        if self.target:
+            ieffect_ref = autoctx.metavars.get(self.target, None)
+            if not isinstance(ieffect_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                raise InvalidArgument(
+                    f"Could not set IEffect target: The variable `{self.target}` is not an IEffectMetaVar "
+                    f"(got `{type(ieffect_ref).__name__}`)."
+                )
+
+            # noinspection PyProtectedMember
+            ieffect = ieffect_ref._effect
+            autoctx.queue(f"**Cancelled Effect**: {ieffect.name} on {ieffect.combatant.name}")
+        elif (ieffect := autoctx.ieffect) is None:
             raise AutomationException("Tried to remove an IEffect without an active IEffect context!")
+        else:
+            autoctx.meta_queue(f"**Removed Effect**: {ieffect.name}")
 
         # remove the effect
-        autoctx.ieffect.remove()
-        autoctx.meta_queue(f"**Removed Effect**: {autoctx.ieffect.name}")
-
-        # remove parent, if applicable
         removed_parent = None
-        if self.remove_parent is not None and (parent_effect := autoctx.ieffect.get_parent_effect()) is not None:
-            removed_parent = self.run_remove_parent(autoctx, parent_effect)
+        if ieffect:
+            ieffect.remove()
 
-        return RemoveIEffectResult(removed_effect=autoctx.ieffect, removed_parent=removed_parent)
+            # remove parent, if applicable
+            if self.remove_parent is not None and (parent_effect := ieffect.get_parent_effect()) is not None:
+                removed_parent = self.run_remove_parent(autoctx, parent_effect)
+
+        return RemoveIEffectResult(removed_effect=ieffect, removed_parent=removed_parent)
 
     def run_remove_parent(self, autoctx: "AutomationContext", parent_effect: "InitiativeEffect"):
         do_remove = self.remove_parent == "always" or (
@@ -47,5 +67,5 @@ class RemoveIEffect(Effect):
 
     def build_str(self, caster, evaluator):
         super().build_str(caster, evaluator)
-        # this should never display since IEffect button automation is never stringified
-        return "Removes triggering effect"
+        # this should only display when a target is used since IEffect button automation is never stringified
+        return "Removes targeted effect"

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -619,10 +619,11 @@ Remove IEffect
     {
         type: "remove_ieffect";
         removeParent?: "always" | "if_no_children";
+        target?: string;
     }
 
-Removes the initiative effect that triggered this automation.
-Only works when run in execution triggered by an initiative effect, such as a ButtonInteraction
+Removes the targeted initiative effect or the initiative effect that triggered this automation.
+If target is not supplied, only works when run in execution triggered by an initiative effect, such as a ButtonInteraction
 (see :ref:`buttoninteraction`).
 
 .. class:: RemoveIEffect
@@ -635,6 +636,12 @@ Only works when run in execution triggered by an initiative effect, such as a Bu
         - ``"always"`` - If the removed effect has a parent, remove it too.
         - ``"if_no_children"`` - If the removed effect has a parent and its only remaining child was the removed effect,
           remove it too.
+          
+    .. attribute:: target
+
+        *optional, default None* - If supplied, will try to remove the given effect instead of the interaction effect. This must be the
+        name of an existing :class:`IEffectMetaVar`. If ``target`` is supplied, the target must be a valid :class:`IEffectMetaVar` or
+        an error will be displayed.
 
 **Variables**
 


### PR DESCRIPTION
### Summary
Solves AFR-955, requires PR avrae/automation-common#1

Adds the ability to specify a IEffectMetaVar name to target when removing an ieffect with the remove_ieffect effect.
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
