### PR TITLE
feat(aliasing): add ctx.command

### DIFF
--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -19,6 +19,7 @@ class AliasContext:
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with
         self._message_id = ctx.message.id
+        self._full_command = ctx.command.qualified_name if ctx.command else None
 
     @property
     def guild(self):
@@ -68,7 +69,17 @@ class AliasContext:
 
         :rtype: str
         """
+
         return self._alias
+
+    @property
+    def command(self):
+        """
+        The full command string the alias was invoked with.
+
+        :rtype: str or None
+        """
+        return self._full_command
 
     @property
     def message_id(self):
@@ -138,8 +149,16 @@ class AliasChannel:
         self._name = str(channel)
         self._id = channel.id
         self._topic = getattr(channel, "topic", None)
-        self._category = AliasCategory(channel.category) if getattr(channel, "category", None) is not None else None
-        self._parent = AliasChannel(channel.parent) if isinstance(channel, disnake.Thread) else None
+        self._category = (
+            AliasCategory(channel.category)
+            if getattr(channel, "category", None) is not None
+            else None
+        )
+        self._parent = (
+            AliasChannel(channel.parent)
+            if isinstance(channel, disnake.Thread)
+            else None
+        )
 
     @property
     def name(self):

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -149,16 +149,8 @@ class AliasChannel:
         self._name = str(channel)
         self._id = channel.id
         self._topic = getattr(channel, "topic", None)
-        self._category = (
-            AliasCategory(channel.category)
-            if getattr(channel, "category", None) is not None
-            else None
-        )
-        self._parent = (
-            AliasChannel(channel.parent)
-            if isinstance(channel, disnake.Thread)
-            else None
-        )
+        self._category = AliasCategory(channel.category) if getattr(channel, "category", None) is not None else None
+        self._parent = AliasChannel(channel.parent) if isinstance(channel, disnake.Thread) else None
 
     @property
     def name(self):

--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -76,6 +76,8 @@ class AliasContext:
     def command(self):
         """
         The full command string the alias was invoked with.
+        This will be None when called inside an Alias, as the command string cannot be determined until after the alias
+        is run.
 
         :rtype: str or None
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,6 +144,11 @@ class ContextBotProxy:
     def author(self):
         return self.guild.get_member(int(DEFAULT_USER_ID))
 
+    @property
+    def command(self):
+        # 1878, used in AvraeContext
+        return None
+
 
 class MessageProxy:
     def __init__(self):


### PR DESCRIPTION
### Summary

Add `ctx.command` to `AliasContext`

*Important:* This field is `Optional[Str]`. It *will* be None when an alias tries to call it, as we do not easily have access to the whole alias path name including parents (correct me if I'm wrong).

Resolves AFR-982

![image](https://user-images.githubusercontent.com/16567386/202003532-3b403f36-6cd7-4630-857d-9ea197850fc0.png)
![image](https://user-images.githubusercontent.com/16567386/202003455-ede58a6d-1b46-4173-b169-6bf4254aaef3.png)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
