### PR TITLE
build: yet another attempt to approve 3pp gamedata prs

### DIFF
--- a/.github/workflows/approve-gamedata-test.yml
+++ b/.github/workflows/approve-gamedata-test.yml
@@ -1,0 +1,21 @@
+# If someone with write access comments "/ci-approve" on a pull request, emit a repository_dispatch event
+name: Approve 3rd Party PR Privileged Tests
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    # Only run for PRs, not issue comments
+    if: ${{ github.event.issue.pull_request }}
+    steps:
+      - name: Dispatch Command
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          token: ${{ secrets.ORG_REPO_ACCESS_TOKEN }}
+          commands: |
+            ci-approve
+          issue-type: pull-request
+          permission: write

--- a/.github/workflows/test-data.yml
+++ b/.github/workflows/test-data.yml
@@ -3,11 +3,8 @@ name: Test Gamedata
 on:
   push:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - labeled  # to approve 3pp PRs, add a label to the PR (like ci: approved)
+  repository_dispatch:
+    types: [ ci-approve-command ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,8 +87,8 @@ Gamedata tests run simulations on every official automation document in order to
 the Automation Engine. Generally, these are added by writing more official automation, rather than gamedata tests.
 
 As these tests operate on non-SRD data, care must be taken not to expose the underlying data in the tests. For PRs
-opened by outside contributors, a project maintainer must approve the gamedata test workflow by adding the `ci: approve`
-label to the PR. Maintainers may need to remove and re-add the label to rerun the PR after PR updates.
+opened by outside contributors, a project maintainer must approve the gamedata test workflow by commenting 
+`/ci-approve` on the PR.
 
 ### Fixtures
 


### PR DESCRIPTION
### Summary
It's really difficult to get GH to set secrets on a 3rd party PR (for good reason!). This updates the build so that a comment `/ci-approve` from a contributor with with write access on a PR triggers the gamedata test suite via a repository dispatch.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
