### PR TITLE
Jokeen/2022w40

### DIFF
--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -350,7 +350,7 @@ async def update_gvar(ctx, gid, value):
 
 
 # snippets
-async def parse_snippets(args, ctx, statblock=None, character=None) -> str:
+async def parse_snippets(args, ctx, statblock=None, character=None, base_args=None) -> str:
     """
     Parses user and server snippets, including any inline scripting.
 
@@ -358,6 +358,7 @@ async def parse_snippets(args, ctx, statblock=None, character=None) -> str:
     :param ctx: The Context.
     :param statblock: The statblock to populate locals from.
     :param character: If passed, provides the base character to use character-scoped functions against.
+    :param base_args: The args to pass through to the snippet code via &ARGS&
     :return: The string, with snippets replaced.
     """
     # make args a list of str
@@ -367,6 +368,8 @@ async def parse_snippets(args, ctx, statblock=None, character=None) -> str:
         args = list(args)
 
     original_args = args[:]
+    if base_args is not None:
+        original_args = base_args + original_args
 
     # set up the evaluator
     evaluator = await evaluators.ScriptingEvaluator.new(ctx)

--- a/cogs5e/dice/cog.py
+++ b/cogs5e/dice/cog.py
@@ -179,7 +179,7 @@ class Dice(commands.Cog):
         attacks = monster.attacks
 
         attack = await search_and_select(ctx, attacks, atk_name, lambda a: a.name)
-        args = await helpers.parse_snippets(args, ctx, statblock=monster)
+        args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, atk_name])
         args = argparse(args)
 
         embed = embed_for_monster(monster, args)
@@ -209,7 +209,7 @@ class Dice(commands.Cog):
     async def monster_check(self, ctx, monster_name, check, *args):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
-        args = await helpers.parse_snippets(args, ctx, statblock=monster)
+        args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, check])
         args = argparse(args)
         skill_key = await search_and_select(ctx, SKILL_NAMES, check, camel_to_title)
 
@@ -232,7 +232,7 @@ class Dice(commands.Cog):
     async def monster_save(self, ctx, monster_name, save_stat, *args):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
-        args = await helpers.parse_snippets(args, ctx, statblock=monster)
+        args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, save_stat])
         args = argparse(args)
 
         embed = embed_for_monster(monster, args)
@@ -257,7 +257,7 @@ class Dice(commands.Cog):
     async def monster_cast(self, ctx, monster_name, spell_name, *args):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
-        args = await helpers.parse_snippets(args, ctx, statblock=monster)
+        args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, spell_name])
         args = argparse(args)
 
         if not args.last("i", type_=bool):

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -793,7 +793,7 @@ class GameTrack(commands.Cog):
 
         char: Character = await ctx.get_character()
 
-        args = await helpers.parse_snippets(args, ctx, character=char)
+        args = await helpers.parse_snippets(args, ctx, character=char, base_args=[spell_name])
         args = argparse(args)
 
         if not args.last("i", type_=bool):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1125,9 +1125,13 @@ class InitTracker(commands.Cog):
         # argument parsing
         is_player = isinstance(combatant, PlayerCombatant)
         if is_player and combatant.character_owner == str(ctx.author.id):
-            args = await helpers.parse_snippets(unparsed_args, ctx, character=combatant.character)
+            args = await helpers.parse_snippets(
+                unparsed_args, ctx, character=combatant.character, base_args=[combatant.name, atk_name]
+            )
         else:
-            args = await helpers.parse_snippets(unparsed_args, ctx, statblock=combatant)
+            args = await helpers.parse_snippets(
+                unparsed_args, ctx, statblock=combatant, base_args=[combatant.name, atk_name]
+            )
         args = argparse(args)
 
         # attack selection/caster handling
@@ -1222,7 +1226,7 @@ class InitTracker(commands.Cog):
         skill_key = await search_and_select(ctx, constants.SKILL_NAMES, check, camel_to_title)
         embed = disnake.Embed(color=combatant.get_color())
 
-        args = await helpers.parse_snippets(args, ctx)
+        args = await helpers.parse_snippets(args, ctx, base_args=[combatant_name, check])
         args = argparse(args)
 
         result = checkutils.run_check(skill_key, combatant, args, embed)
