### PR TITLE
Fix duplicate id existing for turn notif

### DIFF
--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -167,6 +167,8 @@ class AliasStatBlock:
         :param int amount: The amount of HP to add/remove.
         :param bool ignore_temp: If *amount* is negative, whether to damage temp HP first or ignore temp.
         :param bool overflow: If *amount* is positive, whether to allow overhealing or cap at the creature's max HP.
+        :return: A string describing the creature's current, max, and temp HP after the change.
+        :rtype: str
         """
         return self._statblock.modify_hp(int(amount), ignore_temp, overflow)
 

--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -551,7 +551,8 @@ class Combat:
         mentions = self.get_turn_str_mentions_for(self.current_combatant)
         if self.options.turnnotif and self.next_combatant is not None:
             next_combatant = self.get_turn_str_mentions_for(self.next_combatant)
-            mentions = mentions.merge(disnake.AllowedMentions(users=next_combatant.users + mentions.users))
+            merged_users = set(next_combatant.users).union(mentions.users)
+            mentions = mentions.merge(disnake.AllowedMentions(users=list(merged_users)))
         return mentions
 
     def get_turn_str_mentions_for(self, combatant) -> disnake.AllowedMentions:


### PR DESCRIPTION
### Summary
Hotfix to fix the issue with my fix for ``turnnotif`` not pinging the next combatant. Disnake expects a list with no duplicate items and not a set.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
