### PR TITLE
Jokeen/2022w35

### DIFF
--- a/cogs5e/dice/cog.py
+++ b/cogs5e/dice/cog.py
@@ -14,7 +14,7 @@ from gamedata.lookuputils import handle_source_footer, select_monster_full, sele
 from utils.argparser import argparse
 from utils.constants import SKILL_NAMES
 from utils.dice import PersistentRollContext, VerboseMDStringifier
-from utils.functions import search_and_select, try_delete
+from utils.functions import search_and_select, try_delete, camel_to_title
 from .inline import InlineRoller
 from .utils import string_search_adv
 
@@ -211,7 +211,7 @@ class Dice(commands.Cog):
         monster: Monster = await select_monster_full(ctx, monster_name)
         args = await helpers.parse_snippets(args, ctx, statblock=monster)
         args = argparse(args)
-        skill_key = await search_and_select(ctx, SKILL_NAMES, check, lambda s: s)
+        skill_key = await search_and_select(ctx, SKILL_NAMES, check, camel_to_title)
 
         embed = embed_for_monster(monster, args)
 

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -26,6 +26,7 @@ from utils.functions import (
     get_selection,
     search_and_select,
     try_delete,
+    camel_to_title,
 )
 from . import (
     Combat,
@@ -1218,7 +1219,7 @@ class InitTracker(commands.Cog):
         if isinstance(combatant, CombatantGroup):
             return await ctx.send("Groups cannot make checks.")
 
-        skill_key = await search_and_select(ctx, constants.SKILL_NAMES, check, lambda s: s)
+        skill_key = await search_and_select(ctx, constants.SKILL_NAMES, check, camel_to_title)
         embed = disnake.Embed(color=combatant.get_color())
 
         args = await helpers.parse_snippets(args, ctx)

--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -550,7 +550,8 @@ class Combat:
             return disnake.AllowedMentions.none()
         mentions = self.get_turn_str_mentions_for(self.current_combatant)
         if self.options.turnnotif and self.next_combatant is not None:
-            mentions.merge(self.get_turn_str_mentions_for(self.next_combatant))
+            next_combatant = self.get_turn_str_mentions_for(self.next_combatant)
+            mentions = mentions.merge(disnake.AllowedMentions(users=next_combatant.users + mentions.users))
         return mentions
 
     def get_turn_str_mentions_for(self, combatant) -> disnake.AllowedMentions:

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -70,7 +70,7 @@ class Roll(Effect):
         rolled = d20.roll(dice_ast)
         if not self.hidden:
             name_out = self.displayName
-            if name_out is None:
+            if not name_out:
                 name_out = self.name.title()
             autoctx.meta_queue(f"**{name_out}**: {rolled.result}")
 

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -12,7 +12,14 @@ from ..results import RollResult
 
 class Roll(Effect):
     def __init__(
-        self, dice: str, name: str, higher: dict = None, cantripScale: bool = None, hidden: bool = False, **kwargs
+        self,
+        dice: str,
+        name: str,
+        higher: dict = None,
+        cantripScale: bool = None,
+        hidden: bool = False,
+        displayName: str = None,
+        **kwargs,
     ):
         super().__init__("roll", **kwargs)
         self.dice = dice
@@ -20,6 +27,7 @@ class Roll(Effect):
         self.higher = higher
         self.cantripScale = cantripScale
         self.hidden = hidden
+        self.displayName = displayName
 
     def to_dict(self):
         out = super().to_dict()
@@ -61,7 +69,10 @@ class Roll(Effect):
 
         rolled = d20.roll(dice_ast)
         if not self.hidden:
-            autoctx.meta_queue(f"**{self.name.title()}**: {rolled.result}")
+            name_out = self.displayName
+            if name_out is None:
+                name_out = self.name.title()
+            autoctx.meta_queue(f"**{name_out}**: {rolled.result}")
 
         simplified_expr = copy.deepcopy(rolled.expr)
         d20.utils.simplify_expr(simplified_expr)

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -632,7 +632,9 @@ class Character(StatBlock):
         embed.description = "\n".join(desc_details)
 
         # attacks
-        atk_str = self.attacks.build_str(self)
+        atk_str = "\n".join(
+            atk.build_str(self) for atk in sorted(self.attacks.no_activation_types, key=lambda atk: atk.name)
+        )
         if len(atk_str) > 1000:
             atk_str = f"{atk_str[:1000]}\n[...]"
         if atk_str:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -32,7 +32,7 @@ from ddb.gamelog.errors import NoCampaignLink
 from utils import img
 from utils.argparser import argparse
 from utils.constants import SKILL_NAMES
-from utils.functions import confirm, get_positivity, list_get, search_and_select, try_delete
+from utils.functions import confirm, get_positivity, list_get, search_and_select, try_delete, camel_to_title
 from utils.settings.character import CHARACTER_SETTINGS
 
 log = logging.getLogger(__name__)
@@ -257,7 +257,7 @@ class SheetManager(commands.Cog):
     )
     async def check(self, ctx, check, *args):
         char: Character = await ctx.get_character()