@@ -1270,7 +1274,7 @@ class InitTracker(commands.Cog):
             return await ctx.send("Groups cannot make saves.")
 
         embed = disnake.Embed(color=combatant.get_color())
-        args = await helpers.parse_snippets(args, ctx)
+        args = await helpers.parse_snippets(args, ctx, base_args=[combatant_name, save])
         args = argparse(args)
 
         result = checkutils.run_save(save, combatant, args, embed)
@@ -1327,9 +1331,11 @@ class InitTracker(commands.Cog):
 
         is_character = isinstance(combatant, PlayerCombatant)
         if is_character and combatant.character_owner == str(ctx.author.id):
-            args = await helpers.parse_snippets(args, ctx, character=combatant.character)
+            args = await helpers.parse_snippets(
+                args, ctx, character=combatant.character, base_args=[combatant_name, spell_name]
+            )
         else:
-            args = await helpers.parse_snippets(args, ctx, statblock=combatant)
+            args = await helpers.parse_snippets(args, ctx, statblock=combatant, base_args=[combatant_name, spell_name])
         args = argparse(args)
 
         if not args.last("i", type_=bool):

--- a/cogs5e/initiative/effects/interaction.py
+++ b/cogs5e/initiative/effects/interaction.py
@@ -95,7 +95,9 @@ class AttackInteraction(InitEffectInteraction):
         return attack
 
     def __str__(self):
-        return f"Attack: {self.inner_attack.name}"
+        if not (activation_type := self.inner_attack.activation_type):
+            activation_type = "Attack"
+        return f"{activation_type}: {self.inner_attack.name}"
 
 
 class ButtonInteraction(InitEffectInteraction):

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -299,6 +299,15 @@ class IEffect(Effect):
                     )
                 # noinspection PyProtectedMember
                 explicit_parent = parent_ref._effect
+            # explicit support for parenting to the parent of this ieffect's parent
+            elif self.parent == "ieffect.parent" and (parent_ref := autoctx.metavars.get("ieffect", None)) is not None:
+                if not isinstance(parent_ref, aliasing.api.combat.SimpleEffect):
+                    raise InvalidArgument(
+                        f"Could not set IEffect parent: The variable `{self.parent}` is not an initiative effect "
+                        f"(expected SimpleEffect, got `{type(parent_ref).__name__}`)."
+                    )
+                # noinspection PyProtectedMember
+                explicit_parent = parent_ref.parent._effect
 
             if parent_effect := stack_parent or explicit_parent or conc_parent:
                 effect.set_parent(parent_effect)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -48,8 +48,8 @@ class SheetManager(commands.Cog):
         self.bot = bot
 
     @staticmethod
-    async def new_arg_stuff(args, ctx, character):
-        args = await helpers.parse_snippets(args, ctx, character=character)
+    async def new_arg_stuff(args, ctx, character, base_args=None):
+        args = await helpers.parse_snippets(args, ctx, character=character, base_args=base_args)
         args = argparse(args)
         return args
 
@@ -67,7 +67,7 @@ class SheetManager(commands.Cog):
             return await self.action_list(ctx)
 
         char: Character = await ctx.get_character()
-        args = await self.new_arg_stuff(args, ctx, char)
+        args = await self.new_arg_stuff(args, ctx, char, base_args=[atk_name])
         hide = args.last("h", type_=bool)
         embed = embeds.EmbedWithCharacter(char, name=False, image=not hide)
 
@@ -250,7 +250,7 @@ class SheetManager(commands.Cog):
 
         char: Character = await ctx.get_character()
 
-        args = await self.new_arg_stuff(args, ctx, char)
+        args = await self.new_arg_stuff(args, ctx, char, base_args=[skill])
 
         hide = args.last("h", type_=bool)
 
@@ -277,7 +277,7 @@ class SheetManager(commands.Cog):
     async def check(self, ctx, check, *args):
         char: Character = await ctx.get_character()
         skill_key = await search_and_select(ctx, SKILL_NAMES, check, camel_to_title)
