### PR TITLE
fix: missing nlp_caster in !i a and !i cast

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1177,6 +1177,7 @@ class InitTracker(commands.Cog):
                     attack = await actionutils.select_action(
                         ctx, atk_name, attacks=combatant.attacks, message="Select your attack."
                     )
+            ctx.nlp_caster = caster
         except SelectionException:
             return await ctx.send("Attack not found.")
 
@@ -1340,6 +1341,7 @@ class InitTracker(commands.Cog):
             combatant = await get_selection(
                 ctx, combatant.get_combatants(), key=lambda com: com.name, message="Select the caster."
             )
+        ctx.nlp_caster = combatant
 
         is_character = isinstance(combatant, PlayerCombatant)
         if is_character and combatant.character_owner == str(ctx.author.id):


### PR DESCRIPTION
### Summary
Fixes a case where the nlp_caster attribute could fail to be set when using `!i a` or `!i cast`.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