-        skill_key = await search_and_select(ctx, SKILL_NAMES, check, lambda s: s)
+        skill_key = await search_and_select(ctx, SKILL_NAMES, check, camel_to_title)
         args = await self.new_arg_stuff(args, ctx, char)
 
         hide = args.last("h", type_=bool)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -32,6 +32,7 @@ from ddb.gamelog.errors import NoCampaignLink
 from utils import img
 from utils.argparser import argparse
 from utils.constants import SKILL_NAMES
+from utils.enums import ActivationType
 from utils.functions import confirm, get_positivity, list_get, search_and_select, try_delete, camel_to_title
 from utils.settings.character import CHARACTER_SETTINGS
 
@@ -123,9 +124,26 @@ class SheetManager(commands.Cog):
         -phrase <text> - Some flavor text to add to each attack with this attack.
         -thumb <image url> - The attack's image.
         -c <extra crit damage> - How much extra damage (beyond doubling dice) this attack does on a crit.
+        -activation <value> - The activation type of the action (e.g. action, bonus, etc).```
+        | Action Type  | Value |
+        +==============+=======+
+        | Action       | 1     |
+        | No Action    | 2     |
+        | Bonus Action | 3     |
+        | Reaction     | 4     |
+        | Minute       | 6     |
+        | Hour         | 7     |
+        | Special      | 8     |
+        | Legendary    | 9     |
+        | Mythic       | 10    |
+        | Lair         | 11    |```
         """
         character: Character = await ctx.get_character()
         parsed = argparse(args)
+
+        activation = parsed.last("activation", type_=int)
+        if activation is not None:
+            activation = ActivationType(activation)
 
         attack = Attack.new(
             name,
@@ -138,6 +156,7 @@ class SheetManager(commands.Cog):
             phrase=parsed.join("phrase", "\n"),
             thumb=parsed.last("thumb"),
             extra_crit_damage=parsed.last("c"),
+            activation_type=activation,
         )
 
         conflict = next((a for a in character.overrides.attacks if a.name.lower() == attack.name.lower()), None)

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -641,6 +641,7 @@ Roll
         higher?: {int: string};
         cantripScale?: boolean;
         hidden?: boolean;
+        displayName?: string;
     }
 
 Rolls some dice and saves the result in a variable. Displays the roll and its name in a Meta field, unless
@@ -668,6 +669,10 @@ Rolls some dice and saves the result in a variable. Displays the roll and its na
 
         *optional* - If ``true``, won't display the roll in the Meta field, or apply any bonuses from the ``-d``
         argument.
+
+    .. attribute:: displayName
+
+        The name to display in the Meta field. If left blank, it will use the saved name.
 
 **Variables**
 
@@ -896,6 +901,7 @@ Cast Spell
         dc?: IntExpression;
         attackBonus?: IntExpression;
         castingMod?: IntExpression;
+        parent?: string;
     }
 
 Executes the given spell's automation as if it were immediately cast. Does not use a spell
@@ -928,6 +934,11 @@ This is usually used in features that cast spells using alternate resources (i.e
 
         *optional* - The spellcasting modifier to use when casting the spell. If not provided, defaults to the caster's
         default spellcasting modifier.
+
+    .. attribute:: parent
+
+        *optional, default None* - If supplied, sets the spells created effect's parent to the given effect. This must be the
+        name of an existing :class:`IEffectMetaVar`. Useful for handling concentration.
 
 **Variables**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v4.1.4
+git+https://github.com/avrae/automation-common@v4.1.5
 d20==1.1.2
 
 # top-level deps


### PR DESCRIPTION
### Summary

- Fix turnnotif mentions in initiative (resolves AVR-936)
- Fix custom actions with activation types showing up on `!sheet`
- Allow `!check` and variants to use "sleight of hand" and "animal handling" instead of "sleightOfHand" or "animalHandling" (resolves AVR-932)
- Added `-activation` to `!attack add` to set activation type
- Added the `parent` key to Cast Spell automation nodes, allowing the setting of a parent effect for all effects granted by the spell.
- Added the `displayName` key to Roll automation nodes, allowing setting a separate display name to be saved than the one used internally. (resolves #1853)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
