### PR TITLE
fix(aliasing): allow load_yaml to load .inf

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -440,6 +440,7 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
                 yaml.composer.Composer.__init__(self)
                 DraconicConstructor.__init__(self)
                 yaml.resolver.Resolver.__init__(self)
+                self.inf_value = float('inf')
 
         return DraconicLoader
 

--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -440,7 +440,7 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
                 yaml.composer.Composer.__init__(self)
                 DraconicConstructor.__init__(self)
                 yaml.resolver.Resolver.__init__(self)
-                self.inf_value = float('inf')
+                self.inf_value = float("inf")
 
         return DraconicLoader
 


### PR DESCRIPTION
### Summary
A YAML Loader needs to have `inf_value` defined as a property in order to know what to load `.inf`. The only infinity we have available to use in Draconic is float infinity so I felt that DraconicLoader should have it be defined as such.

Currently the evaluator just errors when trying to load `.inf`.
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
