### PR TITLE
Add imports to aliasing

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -7,6 +7,7 @@ import time
 from collections import namedtuple
 from functools import cached_property
 from math import ceil, floor, sqrt
+from types import SimpleNamespace
 from typing import Optional, Union
 
 import d20
@@ -171,13 +172,14 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
             ctx=AliasContext(ctx),
             signature=self.signature,
             verify_signature=self.verify_signature,
+            using=self.using,
         )
 
         # roll limiting
         self._roller = d20.Roller(context=PersistentRollContext(max_rolls=1_000, max_total_rolls=10_000))
         self.builtins.update(vroll=self._limited_vroll, roll=self._limited_roll)
 
-        self._cache = {"gvars": {}, "svars": {}, "uvars": {}}
+        self._cache = {"gvars": {}, "svars": {}, "uvars": {}, "imports": {}}
 
         self.ctx = ctx
         self.character_changed = False
@@ -781,6 +783,43 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         """
         data = str(data)
         return verify_signature(self.ctx, data)
+
+    def using(self, **imports):
+        """
+        Imports Draconic global variables as modules in the current namespace. See :ref:`using-imports` for details.
+
+        >>> using(
+        ...     hello="50943a96-381b-427e-adb9-eea8ebf61f27"
+        ... )
+        >>> hello.hello()
+        "Hello world!"
+        """
+        user_ns = self._names
+        for ns, addr in imports.items():
+            self._import_one(ns, str(addr), user_ns)
+        self._names = user_ns
+
+    def _import_one(self, name: str, addr: str, user_ns: dict):
+        """Import the module at the gvar address *addr* into the *user_ns* under the name *name*"""
+        # get the module contents
+        mod_contents = self.get_gvar(addr)
+        if mod_contents is None:
+            raise ModuleNotFoundError(f"No gvar named {addr!r}")
+
+        try:
+            # if the module is in cache, return the ns from cache
+            mod_ns = self._cache["imports"][addr]
+        except KeyError:
+            # create a new ns and run the gvar
+            self._names = {}
+            self.execute_module(mod_contents, module_name=addr)
+            mod_ns = SimpleNamespace(**self._names)
+            self._cache["imports"][addr] = mod_ns
+
+        # bind to user's global ns
+        if name in self.builtins:
+            raise ValueError(f"{name} is already builtin (no shadow assignments).")
+        user_ns[name] = mod_ns
 
     # ==== warnings ====
     def _eval(self, node):

--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -791,6 +791,13 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         """
         Imports Draconic global variables as modules in the current namespace. See :ref:`using-imports` for details.
 
+        Usually this should be the first statement in a code block if imports are used.
+
+        .. warning::
+
+            Only import modules from trusted sources! The entire contents of an imported module is executed once upon
+            import, and can do bad things like delete all of your variables.
+
         >>> using(
         ...     hello="50943a96-381b-427e-adb9-eea8ebf61f27"
         ... )

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -910,6 +910,8 @@ Draconic's syntax is very similar to Python. Other Python features supported in 
 * `Operators <https://docs.python.org/3/reference/expressions.html#unary-arithmetic-and-bitwise-operations>`_ (``2 + 2``, ``"foo" in "foobar"``, etc)
 * `Assignments <https://docs.python.org/3/reference/simple_stmts.html#assignment-statements>`_ (``a = 15``)
 * `List Comprehensions <https://docs.python.org/3/tutorial/datastructures.html#list-comprehensions>`_
+* `Functions <https://docs.python.org/3/tutorial/controlflow.html#defining-functions>`_
+* `Lambda Expressions <https://docs.python.org/3/tutorial/controlflow.html#lambda-expressions>`_
 
 Initiative Models
 -----------------

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -442,10 +442,6 @@ Draconic Functions
 
 .. autofunction:: aliasing.evaluators.ScriptingEvaluator.get_svar(name)
 
-.. autofunction:: aliasing.evaluators.ScriptingEvaluator.load_json
-
-.. autofunction:: aliasing.evaluators.ScriptingEvaluator.load_yaml
-
 .. function:: randint(stop)
               randint(start, stop[, step])
 
