### PR TITLE
Jokeen/2022w32

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1072,6 +1072,7 @@ class InitTracker(commands.Cog):
         return await self._attack_list(ctx, combatant, *args)
 
     @init.command(
+        name="offturnattack",
         aliases=["aoo", "offturnaction", "oa"],
         help=f"""
         Rolls an attack as another combatant.
@@ -1080,7 +1081,7 @@ class InitTracker(commands.Cog):
         -custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
         """,
     )
-    async def offturnattack(self, ctx, combatant_name, atk_name=None, *, args=""):
+    async def aoo(self, ctx, combatant_name, atk_name=None, *, args=""):
         combat = await ctx.get_combat()
         try:
             combatant = await combat.select_combatant(ctx, combatant_name, "Select the attacker.")
@@ -1292,6 +1293,7 @@ class InitTracker(commands.Cog):
         return await self._cast(ctx, None, spell_name, args)
 
     @init.command(
+        name="offturncast",
         aliases=["rc", "reactcast"],
         help=f"""
         Casts a spell as another combatant.
@@ -1301,7 +1303,7 @@ class InitTracker(commands.Cog):
         {VALID_AUTOMATION_ARGS}
         """,
     )
-    async def offturncast(self, ctx, combatant_name, spell_name, *, args=""):
+    async def reactcast(self, ctx, combatant_name, spell_name, *, args=""):
         return await self._cast(ctx, combatant_name, spell_name, args)
 
     async def _cast(self, ctx, combatant_name, spell_name, args):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1072,15 +1072,15 @@ class InitTracker(commands.Cog):
         return await self._attack_list(ctx, combatant, *args)
 
     @init.command(
-        aliases=["offturnattack", "offturnaction", "oa"],
+        aliases=["aoo", "offturnaction", "oa"],
         help=f"""
-        Rolls an attack against another combatant.
+        Rolls an attack as another combatant.
         __**Valid Arguments**__
         {VALID_AUTOMATION_ARGS}
         -custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
         """,
     )
-    async def aoo(self, ctx, combatant_name, atk_name=None, *, args=""):
+    async def offturnattack(self, ctx, combatant_name, atk_name=None, *, args=""):
         combat = await ctx.get_combat()
         try:
             combatant = await combat.select_combatant(ctx, combatant_name, "Select the attacker.")
@@ -1292,16 +1292,16 @@ class InitTracker(commands.Cog):
         return await self._cast(ctx, None, spell_name, args)
 
     @init.command(
-        aliases=["rc", "offturncast"],
+        aliases=["rc", "reactcast"],
         help=f"""
-        Casts a spell against another combatant.
+        Casts a spell as another combatant.
         __**Valid Arguments**__
         {VALID_SPELLCASTING_ARGS}
         
         {VALID_AUTOMATION_ARGS}
         """,
     )
-    async def reactcast(self, ctx, combatant_name, spell_name, *, args=""):
+    async def offturncast(self, ctx, combatant_name, spell_name, *, args=""):
         return await self._cast(ctx, combatant_name, spell_name, args)
 
     async def _cast(self, ctx, combatant_name, spell_name, args):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1072,12 +1072,13 @@ class InitTracker(commands.Cog):
         return await self._attack_list(ctx, combatant, *args)
 
     @init.command(
+        aliases=["offturnattack", "offturnaction", "oa"],
         help=f"""
         Rolls an attack against another combatant.
         __**Valid Arguments**__
         {VALID_AUTOMATION_ARGS}
         -custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
-        """
+        """,
     )
     async def aoo(self, ctx, combatant_name, atk_name=None, *, args=""):
         combat = await ctx.get_combat()
@@ -1291,7 +1292,7 @@ class InitTracker(commands.Cog):
         return await self._cast(ctx, None, spell_name, args)
 
     @init.command(
-        aliases=["rc"],
+        aliases=["rc", "offturncast"],
         help=f"""
         Casts a spell against another combatant.
         __**Valid Arguments**__

--- a/gamedata/spell.py
+++ b/gamedata/spell.py
@@ -87,6 +87,7 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
     def from_homebrew(cls, data, source):  # homebrew spells
         data["components"] = parse_homebrew_components(data["components"])
         data["range_"] = data.pop("range")
+        data["automation"] = data.get("automation")
         return cls(homebrew=True, source=source, **data).initialize_automation(data)
 
     def get_school(self):


### PR DESCRIPTION
### Summary
Ensures the automation key is always present for homebrew spells when initializing automation 
Adds additional aliases for `!i rc` and `!i aoo` to match other reaction based commands, and changed the default alias to group with the others. 

Resolves #1845 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
