### PR TITLE
Jokeen/2022w36

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -58,9 +58,9 @@ class Attack(Effect):
         # ==== caster options ====
         # character-specific arguments
         if autoctx.character:
-            if "reroll" not in args:
+            if args.last("reroll") is None:
                 reroll = autoctx.character.options.reroll
-            if "criton" not in args:
+            if args.last("criton") is None:
                 criton = autoctx.character.options.crit_on
 
         # explicit advantage

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -56,7 +56,7 @@ class Damage(Effect):
         crit_damage_type = autoctx.crit_type
 
         # character-specific arguments
-        if autoctx.character and "critdice" not in args:
+        if autoctx.character and args.last("critdice") is None:
             critdice = autoctx.character.options.extra_crit_dice
 
         # combat-specific arguments

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -66,7 +66,7 @@ class Save(Effect):
         elif autoctx.dc_override is not None:
             dc = autoctx.dc_override
 
-        if "dc" in autoctx.args:
+        if autoctx.args.last("dc") is not None:
             dc = maybe_mod(autoctx.args.last("dc"), dc)
 
         if dc is None:

--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -80,7 +80,7 @@ class PBPUtils(commands.Cog):
     async def br(self, ctx):
         """Prints a scene break."""
         await try_delete(ctx.message)
-        await ctx.send("```\n \n```")
+        await ctx.send("```\n​\n```")
 
     @commands.command(hidden=True)
     async def pythag(self, ctx, num1: int, num2: int):

--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -80,6 +80,7 @@ class PBPUtils(commands.Cog):
     async def br(self, ctx):
         """Prints a scene break."""
         await try_delete(ctx.message)
+        # There is a zero-width space between the \n's, to ensure the code block displays properly on mobile
         await ctx.send("```\n​\n```")
 
     @commands.command(hidden=True)


### PR DESCRIPTION
### Summary
- Fixed an issue with new argparse where certain aspects of `-dc`, `-criton`, `-critdice` and `-reroll` were either not being detected or erroring
- - Fixes #1856 and #1857
- Fixes `!br` not displaying correctly on Android devices by replacing the space with a zero-width space

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
