### PR TITLE
Jokeen/2022w25

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -98,7 +98,7 @@ class Attack(Effect):
             nocrit = nocrit or autoctx.target.character.options.ignore_crit
 
         # ==== execution ====
-        attack_bonus = autoctx.ab_override or autoctx.caster.spellbook.sab
+        attack_bonus = autoctx.ab_override if autoctx.ab_override is not None else autoctx.caster.spellbook.sab
 
         # explicit bonus
         if self.bonus:

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -60,7 +60,12 @@ class Save(Effect):
                 raise AutomationException(f"{self.dc!r} cannot be interpreted as a DC.")
 
         # dc hierarchy: arg > self.dc > spell cast override > spellbook dc
-        dc = dc_override or autoctx.dc_override or autoctx.caster.spellbook.dc
+        dc = autoctx.caster.spellbook.dc
+        if dc_override:
+            dc = dc_override
+        elif autoctx.dc_override is not None:
+            dc = autoctx.dc_override
+
         if "dc" in autoctx.args:
             dc = maybe_mod(autoctx.args.last("dc"), dc)
 

--- a/cogs5e/models/automation/effects/target.py
+++ b/cogs5e/models/automation/effects/target.py
@@ -154,6 +154,7 @@ class Target(Effect):
 
         # #1335
         autoctx.metavars["targetIteration"] = 1
+        autoctx.metavars["targetIterations"] = rr
 
         # 2 binary attributes: (rr?, target?)
         # each case must end with a push_embed_field()

--- a/cogs5e/models/automation/effects/usecounter.py
+++ b/cogs5e/models/automation/effects/usecounter.py
@@ -120,8 +120,9 @@ class UseCounter(Effect):
         autoctx.spell_level_override = level
 
         # queue resource usage in own field
