### PR TITLE
refactor: utility wrappers for feature flags

### DIFF
--- a/cogs5e/dice/inline.py
+++ b/cogs5e/dice/inline.py
@@ -8,7 +8,6 @@ import utils.settings
 from cogs5e.models import embeds
 from cogs5e.models.errors import AvraeException, InvalidArgument, NoCharacter
 from utils import constants
-from utils.aldclient import discord_user_to_dict
 from utils.dice import PersistentRollContext
 from utils.functions import camel_to_title, verbose_stat
 from .utils import string_search_adv
@@ -29,8 +28,8 @@ class InlineRoller:
             return
 
         # inline rolling feature flag
-        if not await self.bot.ldclient.variation(
-            "cog.dice.inline_rolling.enabled", user=discord_user_to_dict(message.author), default=False
+        if not await self.bot.ldclient.variation_for_discord_user(
+            "cog.dice.inline_rolling.enabled", user=message.author, default=False
         ):
             return
 
@@ -72,8 +71,8 @@ class InlineRoller:
             return
 
         # inline rolling feature flag
-        if not await self.bot.ldclient.variation(
-            "cog.dice.inline_rolling.enabled", user=discord_user_to_dict(message.author), default=False
+        if not await self.bot.ldclient.variation_for_discord_user(
+            "cog.dice.inline_rolling.enabled", user=message.author, default=False
         ):
             return
 

--- a/cogs5e/gamelog/cog.py
+++ b/cogs5e/gamelog/cog.py
@@ -186,7 +186,9 @@ class GameLog(commands.Cog):
         if ddb_user is None:
             return campaign_id, None
         # and they must be allowed to use game log send by feature flag
-        flag = await self.bot.ldclient.variation("cog.gamelog.roll_send.enabled", ddb_user.to_ld_dict(), False)
+        flag = await self.bot.ldclient.variation_for_ddb_user(
+            "cog.gamelog.roll_send.enabled", ddb_user, False, discord_id=ctx.author.id
+        )
         if not flag:
             return campaign_id, None
         return campaign_id, ddb_user

--- a/cogs5e/models/ddbsync.py
+++ b/cogs5e/models/ddbsync.py
@@ -106,8 +106,8 @@ class DDBSheetSync(LiveIntegration):
         self._ddb_user = ddb_user
         if ddb_user is None:
             return
-        flag = await ctx.bot.ldclient.variation(
-            "cog.sheetmanager.sync.send.enabled", ddb_user.to_ld_dict(), default=False
+        flag = await ctx.bot.ldclient.variation_for_ddb_user(
+            "cog.sheetmanager.sync.send.enabled", ddb_user, default=False, discord_id=ctx.author.id
         )
         if not flag:
             return

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -749,11 +749,9 @@ class SheetManager(commands.Cog):
 async def send_ddb_ctas(ctx, character):
     """Sends relevant CTAs after a DDB character is imported. Only show a CTA 1/24h to not spam people."""
     ddb_user = await ctx.bot.ddb.get_ddb_user(ctx, ctx.author.id)
-    if ddb_user is not None:
-        ld_dict = ddb_user.to_ld_dict()
-    else:
-        ld_dict = {"key": str(ctx.author.id), "anonymous": True}
-    gamelog_flag = await ctx.bot.ldclient.variation("cog.gamelog.cta.enabled", ld_dict, False)
+    gamelog_flag = await ctx.bot.ldclient.variation_for_ddb_user(
+        "cog.gamelog.cta.enabled", ddb_user, False, discord_id=ctx.author.id
+    )
 
     # get server settings for whether to pull up campaign settings
     if ctx.guild is not None:

--- a/cogsmisc/core.py
+++ b/cogsmisc/core.py
@@ -188,7 +188,9 @@ class Core(commands.Cog):
             f"on D&D Beyond are available in Avrae."
         )
 
-        desc = await self.bot.ldclient.variation("command.ddb.desc", ddb_user.to_ld_dict(), default_desc)
+        desc = await self.bot.ldclient.variation_for_ddb_user(
+            "command.ddb.desc", ddb_user, default_desc, discord_id=ctx.author.id
+        )
         embed.description = desc
 
         if ddb_user.is_staff:

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -9,7 +9,6 @@ from disnake.ext import commands
 
 from cogs5e.models.embeds import EmbedWithAuthor
 from utils import checks, config
-from utils.aldclient import discord_user_to_dict
 from utils.functions import confirm, get_guild_member, search_and_select
 from .ddblink import DDBLink
 from .init_dm import DMInitiative
@@ -159,8 +158,8 @@ class Tutorials(commands.Cog):
         if to_user is None:
             return
 
-        flag_on = await self.bot.ldclient.variation(
-            "cog.tutorials.guild_join.enabled", discord_user_to_dict(to_user), default=False
+        flag_on = await self.bot.ldclient.variation_for_discord_user(
+            "cog.tutorials.guild_join.enabled", to_user, default=False
         )
         if not flag_on:
             return

--- a/dbot.py
+++ b/dbot.py
@@ -25,7 +25,7 @@ from ddb.gamelog import GameLogClient
 from gamedata.compendium import compendium
 from gamedata.lookuputils import handle_required_license
 from utils import clustering, config, context
-from utils.aldclient import AsyncLaunchDarklyClient
+from utils.feature_flags import AsyncLaunchDarklyClient
 from utils.help import help_command
 from utils.redisIO import RedisIO
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -183,5 +183,10 @@ class MockAsyncLaunchDarklyClient:
     async def variation(self, key, user, default):
         return self.flag_store.get(key, default)
 
+    variation_for_discord_user = variation
+
+    async def variation_for_ddb_user(self, key, user, default, *__, **___):
+        return await self.variation(key, user, default)
+
     def close(self):
         pass

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -48,15 +48,11 @@ class CharacterSettingsMenuBase(MenuBase, abc.ABC):
         # ddb sheets: if either of the flags are enabled
         elif self.character.sheet_type == "beyond":
             ddb_user = await self.bot.ddb.get_ddb_user(self, self.owner.id)
-            if ddb_user is None:
-                ddb_user_ld = {"key": str(self.owner.id), "anonymous": True}
-            else:
-                ddb_user_ld = ddb_user.to_ld_dict()
-            outbound_flag = await self.bot.ldclient.variation(
-                "cog.sheetmanager.sync.send.enabled", ddb_user_ld, default=False
+            outbound_flag = await self.bot.ldclient.variation_for_ddb_user(
+                "cog.sheetmanager.sync.send.enabled", ddb_user, default=False, discord_id=self.owner.id
             )
-            inbound_flag = await self.bot.ldclient.variation(
-                "cog.gamelog.character-update-fulfilled.enabled", ddb_user_ld, default=False
+            inbound_flag = await self.bot.ldclient.variation_for_ddb_user(
+                "cog.gamelog.character-update-fulfilled.enabled", ddb_user, default=False, discord_id=self.owner.id
             )
             self._can_do_character_sync = outbound_flag, inbound_flag
         else:

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -7,11 +7,10 @@ from typing import List, Optional, TYPE_CHECKING, TypeVar
 import d20
 import disnake
 
-from utils.aldclient import discord_user_to_dict
 from utils.constants import STAT_ABBREVIATIONS
 from utils.enums import CritDamageType
 from utils.functions import natural_join
-from utils.settings.guild import InlineRollingType, ServerSettings, RandcharRule, LegacyPreference
+from utils.settings.guild import InlineRollingType, LegacyPreference, RandcharRule, ServerSettings
 from .menu import MenuBase
 
 _AvraeT = TypeVar("_AvraeT", bound=disnake.Client)
@@ -34,8 +33,8 @@ class ServerSettingsMenuBase(MenuBase, abc.ABC):
         await self.settings.commit(self.bot.mdb)
 
     async def get_inline_rolling_desc(self) -> str:
-        flag_enabled = await self.bot.ldclient.variation(
-            "cog.dice.inline_rolling.enabled", user=discord_user_to_dict(self.owner), default=False
+        flag_enabled = await self.bot.ldclient.variation_for_discord_user(
+            "cog.dice.inline_rolling.enabled", user=self.owner, default=False
         )
         if not flag_enabled:
             return "Inline rolling is currently **globally disabled** for all users. Check back soon!"
@@ -113,8 +112,8 @@ class ServerSettingsUI(ServerSettingsMenuBase):
         )
 
         nlp_enabled_description = ""
-        nlp_feature_flag = await self.bot.ldclient.variation(
-            "cog.initiative.upenn_nlp.enabled", user=discord_user_to_dict(self.owner), default=False
+        nlp_feature_flag = await self.bot.ldclient.variation_for_discord_user(
+            "cog.initiative.upenn_nlp.enabled", user=self.owner, default=False
         )
         if nlp_feature_flag:
             nlp_enabled_description = f"\n**Contribute Message Data to NLP Training**: {self.settings.upenn_nlp_opt_in}"
@@ -400,8 +399,8 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
             self.toggle_upenn_nlp_opt_in: disnake.ui.Button
 
         # nlp feature flag
-        flag_enabled = await self.bot.ldclient.variation(
-            "cog.initiative.upenn_nlp.enabled", user=discord_user_to_dict(self.owner), default=False
+        flag_enabled = await self.bot.ldclient.variation_for_discord_user(
+            "cog.initiative.upenn_nlp.enabled", user=self.owner, default=False
         )
         if not flag_enabled:
             self.remove_item(self.toggle_upenn_nlp_opt_in)
@@ -437,8 +436,8 @@ class _MiscellaneousSettingsUI(ServerSettingsMenuBase):
             inline=False,
         )
 
-        nlp_feature_flag = await self.bot.ldclient.variation(
-            "cog.initiative.upenn_nlp.enabled", user=discord_user_to_dict(self.owner), default=False
+        nlp_feature_flag = await self.bot.ldclient.variation_for_discord_user(
+            "cog.initiative.upenn_nlp.enabled", user=self.owner, default=False
         )
         if nlp_feature_flag:
             embed.add_field(

--- a/utils/checks.py
+++ b/utils/checks.py
@@ -1,6 +1,5 @@
 from disnake.ext import commands
 
-from utils.aldclient import discord_user_to_dict
 from utils.functions import natural_join
 
 is_owner = commands.is_owner
@@ -54,14 +53,12 @@ def feature_flag(flag_name, use_ddb_user=False, default=False):
     async def predicate(ctx):
         if use_ddb_user:
             ddb_user = await ctx.bot.ddb.get_ddb_user(ctx, ctx.author.id)
-            if ddb_user is None:
-                user = {"key": str(ctx.author.id), "anonymous": True}
-            else:
-                user = ddb_user.to_ld_dict()
+            flag_on = await ctx.bot.ldclient.variation_for_ddb_user(
+                flag_name, user=ddb_user, default=default, discord_id=ctx.author.id
+            )
         else:
-            user = discord_user_to_dict(ctx.author)
+            flag_on = await ctx.bot.ldclient.variation_for_discord_user(flag_name, user=ctx.author, default=default)
 
-        flag_on = await ctx.bot.ldclient.variation(flag_name, user, default)
         if flag_on:
             return True
 

--- a/utils/feature_flags.py
+++ b/utils/feature_flags.py
@@ -1,7 +1,13 @@
 """
 Asyncio wrapper for launchdarkly client to ensure flag evaluation is not a blocking call.
 """
+from typing import Optional, TYPE_CHECKING
+
 import ldclient
+
+if TYPE_CHECKING:
+    import ddb.auth
+    import disnake
 
 
 class AsyncLaunchDarklyClient(ldclient.LDClient):
@@ -14,6 +20,18 @@ class AsyncLaunchDarklyClient(ldclient.LDClient):
 
     async def variation(self, key, user, default):  # run variation evaluation in a separate thread
         return await self.loop.run_in_executor(None, super().variation, key, user, default)
+
+    async def variation_for_discord_user(self, key: str, user: "disnake.User", default):
+        """Return a variation for a key given a discord user."""
+        return await self.variation(key, discord_user_to_dict(user), default)
+
+    async def variation_for_ddb_user(self, key: str, user: Optional["ddb.auth.BeyondUser"], default, discord_id: int):
+        """Return a variation for a key given a DDB user or None."""
+        if user is None:
+            user = {"key": str(discord_id), "anonymous": True}
+        else:
+            user = user.to_ld_dict()
+        return await self.variation(key, user, default)
 
 
 def discord_user_to_dict(user):


### PR DESCRIPTION
### Summary
Adds wrappers around `AsyncLaunchDarklyClient.variation` in order to make the two different methods for getting feature flag values for Discord/DDB users more consistent.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