@@ -504,6 +500,8 @@ Draconic Functions
 .. autofunction:: aliasing.evaluators.ScriptingEvaluator.verify_signature(data)
 
 .. autofunction:: aliasing.api.functions.typeof
+
+.. autofunction:: aliasing.evaluators.ScriptingEvaluator.using
 
 .. autofunction:: aliasing.evaluators.ScriptingEvaluator.uvar_exists(name)
 
@@ -899,6 +897,87 @@ an alias' metadata on each combatant).
 
 Metadata can be created, retrieved, and deleted using the :meth:`.SimpleCombat.set_metadata`,
 :meth:`.SimpleCombat.get_metadata`, and :meth:`.SimpleCombat.delete_metadata` methods, respectively.
+
+.. _using-imports:
+
+Using Imports
+-------------
+
+Imports are a way for alias authors to share common code across multiple aliases, provide common libraries of code for
+other authors to write code compatible with your alias, and more!
+
+If you already have the address of a module to import, use :meth:`~aliasing.evaluators.ScriptingEvaluator.using` at the
+top of your code block in order to import the module into your namespace. For example:
+
+.. code-block:: text
+
+    !alias hello-world echo <drac2>
+    using(
+        hello="50943a96-381b-427e-adb9-eea8ebf61f27"
+    )
+    return hello.hello()
+    </drac2>
+
+Use ``!gvar 50943a96-381b-427e-adb9-eea8ebf61f27`` to take a peek at the ``hello`` module!
+
+You can also import multiple modules in the same expression:
+
+.. code-block:: text
+
+    !alias hello-world echo <drac2>
+    using(
+        hello="50943a96-381b-427e-adb9-eea8ebf61f27",
+        hello_utils="0bbddb9f-c86f-4af8-9e04-1964425b1554"
+    )
+    return f"{hello.hello('you')}\n{hello_utils.hello_to_my_character()}"
+    </drac2>
+
+The ``hello_utils`` module (``!gvar 0bbddb9f-c86f-4af8-9e04-1964425b1554``) also demonstrates how modules can import
+other modules!
+
+Each imported module is bound to a namespace that contains each of the names (constants, functions, etc) defined in the
+module. For example, the ``hello`` module (``50943a96-381b-427e-adb9-eea8ebf61f27``) defines the ``HELLO_WORLD``
+constant and ``hello()`` function, so a consumer could access these with ``hello.HELLO_WORLD`` and ``hello.hello()``,
+respectively.
+
+.. warning::
+
+    Only import modules from trusted sources! The entire contents of an imported module is executed once upon
+    import, and can do bad things like delete all of your variables.
+
+    All gvar modules are open-source by default, so it is encouraged to view the imported module using ``!gvar``.
+
+Writing Modules
+^^^^^^^^^^^^^^^
+
+Modules are easy to publish and update! Simply create a gvar that contains valid Draconic code (**without** wrapping it
+in any delimiters such as ``<drac2>``).
+
+We encourage modules to follow the following format to make them easy to read:
+
+.. code-block:: python
+
+    # recommended_module_name
+    # This is a short description about what the module does.
+    #
+    # SOME_CONSTANT: some documentation about what this constant is
+    # some_function(show, the, args): some short documentation about what this function does
+    #     and how to call it
+    #     wow, this is long! use indentation if you need multiple lines
+    #     but otherwise longer documentation should go in the function's """docstring"""
+
+    SOME_CONSTANT = 3.141592
+
+    def some_function(show, the, args):
+        """Here is where the longer documentation about the function can go."""
+        pass
+
+Use ``!gvar 50943a96-381b-427e-adb9-eea8ebf61f27`` and ``!gvar 0bbddb9f-c86f-4af8-9e04-1964425b1554`` to view
+the ``hello`` and ``hello_utils`` example modules used above for an example!
+
+.. note::
+
+    Because all gvars are public to anyone who knows the address, modules are open-source by default.
 
 See Also
 --------


### PR DESCRIPTION
### Summary
Allows aliases/snippets to import modules defined in gvars using the new `using()` function.

Adds documentation on imports and module-writing.

Depends on https://github.com/avrae/draconic/pull/17

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
