### PR TITLE
add AliasResistances util methods to find canonical resistance to str

### DIFF
--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -651,6 +651,34 @@ class AliasResistances:
         """
         return self._resistances.neutral
 
+    def is_resistant(self, damage_type: str) -> bool:
+        """
+        Whether or not this AliasResistances contains any resistances that apply to the given damage type string.
+
+        If the AliasResistances contains both a neutral and a resistance that applies, returns False.
+        """
+        return self._resistances.is_resistant(str(damage_type))
+
+    def is_immune(self, damage_type: str) -> bool:
+        """
+        Whether or not this AliasResistances contains any immunities that apply to the given damage type string.
+
+        If the AliasResistances contains both a neutral and an immunity that applies, returns False.
+        """
+        return self._resistances.is_immune(str(damage_type))
+
+    def is_vulnerable(self, damage_type: str) -> bool:
+        """
+        Whether or not this AliasResistances contains any vulnerabilities that apply to the given damage type string.
+
+        If the AliasResistances contains both a neutral and a vulnerability that applies, returns False.
+        """
+        return self._resistances.is_vulnerable(str(damage_type))
+
+    def is_neutral(self, damage_type: str) -> bool:
+        """Whether or not this AliasResistances contains any neutrals that apply to the given damage type string."""
+        return self._resistances.is_neutral(str(damage_type))
+
     def __str__(self):
         return str(self._resistances)
 

--- a/cogs5e/models/sheet/resistance.py
+++ b/cogs5e/models/sheet/resistance.py
@@ -53,6 +53,42 @@ class Resistances:
         return Resistances(self.resist.copy(), self.immune.copy(), self.vuln.copy(), self.neutral.copy())
 
     # ---------- main funcs ----------
+    def is_resistant(self, damage_type: str | set[str]) -> bool:
+        """
+        Whether or not this Resistances contains any resistances that apply to the given damage type string.
+
+        If the Resistances contains both a neutral and a resistance that applies, returns False.
+        """
+        if isinstance(damage_type, str):
+            damage_type = set(t.lower() for t in _resist_tokenize(damage_type))
+        return any(r.applies_to(damage_type) for r in self.resist) and not self.is_neutral(damage_type)
+
+    def is_immune(self, damage_type: str | set[str]) -> bool:
+        """
+        Whether or not this Resistances contains any immunities that apply to the given damage type string.
+
+        If the Resistances contains both a neutral and a immunity that applies, returns False.
+        """
+        if isinstance(damage_type, str):
+            damage_type = set(t.lower() for t in _resist_tokenize(damage_type))
+        return any(r.applies_to(damage_type) for r in self.immune) and not self.is_neutral(damage_type)
+
+    def is_vulnerable(self, damage_type: str | set[str]) -> bool:
+        """
+        Whether or not this Resistances contains any vulnerabilities that apply to the given damage type string.
+
+        If the Resistances contains both a neutral and a vulnerability that applies, returns False.
+        """
+        if isinstance(damage_type, str):
+            damage_type = set(t.lower() for t in _resist_tokenize(damage_type))
+        return any(r.applies_to(damage_type) for r in self.vuln) and not self.is_neutral(damage_type)
+
+    def is_neutral(self, damage_type: str | set[str]) -> bool:
+        """Whether or not this Resistances contains any neutrals that apply to the given damage type string."""
+        if isinstance(damage_type, str):
+            damage_type = set(t.lower() for t in _resist_tokenize(damage_type))
+        return any(r.applies_to(damage_type) for r in self.neutral)
+
     def update(self, other, overwrite=True):
         """
         Updates this Resistances with the resistances of another.

--- a/tests/unit/resistance_test.py
+++ b/tests/unit/resistance_test.py
@@ -1,4 +1,4 @@
-from cogs5e.models.sheet.resistance import Resistance
+from cogs5e.models.sheet.resistance import Resistance, Resistances
 
 
 def test_simple_resistance():
@@ -62,3 +62,23 @@ def test_resistance_from_str():
     assert Resistance("fire", unless=["abc"], only=["def"]) == Resistance.from_str("nonabc def fire")
     assert Resistance("fire", only=["cold"]) == Resistance.from_str("cold fire")
     assert Resistance("cold", only=["fire"]) == Resistance.from_str("fire cold")
+
+
+def test_resistances_util_methods():
+    r = Resistances(
+        resist=[Resistance.from_str("resist"), Resistance.from_str("resist neutral")],
+        immune=[Resistance.from_str("immune"), Resistance.from_str("immune neutral")],
+        vuln=[Resistance.from_str("vuln"), Resistance.from_str("vuln neutral")],
+        neutral=[Resistance("neutral")],
+    )
+    assert r.is_resistant("resist")
+    assert not r.is_resistant("resist neutral")
+    assert r.is_immune("immune")
+    assert not r.is_immune("immune neutral")
+    assert r.is_vulnerable("vuln")
+    assert not r.is_vulnerable("vuln neutral")
+    assert r.is_neutral("neutral")
+    assert r.is_neutral("resist neutral")
+    assert r.is_neutral("immune neutral")
+    assert r.is_neutral("vuln neutral")
+    assert not r.is_neutral("foo")


### PR DESCRIPTION
### Summary
Adds `Resistances.is_[resistant/immune/vulnerable/neutral](damage_type: str)` and respective AliasResistances methods to make finding out whether a target is resistant to a damage type string easier.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