-        overflow_str = f"\n({overflow} overflow)" if overflow else ""
-        autoctx.postflight_queue_field(name="Spell Slots", value=f"{slots_str} ({delta:+}){overflow_str}")
+        if amount:
+            overflow_str = f"\n({overflow} overflow)" if overflow else ""
+            autoctx.postflight_queue_field(name="Spell Slots", value=f"{slots_str} ({delta:+}){overflow_str}")
 
         return UseCounterResult(
             counter_name=str(level),
@@ -141,8 +142,9 @@ class UseCounter(Effect):
         overflow = abs(final_value - target_value)
 
         # queue resource usage in own field
-        overflow_str = f"\n({overflow} overflow)" if overflow else ""
-        autoctx.postflight_queue_field(name=counter.name, value=f"{str(counter)} ({delta:+}){overflow_str}")
+        if amount:
+            overflow_str = f"\n({overflow} overflow)" if overflow else ""
+            autoctx.postflight_queue_field(name=counter.name, value=f"{str(counter)} ({delta:+}){overflow_str}")
 
         return UseCounterResult(
             counter_name=counter.name, counter_remaining=final_value, used_amount=-delta, requested_amount=amount

--- a/cogs5e/models/automation/effects/usecounter.py
+++ b/cogs5e/models/automation/effects/usecounter.py
@@ -120,8 +120,9 @@ class UseCounter(Effect):
         autoctx.spell_level_override = level
 
         # queue resource usage in own field
+        delta_str = f"({delta:+})" if delta else ""
         overflow_str = f"\n({overflow} overflow)" if overflow else ""
-        autoctx.postflight_queue_field(name="Spell Slots", value=f"{slots_str} ({delta:+}){overflow_str}")
+        autoctx.postflight_queue_field(name="Spell Slots", value=f"{slots_str} {delta_str}{overflow_str}")
 
         return UseCounterResult(
             counter_name=str(level),
@@ -141,8 +142,9 @@ class UseCounter(Effect):
         overflow = abs(final_value - target_value)
 
         # queue resource usage in own field
+        delta_str = f"({delta:+})" if delta else ""
         overflow_str = f"\n({overflow} overflow)" if overflow else ""
-        autoctx.postflight_queue_field(name=counter.name, value=f"{str(counter)} ({delta:+}){overflow_str}")
+        autoctx.postflight_queue_field(name=counter.name, value=f"{str(counter)} {delta_str}{overflow_str}")
 
         return UseCounterResult(
             counter_name=counter.name, counter_remaining=final_value, used_amount=-delta, requested_amount=amount

--- a/cogs5e/models/automation/effects/usecounter.py
+++ b/cogs5e/models/automation/effects/usecounter.py
@@ -120,9 +120,8 @@ class UseCounter(Effect):
         autoctx.spell_level_override = level
 
         # queue resource usage in own field
-        if amount:
-            overflow_str = f"\n({overflow} overflow)" if overflow else ""
-            autoctx.postflight_queue_field(name="Spell Slots", value=f"{slots_str} ({delta:+}){overflow_str}")
+        overflow_str = f"\n({overflow} overflow)" if overflow else ""
+        autoctx.postflight_queue_field(name="Spell Slots", value=f"{slots_str} ({delta:+}){overflow_str}")
 
         return UseCounterResult(
             counter_name=str(level),
@@ -142,9 +141,8 @@ class UseCounter(Effect):
         overflow = abs(final_value - target_value)
 
         # queue resource usage in own field
-        if amount:
-            overflow_str = f"\n({overflow} overflow)" if overflow else ""
-            autoctx.postflight_queue_field(name=counter.name, value=f"{str(counter)} ({delta:+}){overflow_str}")
+        overflow_str = f"\n({overflow} overflow)" if overflow else ""
+        autoctx.postflight_queue_field(name=counter.name, value=f"{str(counter)} ({delta:+}){overflow_str}")
 
         return UseCounterResult(
             counter_name=counter.name, counter_remaining=final_value, used_amount=-delta, requested_amount=amount

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -69,6 +69,9 @@ class AutomationContext:
         self.spell_level_override = spell_level_override  # used in Cast Spell effect
         self.conc_effect = conc_effect
 
+        self.metavars["spell_attack_bonus"] = self.ab_override or self.caster.spellbook.sab
+        self.metavars["spell_dc"] = self.dc_override or self.caster.spellbook.dc
+
         # InitiativeEffect utils
         self.ieffect = ieffect
         if ieffect is not None:

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -38,6 +38,8 @@ All Automation runs provide the following variables:
   automation.
 - ``targets`` (list of :class:`~aliasing.api.statblock.AliasStatBlock`, :class:`str`, or None) A list of combatants
   targeted by this automation (i.e. the ``-t`` argument).
+- ``spell_attack_bonus`` (:class:`int` or None) - The attack bonus for the spell, or the caster's default attack bonus.
+- ``spell_dc`` (:class:`int` or None) - The DC for the spell, or the caster's default DC.
 
 Additionally, runs triggered by an initiative effect (such as automation provided in a :ref:`ButtonInteraction`) provide
 the following variables:

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -89,6 +89,7 @@ It designates what creatures to affect.
 
 - ``target`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The current target.
 - ``targetIteration`` (:class:`int`) If running multiple iterations (i.e. ``-rr``), the current iteration (1-indexed).
+- ``targetIterations`` (:class:`int`) The total number of iterations. Minimum 1, maximum 25.
 - ``targetIndex`` (:class:`int`) The index of the target in the list of targets processed by this effect
   (0-indexed - first target = ``0``, second = ``1``, etc.). Self targets, nth-targets, and parent targets will always
   be ``0``.


### PR DESCRIPTION
### Summary

- Hide counter delta if delta is 0 in automation
- Adds the ``targetIterations``, ``spell_attack_bonus``, and ``spell_dc`` metavars to automation
- Fixed an edge case for having a 0 SAB/DC on a spell override and a default DC
- - Resolves https://github.com/avrae/avrae/issues/1764 with https://github.com/avrae/avrae-character-lambda/pull/7

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
