### PR TITLE
fix(aliasing): uvar cache is used instead of names

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -237,7 +237,7 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         :rtype: bool
         """
         name = str(name)
-        return self.exists(name) and name in self._cache["uvars"]
+        return name in self._cache["uvars"]
 
     def get_gvar(self, address):
         """
@@ -320,7 +320,7 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         :param str value: The value to set it to.
         """
         name = str(name)
-        if not name in self.names:
+        if not name in self._cache["uvars"]:
             self.set_uvar(name, value)
 
     def delete_uvar(self, name):


### PR DESCRIPTION
### Summary
Change `uvar_exists` and `set_uvar_nx` from using `names` to `_cache['uvars']`
Fixes #AVR-931

### Checklist
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