-        args = await self.new_arg_stuff(args, ctx, char)
+        args = await self.new_arg_stuff(args, ctx, char, base_args=[check])
 
         hide = args.last("h", type_=bool)
 

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -521,8 +521,8 @@ async def _snippet_before_edit(ctx, name=None, delete=False):
     name = name.lower()
     if name in SPECIAL_ARGS or name.startswith("-"):
         confirmation = (
-            f"**Warning:** Creating a snippet named `{name}` will prevent you from using the built-in `{name}` argument"
-            " in Avrae commands.\nAre you sure you want to create this snippet? (Reply with yes/no)"
+            f"**Warning:** Creating a snippet named `{name}` will prevent you from using a built-in argument `{name}`"
+            " if one exists.\nAre you sure you want to create this snippet? (Reply with yes/no)"
         )
     # roll string checking
     try:

--- a/tests/e2e/cogs/customization_test.py
+++ b/tests/e2e/cogs/customization_test.py
@@ -23,7 +23,7 @@ async def test_snippet_before_edit(avrae, dhttp):
     avrae.message("!snippet adv adv")
     await dhttp.receive_message(
         "**Warning:** Creating a snippet named `adv` will prevent you from using "
-        "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+        "a built-in argument `adv` if one exists.\nAre you sure you want to "
         "create this snippet? (Reply with yes/no)",
         regex=False,
     )
@@ -33,7 +33,7 @@ async def test_snippet_before_edit(avrae, dhttp):
     avrae.message("!snippet adv adv")
     await dhttp.receive_message(
         "**Warning:** Creating a snippet named `adv` will prevent you from using "
-        "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+        "a built-in argument `adv` if one exists.\nAre you sure you want to "
         "create this snippet? (Reply with yes/no)",
         regex=False,
     )
@@ -43,7 +43,7 @@ async def test_snippet_before_edit(avrae, dhttp):
     avrae.message("!snippet str adv")
     await dhttp.receive_message(
         "**Warning:** Creating a snippet named `str` will prevent you from using "
-        "the built-in `str` argument in Avrae commands.\nAre you sure you want to "
+        "a built-in argument `str` if one exists.\nAre you sure you want to "
         "create this snippet? (Reply with yes/no)",
         regex=False,
     )
@@ -69,7 +69,7 @@ async def test_snippet_before_edit(avrae, dhttp):
     avrae.message("!serversnippet adv adv", as_owner=True)
     await dhttp.receive_message(
         "**Warning:** Creating a snippet named `adv` will prevent you from using "
-        "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+        "a built-in argument `adv` if one exists.\nAre you sure you want to "
         "create this snippet? (Reply with yes/no)",
         regex=False,
     )
@@ -95,7 +95,7 @@ async def test_snippet_before_edit(avrae, dhttp):
     avrae.message("!snippet rename do adv")
     await dhttp.receive_message(
         "**Warning:** Creating a snippet named `adv` will prevent you from using "
-        "the built-in `adv` argument in Avrae commands.\nAre you sure you want to "
+        "a built-in argument `adv` if one exists.\nAre you sure you want to "
         "create this snippet? (Reply with yes/no)",
         regex=False,
     )

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -16,6 +16,23 @@ class ActivationType(enum.IntEnum):
     MYTHIC = 10
     LAIR = 11
 
+    def __str__(self):
+        match self.value:
+            case 1:
+                return "Action"
+            case 3:
+                return "Bonus Action"
+            case 4:
+                return "Reaction"
+            case 2 | 6 | 7 | 8:
+                return "Special"
+            case 9:
+                return "Legendary Action"
+            case 10:
+                return "Mythic Action"
+            case 11:
+                return "Lair Action"
+
 
 class AdvantageType(enum.IntEnum):
     """


### PR DESCRIPTION
### Summary

- Adds the base arguments of a command to snippets ``&ARGS&``. This will allow them to also detect what check/attack/etc is being rolled, and will more closely match with how ``&ARGS&`` is inside aliases
- Added clarity to the snippet name warning when creating a snippet starting with `-`, which will be more commonplace now that ``&ARGS&`` is available
- Updated the text inside ieffect short text for actions granted by the ieffect, to represent the activation type
- Add explicit support for ``ieffect.parent`` as a parent source for ieffects

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
