### PR TITLE
Jokeen/2022w42

### DIFF
--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -697,7 +697,6 @@ class AliasSpellbook:
         """
         self._spellbook = spellbook
         self._spells = None
-        self._spell_dict = None
 
     @property
     def dc(self):
@@ -785,16 +784,14 @@ class AliasSpellbook:
 
     def get(self, spell_name: str):
         """
-        Returns the spell of the given name, case-insensitive, if it's in the spellbook, or None if it is not.
+        Returns a list of the spells of the given name in the spellbook, case-insensitive.
 
-        :rtype: AliasSpellbookSpell or None
+        :rtype: List[AliasSpellbookSpell]
         """
-        if self._spell_dict is None:
-            if self._spells is None:
-                self._spells = [AliasSpellbookSpell(s) for s in self._spellbook.spells]
-            self._spell_dict = {spell.name.lower(): spell for spell in self._spells}
+        if self._spells is None:
+            self._spells = [AliasSpellbookSpell(s) for s in self._spellbook.spells]
 
-        return self._spell_dict.get(spell_name.lower())
+        return [spell for spell in self._spells if spell_name.lower() == spell.name.lower()]
 
     def slots_str(self, level):
         """

--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -697,6 +697,7 @@ class AliasSpellbook:
         """
         self._spellbook = spellbook
         self._spells = None
+        self._spell_dict = None
 
     @property
     def dc(self):
@@ -781,6 +782,19 @@ class AliasSpellbook:
         :rtype: int or None
         """
         return self._spellbook.max_pact_slots
+
+    def get(self, spell_name: str):
+        """
+        Returns the spell of the given name, case-insensitive, if it's in the spellbook, or None if it is not.
+
+        :rtype: AliasSpellbookSpell or None
+        """
+        if self._spell_dict is None:
+            if self._spells is None:
+                self._spells = [AliasSpellbookSpell(s) for s in self._spellbook.spells]
+            self._spell_dict = {spell.name.lower(): spell for spell in self._spells}
+
+        return self._spell_dict.get(spell_name.lower())
 
     def slots_str(self, level):
         """

--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -782,7 +782,7 @@ class AliasSpellbook:
         """
         return self._spellbook.max_pact_slots
 
-    def get(self, spell_name: str):
+    def find(self, spell_name: str):
         """
         Returns a list of the spells of the given name in the spellbook, case-insensitive.
 

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -524,6 +524,7 @@ class InitTracker(commands.Cog):
         Rerolls initiative for all combatants, and starts a new round of combat.
         __Valid Arguments__
         `-restart` - Resets the round counter (effectively restarting initiative).
+        `-effects` - Removes all effects from all combatants
         """
         combat = await ctx.get_combat()
         a = argparse(args)
@@ -534,6 +535,11 @@ class InitTracker(commands.Cog):
         # -restart (#1053)
         if a.last("restart"):
             combat.round_num = 0
+
+        # -reset (#1867)
+        if a.last("effects"):
+            [combatant.remove_all_effects() for combatant in combat.combatants]
+            await ctx.send("Removed effects from all combatants.")
 
         # repost summary message
         old_summary = combat.get_summary_msg()

--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -43,7 +43,7 @@ class PBPUtils(commands.Cog):
         -image <image url>
         -footer <footer text>
         -f "<Field Title>|<Field Text>[|inline]"
-            (e.g. "Donuts|I have 15 donuts|inline" for an inline field, or "Donuts|I have 15 donuts" for one with its own line.)
+            (e.g. "Donuts|I have 15 donuts|inline" for up to 3 inline fields on a single line, or "Donuts|I have 15 donuts" for one with its own line.)
         -color [hex color]
             Leave blank for random color.
         -t <timeout (0..600)>

--- a/ddb/client.py
+++ b/ddb/client.py
@@ -93,6 +93,11 @@ class BeyondClient(BeyondClientBase):
             if entity.is_free or user_licenses & entity.license_ids:
                 accessible.add(entity.entity_id)
 
+        # source 14 is TftYP, and 16-22 are the modules within.
+        # DDB only gives entitlements for the modules
+        if entity_type == "source" and {16, 17, 18, 19, 20, 21, 22}.issubset(user_licenses):
+            accessible.add(14)
+
         log.debug(f"Discord user {user_id} can see {entity_type}s {accessible}")
 
         return accessible


### PR DESCRIPTION
### Summary

- Adds direct handling for the Tales from the Yawning Portal entitlements
  - Due to the modular nature of this product, DDB only provides entitlements for each module and not the book as a whole
  - In order to allow the Entitlement for this produce on the Workshop, it will check if the user has the entitlement for every module, and if so, treat them as if they have the entitlement for the book as a whole
- Add an `AliasSpellbook.get(spellname)` method to get a list of copies of that spell within the spellbook
  - This is a faster alternative to get an individual spell at an alias level, but also grants the ability to get it within automation where list/list-comps are not available
- Update the phrasing on `-f` fields in `!help embed`, to help clarify that inline fields are only inline to themselves and a max of 3 per 'row'
- Add an `-effects` arg to `!init reroll` to clear all ieffects from all combatants, to ease resetting of combat

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
