### PR TITLE
Fix docs for argparse() in aliasing

### DIFF
--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -391,7 +391,24 @@ Python Builtins
 Draconic Functions
 ^^^^^^^^^^^^^^^^^^
 
-.. autofunction:: utils.argparser.argparse(args)
+.. function:: argparse(args, parse_ephem=True)
+
+    Given an argument string or list, returns the parsed arguments using the argument nondeterministic finite automaton.
+
+    If *parse_ephem* is False, arguments like ``-d1`` are saved literally rather than as an ephemeral argument.
+
+    .. note::
+
+        Arguments must begin with a letter and not end with a number (e.g. ``d``, ``e12s``, ``a!!``). Values immediately
+        following a flag argument (i.e. one that starts with ``-``) will not be parsed as arguments unless they are also
+        a flag argument.
+
+        There are three exceptions to this rule: ``-i``, ``-h``, and ``-v``, none of which take additional values.
+
+    :param args: A list or string of arguments.
+    :param bool parse_ephem:  Whether to treat args like ``-d1`` as ephemeral arguments or literal ones.
+    :return: The parsed arguments
+    :rtype: :class:`~utils.argparser.ParsedArguments()`
 
     >>> args = argparse("adv -rr 2 -b 1d4[bless]")
     >>> args.adv()

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -106,6 +106,8 @@ def argparse(args, character=None, splitter=argsplit, parse_ephem=True) -> "Pars
     If the argument is a string, uses *splitter* to split the string into args.
     If *parse_ephem* is False, arguments like ``-d1`` are saved literally rather than as an ephemeral argument.
 
+    Draconic docs for this are not linked, and will have to be manually updated if this function changes.
+
     .. note::
 
         Arguments must begin with a letter and not end with a number (e.g. ``d``, ``e12s``, ``a!!``). Values immediately


### PR DESCRIPTION
### Summary
Just fixes the aliasing documentation to represent the arguments available.
This breaks it away from using autofunction because the internal function has arguments that are not usable in Draconic (character), so also added a note that the aliasing docs have to be updated as well if the function changes

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
