### PR TITLE
Add support for v1.dicecloud.com and prepare for v2

### DIFF
--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -680,7 +680,7 @@ class Character(StatBlock):
         """
         base_urls = {
             "beyond": "https://ddb.ac/characters/",
-            "dicecloud": "https://dicecloud.com/character/",
+            "dicecloud": "https://v1.dicecloud.com/character/",
             "google": "https://docs.google.com/spreadsheets/d/",
         }
         if self.sheet_type in base_urls:

--- a/cogs5e/models/dicecloud/client.py
+++ b/cogs5e/models/dicecloud/client.py
@@ -9,8 +9,8 @@ from utils import config
 from .errors import InsertFailure, LoginFailure
 from .http import DicecloudHTTP
 
-API_BASE = "https://dicecloud.com"
-SOCKET_BASE = "wss://dicecloud.com/websocket"
+API_BASE = "https://v1.dicecloud.com"
+SOCKET_BASE = "wss://v1.dicecloud.com/websocket"
 
 log = logging.getLogger(__name__)
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -627,7 +627,7 @@ class SheetManager(commands.Cog):
         """
         Loads a character sheet from one of the accepted sites:
             [D&D Beyond](https://www.dndbeyond.com/)
-            [Dicecloud](https://dicecloud.com/)
+            [Dicecloud v1](https://v1.dicecloud.com/)
             [GSheet v2.1](https://gsheet2.avrae.io) (auto)
             [GSheet v1.4](https://gsheet.avrae.io) (manual)
 

--- a/cogs5e/sheets/dicecloud.py
+++ b/cogs5e/sheets/dicecloud.py
@@ -45,8 +45,8 @@ CLASS_RESOURCE_RESETS = {
     "sorceryPoints": "long",
     "superiorityDice": "short",
 }
-API_BASE = "https://dicecloud.com/character/"
-DICECLOUD_URL_RE = re.compile(r"(?:https?://)?dicecloud\.com/character/([\d\w]+)/?")
+API_BASE = "https://v1.dicecloud.com/character/"
+DICECLOUD_URL_RE = re.compile(r"(?:https?://)?(?:v1\.)?dicecloud\.com/character/([\d\w]+)/?")
 
 
 class DicecloudParser(SheetLoaderABC):


### PR DESCRIPTION
### Summary
This changes the api endpoints and regex for dicecloud to point at v1.dicecloud.com

A redirect was put in ahead of the v2 dicecloud release, and unfortunately is 'breaking' imports for Dicecloud. (people can remove the `v1.` subdomain and import fine). This PR will allow imports to continue to work fine for v1 sheets until our support for v2 comes next Tuesday.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
