### PR TITLE
Lookup Slash Commands

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -21,7 +21,7 @@ from gamedata.compendium import compendium
 from gamedata.klass import ClassFeature
 from gamedata.lookuputils import create_selectkey, lookup_converter, can_access
 from gamedata.race import RaceFeature
-from gamedata.shared import CachedSourced
+from gamedata.shared import CachedSourced, Sourced
 from utils import checks, img
 from utils.argparser import argparse
 from utils.functions import chunk_text, get_positivity, search_and_select, smart_trim, trim_str, try_delete, search
@@ -1012,7 +1012,7 @@ class Lookup(commands.Cog):
             await ctx.send("Result sent to messages.", ephemeral=True)
         return ctx.author if guild_settings.lookup_pm_result else ctx
 
-    async def _check_access(self, inter, entity: "Sourced", entity_choices: list[str]):
+    async def _check_access(self, inter, entity: Sourced, entity_choices: list[str]):
         available_ids = {
             k: await self.bot.ddb.get_accessible_entities(inter, inter.author.id, k) for k in entity_choices
         }

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -857,7 +857,7 @@ class Lookup(commands.Cog):
                     token_args = "-border plain"
                 image = await img.generate_token(monster.get_image_url(), is_subscriber, token_args)
             except Exception as e:
-                return await ctx.send(f"Error generating token: {e}")
+                return await destination.send(f"Error generating token: {e}")
         else:
             # official monsters
             token_url = monster.get_token_url(is_subscriber)
@@ -865,7 +865,7 @@ class Lookup(commands.Cog):
                 token_url = monster.get_token_url(False)
 
             if not token_url:
-                return await ctx.send("This monster has no image.")
+                return await destination.send("This monster has no image.")
 
             image = await img.fetch_monster_image(token_url)
 
@@ -876,7 +876,7 @@ class Lookup(commands.Cog):
 
         file = disnake.File(image, filename="image.png")
         embed.set_image(url="attachment://image.png")
-        await ctx.send(embed=embed, file=file)
+        await destination.send(embed=embed, file=file)
 
     # ==== spells ====
     @commands.command()

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -437,7 +437,7 @@ class Lookup(commands.Cog):
                 await inter.send("Subclass not found.", ephemeral=True)
                 return
             name = name[0]
-        await self._check_access(inter, name, ["subclass"])
+        await self._check_access(inter, name, ["class"])
         return await self._subclass(inter, name)
 
     @slash_subclass.autocomplete("name")

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -441,7 +441,7 @@ class Lookup(commands.Cog):
 
     @slash_subclass.autocomplete("name")
     async def slash_subclass_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
-        available_ids = {"class": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "subclass")}
+        available_ids = {"class": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "class")}
         select_key = create_selectkey(available_ids)
         result, strict = search(compendium.subclasses, user_input, lambda e: e.name, 25)
         if strict:
@@ -1008,9 +1008,8 @@ class Lookup(commands.Cog):
         if guild_settings is None:
             return ctx
         if slash_command and guild_settings.lookup_pm_result:
-            await ctx.send(
-                f"Result sent to your [Direct Messages]({await ctx.author.create_dm().jump_url})", ephemeral=True
-            )
+            dm_link = await ctx.author.create_dm()
+            await ctx.send(f"Result sent to your [Direct Messages]({dm_link.jump_url})", ephemeral=True)
         return ctx.author if guild_settings.lookup_pm_result else ctx
 
     async def _check_access(self, inter, entity: Sourced, entity_choices: list[str]):

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -19,7 +19,7 @@ from cogsmisc.stats import Stats
 from gamedata import lookuputils
 from gamedata.compendium import compendium
 from gamedata.klass import ClassFeature
-from gamedata.lookuputils import create_selectkey, lookup_converter, can_access
+from gamedata.lookuputils import create_selectkey, lookup_converter, can_access, slash_match_key
 from gamedata.race import RaceFeature
 from gamedata.shared import CachedSourced, Sourced
 from utils import checks, img
@@ -165,7 +165,7 @@ class Lookup(commands.Cog):
         available_ids = {"feat": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "feat")}
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(compendium.feats, user_input, lambda e: f"{e.name} {e.source}", 25)
+        result, strict = search(compendium.feats, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -213,9 +213,7 @@ class Lookup(commands.Cog):
         }
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(
-            compendium.rfeats + compendium.subrfeats, user_input, lambda e: f"{e.name} {e.source}", 25
-        )
+        result, strict = search(compendium.rfeats + compendium.subrfeats, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -260,9 +258,7 @@ class Lookup(commands.Cog):
         }
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(
-            compendium.races + compendium.subraces, user_input, lambda e: f"{e.name} {e.source}", 25
-        )
+        result, strict = search(compendium.races + compendium.subraces, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -311,9 +307,7 @@ class Lookup(commands.Cog):
         }
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(
-            compendium.cfeats + compendium.optional_cfeats, user_input, lambda e: f"{e.name} {e.source}", 25
-        )
+        result, strict = search(compendium.cfeats + compendium.optional_cfeats, user_input, slash_match_key, 25)
 
         if strict:
             return [select_key(result, True)]
@@ -362,7 +356,7 @@ class Lookup(commands.Cog):
     async def slash_class_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         available_ids = {"class": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "class")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(compendium.classes, user_input, lambda e: f"{e.name} {e.source}", 25)
+        result, strict = search(compendium.classes, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -449,7 +443,7 @@ class Lookup(commands.Cog):
     async def slash_subclass_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         available_ids = {"class": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "class")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(compendium.subclasses, user_input, lambda e: f"{e.name} {e.source}", 25)
+        result, strict = search(compendium.subclasses, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -504,7 +498,7 @@ class Lookup(commands.Cog):
     async def slash_background_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         available_ids = {"background": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "background")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(compendium.backgrounds, user_input, lambda e: f"{e.name} {e.source}", 25)
+        result, strict = search(compendium.backgrounds, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -832,9 +826,7 @@ class Lookup(commands.Cog):
 
         available_ids = {"monster": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "monster")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(
-            choices, user_input, lambda e: f"{e.name} {e.source} {'homebrew' if e.homebrew else ''}"
-        )
+        result, strict = search(choices, user_input, slash_match_key)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -909,9 +901,7 @@ class Lookup(commands.Cog):
 
         available_ids = {"spell": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "spell")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(
-            choices, user_input, lambda e: f"{e.name} {e.source} {'homebrew' if e.homebrew else ''}", 25
-        )
+        result, strict = search(choices, user_input, slash_match_key, 25)
 
         if strict:
             return [select_key(result, True)]
@@ -1007,9 +997,7 @@ class Lookup(commands.Cog):
         available_ids = {k: await self.bot.ddb.get_accessible_entities(inter, inter.author.id, k) for k in choice_dict}
 
         select_key = create_selectkey(available_ids)
-        result, strict = search(
-            choices, user_input, lambda e: f"{e.name} {e.source} {'homebrew' if e.homebrew else ''}", 25
-        )
+        result, strict = search(choices, user_input, slash_match_key, 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -752,6 +752,7 @@ class Lookup(commands.Cog):
         return await self._monimage(inter, name, hide_name)
 
     async def _monimage(self, ctx, monster: gamedata.Monster, hide_name):
+        destination = await self._get_destination(ctx)
         url = monster.get_image_url()
         embed = EmbedWithAuthor(ctx)
         if not hide_name:
@@ -762,7 +763,7 @@ class Lookup(commands.Cog):
             return await ctx.channel.send("This monster has no image.")
 
         embed.set_image(url=url)
-        await ctx.send(embed=embed)
+        await destination.send(embed=embed)
 
     @commands.command()
     async def token(self, ctx, name=None, *args):
@@ -839,6 +840,8 @@ class Lookup(commands.Cog):
         return [select_key(r, True) for r in result][:25]
 
     async def _token(self, ctx, monster: gamedata.Monster, plain_border, hide_name):
+        destination = await self._get_destination(ctx)
+
         # select border
         ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
         is_subscriber = ddb_user and ddb_user.is_subscriber
@@ -846,7 +849,7 @@ class Lookup(commands.Cog):
         if monster.homebrew:
             # homebrew: generate token
             if not monster.get_image_url():
-                return await ctx.send("This monster has no image.")
+                return await destination.send("This monster has no image.")
             try:
                 token_args = None
                 # Not the cleanest but leaves it open to additional args in the future

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -1077,11 +1077,13 @@ class Lookup(commands.Cog):
     # ==== helpers ====
     @staticmethod
     async def _get_destination(ctx):
+        guild_settings = None
         if hasattr(ctx, "get_server_settings"):
             guild_settings = await ctx.get_server_settings()
             slash_command = False
         else:
-            guild_settings = await ServerSettings.for_guild(mdb=ctx.bot.mdb, guild_id=ctx.guild.id)
+            if ctx.guild is not None:
+                guild_settings = await ServerSettings.for_guild(mdb=ctx.bot.mdb, guild_id=ctx.guild.id)
             slash_command = True
         if guild_settings is None:
             return ctx

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -165,7 +165,7 @@ class Lookup(commands.Cog):
         available_ids = {"feat": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "feat")}
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(compendium.feats, user_input, lambda e: e.name, 25)
+        result, strict = search(compendium.feats, user_input, lambda e: f"{e.name} {e.source}", 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -213,7 +213,9 @@ class Lookup(commands.Cog):
         }
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(compendium.rfeats + compendium.subrfeats, user_input, lambda e: e.name, 25)
+        result, strict = search(
+            compendium.rfeats + compendium.subrfeats, user_input, lambda e: f"{e.name} {e.source}", 25
+        )
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -258,7 +260,9 @@ class Lookup(commands.Cog):
         }
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(compendium.races + compendium.subraces, user_input, lambda e: e.name, 25)
+        result, strict = search(
+            compendium.races + compendium.subraces, user_input, lambda e: f"{e.name} {e.source}", 25
+        )
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -307,7 +311,9 @@ class Lookup(commands.Cog):
         }
         select_key = create_selectkey(available_ids)
 
-        result, strict = search(compendium.cfeats + compendium.optional_cfeats, user_input, lambda e: e.name, 25)
+        result, strict = search(
+            compendium.cfeats + compendium.optional_cfeats, user_input, lambda e: f"{e.name} {e.source}", 25
+        )
 
         if strict:
             return [select_key(result, True)]
@@ -356,7 +362,7 @@ class Lookup(commands.Cog):
     async def slash_class_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         available_ids = {"class": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "class")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(compendium.classes, user_input, lambda e: e.name, 25)
+        result, strict = search(compendium.classes, user_input, lambda e: f"{e.name} {e.source}", 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -443,7 +449,7 @@ class Lookup(commands.Cog):
     async def slash_subclass_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         available_ids = {"class": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "class")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(compendium.subclasses, user_input, lambda e: e.name, 25)
+        result, strict = search(compendium.subclasses, user_input, lambda e: f"{e.name} {e.source}", 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -498,7 +504,7 @@ class Lookup(commands.Cog):
     async def slash_background_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         available_ids = {"background": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "background")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(compendium.backgrounds, user_input, lambda e: e.name, 25)
+        result, strict = search(compendium.backgrounds, user_input, lambda e: f"{e.name} {e.source}", 25)
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -567,7 +573,9 @@ class Lookup(commands.Cog):
 
         available_ids = {"monster": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "monster")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(choices, user_input, lambda e: e.name, 25)
+        result, strict = search(
+            choices, user_input, lambda e: f"{e.name} {e.source} {'homebrew' if e.homebrew else ''}", 25
+        )
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]
@@ -835,7 +843,9 @@ class Lookup(commands.Cog):
 
         available_ids = {"spell": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "spell")}
         select_key = create_selectkey(available_ids)
-        result, strict = search(choices, user_input, lambda e: e.name, 25)
+        result, strict = search(
+            choices, user_input, lambda e: f"{e.name} {e.source} {'homebrew' if e.homebrew else ''}", 25
+        )
 
         if strict:
             return [select_key(result, True)]
@@ -931,7 +941,9 @@ class Lookup(commands.Cog):
         available_ids = {k: await self.bot.ddb.get_accessible_entities(inter, inter.author.id, k) for k in choice_dict}
 
         select_key = create_selectkey(available_ids)
-        result, strict = search(choices, user_input, lambda e: e.name, 25)
+        result, strict = search(
+            choices, user_input, lambda e: f"{e.name} {e.source} {'homebrew' if e.homebrew else ''}", 25
+        )
         if strict:
             return [select_key(result, True)]
         return [select_key(r, True) for r in result][:25]

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -1023,35 +1023,20 @@ class Lookup(commands.Cog):
         available_entities = await entity_source(ctx)
         # Items have 4 entity types and as such return a dict
         if isinstance(available_entities, dict):
-            converted_entities = []
-            for e_type, entities in available_entities.items():
-                converted_entities.extend(
-                    [
-                        CachedSourced(
-                            name=e.name,
-                            entity_type=e_type,
-                            source=e.source,
-                            homebrew=e.homebrew,
-                            entity_id=e.entity_id,
-                            is_free=e.is_free,
-                            is_legacy=e.is_legacy,
-                        )
-                        for e in entities
-                    ]
-                )
-        else:
-            converted_entities = [
-                CachedSourced(
-                    name=e.name,
-                    entity_type=entity_type,
-                    source=e.source,
-                    homebrew=e.homebrew,
-                    entity_id=e.entity_id,
-                    is_free=e.is_free,
-                    is_legacy=e.is_legacy,
-                )
-                for e in available_entities
-            ]
+            available_entities = list(itertools.chain.from_iterable(available_entities.values()))
+
+        converted_entities = [
+            CachedSourced(
+                name=e.name,
+                entity_type=e.entity_type,
+                source=e.source,
+                homebrew=e.homebrew,
+                entity_id=e.entity_id,
+                is_free=e.is_free,
+                is_legacy=e.is_legacy,
+            )
+            for e in available_entities
+        ]
 
         # cache monsters
         ENTITY_CACHE[key] = converted_entities

--- a/cogsmisc/tutorials/__init__.py
+++ b/cogsmisc/tutorials/__init__.py
@@ -53,8 +53,8 @@ class Tutorials(commands.Cog):
             name="Using Slash Commands With Avrae",
             value=(
                 "It looks like you're trying to use slash commands! Due to the complexity of certain Avrae commands,"
-                " Avrae does not support Discord's slash command framework. To use Avrae commands, add a *prefix*"
-                f" before the command you want to use - like `{guild_prefix}roll 1d20`."
+                " Avrae does not support Discord's slash command framework for every command. To use most of Avrae's "
+                f"commands, add a *prefix* before the command you want to use - like `{guild_prefix}roll 1d20`."
             ),
             inline=False,
         )

--- a/dbot.py
+++ b/dbot.py
@@ -260,8 +260,9 @@ async def on_resumed():
     log.info("resumed.")
 
 
-@bot.event
-async def on_command_error(ctx, error):
+@bot.listen("on_command_error")
+@bot.listen("on_slash_command_error")
+async def command_errors(ctx, error):
     if isinstance(error, commands.CommandNotFound):
         return
 

--- a/dbot.py
+++ b/dbot.py
@@ -13,6 +13,7 @@ import motor.motor_asyncio
 import psutil
 import sentry_sdk
 from aiohttp import ClientOSError, ClientResponseError
+from disnake import ApplicationCommandInteraction
 from disnake.errors import Forbidden, HTTPException, InvalidArgument, NotFound
 from disnake.ext import commands
 from disnake.ext.commands.errors import CommandInvokeError
@@ -336,10 +337,10 @@ async def command_errors(ctx, error):
         "Please join <https://support.avrae.io> and let us know about the error!"
     )
 
-    if hasattr(ctx, "message"):
-        log.warning("Error caused by message: `{}`".format(ctx.message.content))
+    if isinstance(ctx, ApplicationCommandInteraction):
+        log.warning(f"Error caused by slash command: `/{ctx.data.name}` with options: {ctx.options}")
     else:
-        log.warning("Error caused by slash command: `/{}` with options: {}".format(ctx.data.name, ctx.options))
+        log.warning(f"Error caused by message: `{ctx.message.content}`")
     for line in traceback.format_exception(type(error), error, error.__traceback__):
         log.warning(line)
 

--- a/dbot.py
+++ b/dbot.py
@@ -336,7 +336,10 @@ async def command_errors(ctx, error):
         "Please join <https://support.avrae.io> and let us know about the error!"
     )
 
-    log.warning("Error caused by message: `{}`".format(ctx.message.content))
+    if hasattr(ctx, "message"):
+        log.warning("Error caused by message: `{}`".format(ctx.message.content))
+    else:
+        log.warning("Error caused by slash command: `/{}` with options: {}".format(ctx.data.name, ctx.options))
     for line in traceback.format_exception(type(error), error, error.__traceback__):
         log.warning(line)
 

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -5,17 +5,22 @@ Created on Jan 13, 2017
 """
 import itertools
 import logging
-from typing import Dict, List, TYPE_CHECKING, TypeVar
+from typing import Dict, List, TYPE_CHECKING, TypeVar, Callable
 
+import disnake
+
+import gamedata
 from cogs5e.models.embeds import EmbedWithAuthor
 from cogs5e.models.errors import NoActiveBrew, RequiresLicense
 from cogs5e.models.homebrew import Pack, Tome
 from cogs5e.models.homebrew.bestiary import Bestiary
 from cogsmisc.stats import Stats
 from utils.constants import HOMEBREW_EMOJI, HOMEBREW_ICON
-from utils.functions import get_selection, search_and_select
+from utils.functions import get_selection, search_and_select, search
 from utils.settings.guild import LegacyPreference
 from .compendium import compendium
+from .klass import ClassFeature
+from .race import RaceFeature
 
 if TYPE_CHECKING:
     from utils.context import AvraeContext
@@ -201,14 +206,18 @@ def _create_selector(available_ids: dict[str, set[int]]):
     return legacy_entity_selector
 
 
-def _create_selectkey(available_ids: dict[str, set[int]]):
-    def selectkey(e: "Sourced"):
+def create_selectkey(available_ids: dict[str, set[int]]):
+    def selectkey(e: "Sourced", slash: bool = False):
+        legacy = "legacy" if slash else "*legacy*"
+        no_access = "*" if slash else "\\*"
+        homebrew = "🍺" if slash else HOMEBREW_EMOJI
+
         if e.homebrew:
-            return f"{e.name} ({HOMEBREW_EMOJI} {e.source})"
-        entity_source = e.source if not e.is_legacy else f"{e.source}; *legacy*"
+            return f"{e.name} ({homebrew} - {e.source})"
+        entity_source = e.source if not e.is_legacy else f"{e.source}; {legacy}"
         if can_access(e, available_ids[e.entitlement_entity_type]):
             return f"{e.name} ({entity_source})"
-        return f"{e.name} ({entity_source})\\*"
+        return f"{e.name} ({entity_source}){no_access}"
 
     return selectkey
 
@@ -220,6 +229,108 @@ async def add_training_data(mdb, lookup_type, query, result_name, metadata=None,
         data["chosen_index"] = metadata.get("chosen_index", 0)
         data["homebrew"] = metadata.get("homebrew", False)
     await mdb.nn_training.insert_one(data)
+
+
+def lookup_converter(entity_type: str) -> Callable:
+    async def monster_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.monster:
+        choices = await get_monster_choices(inter)
+        result: gamedata.monster = search(choices, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That monster doesn't exist")
+        return result
+
+    async def item_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.item:
+        choices = await get_item_entitlement_choice_map(inter)
+        result: gamedata.monster = search(list(itertools.chain.from_iterable(choices.values())), arg, lambda e: e.name)[
+            0
+        ]
+        if result is None:
+            raise ValueError("That item doesn't exist")
+        return result
+
+    async def spell_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.spell:
+        choices = await get_spell_choices(inter)
+        result: gamedata.spell = search(choices, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That spell doesn't exist")
+        return result
+
+    def rule_converter(_: disnake.ApplicationCommandInteraction, arg: str):
+        choices = []
+        for actiontype in compendium.rule_references:
+            choices.extend(actiontype["items"])
+        result: gamedata.monster = search(choices, arg, lambda e: e["fullName"])[0]
+        if result is None:
+            raise ValueError("That rule doesn't exist")
+        return result
+
+    def background_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Background:
+        result: gamedata.Background = search(compendium.backgrounds, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That background doesn't exist")
+        return result
+
+    def feat_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.feat:
+        result: gamedata.feat = search(compendium.feats, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That feat doesn't exist")
+        return result
+
+    def race_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.race:
+        result: gamedata.race = search(compendium.races + compendium.subraces, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That race doesn't exist")
+        return result
+
+    def racefeat_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> RaceFeature:
+        result: RaceFeature = search(compendium.rfeats + compendium.subrfeats, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That racial feature doesn't exist")
+        return result
+
+    def class_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Class:
+        result: gamedata.Class = search(compendium.classes, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That class doesn't exist")
+        return result
+
+    def subclass_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Subclass:
+        result: gamedata.Subclass = search(compendium.subclasses, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That class doesn't exist")
+        return result
+
+    def classfeat_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> ClassFeature:
+        result: ClassFeature = search(compendium.cfeats + compendium.optional_cfeats, arg, lambda e: e.name)[0]
+        if result is None:
+            raise ValueError("That class feature doesn't exist")
+        return result
+
+    match entity_type:
+        case "monster":
+            return monster_converter
+        case "item":
+            return item_converter
+        case "spell":
+            return spell_converter
+        case "rule":
+            return rule_converter
+        case "background":
+            return background_converter
+        case "feat":
+            return feat_converter
+        case "race":
+            return race_converter
+        case "racefeat":
+            return racefeat_converter
+        case "class":
+            return class_converter
+        case "subclass":
+            return subclass_converter
+        case "classfeat":
+            return classfeat_converter
+        case _:
+            raise ValueError("That converter does not exist")
 
 
 async def search_entities(
@@ -251,7 +362,7 @@ async def search_entities(
         list(itertools.chain.from_iterable(entities.values())),
         query,
         lambda e: e.name,
-        selectkey=_create_selectkey(available_ids),
+        selectkey=create_selectkey(available_ids),
         selector=_create_selector(available_ids),
         return_metadata=True,
         **kwargs,

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -231,17 +231,21 @@ async def add_training_data(mdb, lookup_type, query, result_name, metadata=None,
     await mdb.nn_training.insert_one(data)
 
 
+def slash_match_key(entity):
+    return f"{entity.name} {entity.source} {'homebrew' if entity.homebrew else ''}"
+
+
 def lookup_converter(entity_type: str) -> Callable:
     async def monster_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.monster:
         choices = await get_monster_choices(inter)
-        result: gamedata.monster = search(choices, arg, lambda e: e.name)[0]
+        result: gamedata.monster = search(choices, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That monster doesn't exist")
         return result
 
     async def item_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.item:
         choices = await get_item_entitlement_choice_map(inter)
-        result: gamedata.monster = search(list(itertools.chain.from_iterable(choices.values())), arg, lambda e: e.name)[
+        result: gamedata.monster = search(list(itertools.chain.from_iterable(choices.values())), arg, slash_match_key)[
             0
         ]
         if result is None:
@@ -250,7 +254,7 @@ def lookup_converter(entity_type: str) -> Callable:
 
     async def spell_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.spell:
         choices = await get_spell_choices(inter)
-        result: gamedata.spell = search(choices, arg, lambda e: e.name)[0]
+        result: gamedata.spell = search(choices, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That spell doesn't exist")
         return result
@@ -265,43 +269,43 @@ def lookup_converter(entity_type: str) -> Callable:
         return result
 
     def background_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Background:
-        result: gamedata.Background = search(compendium.backgrounds, arg, lambda e: e.name)[0]
+        result: gamedata.Background = search(compendium.backgrounds, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That background doesn't exist")
         return result
 
     def feat_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.feat:
-        result: gamedata.feat = search(compendium.feats, arg, lambda e: e.name)[0]
+        result: gamedata.feat = search(compendium.feats, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That feat doesn't exist")
         return result
 
     def race_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.race:
-        result: gamedata.race = search(compendium.races + compendium.subraces, arg, lambda e: e.name)[0]
+        result: gamedata.race = search(compendium.races + compendium.subraces, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That race doesn't exist")
         return result
 
     def racefeat_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> RaceFeature:
-        result: RaceFeature = search(compendium.rfeats + compendium.subrfeats, arg, lambda e: e.name)[0]
+        result: RaceFeature = search(compendium.rfeats + compendium.subrfeats, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That racial feature doesn't exist")
         return result
 
     def class_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Class:
-        result: gamedata.Class = search(compendium.classes, arg, lambda e: e.name)[0]
+        result: gamedata.Class = search(compendium.classes, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That class doesn't exist")
         return result
 
     def subclass_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Subclass:
-        result: gamedata.Subclass = search(compendium.subclasses, arg, lambda e: e.name)[0]
+        result: gamedata.Subclass = search(compendium.subclasses, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That class doesn't exist")
         return result
 
     def classfeat_converter(_: disnake.ApplicationCommandInteraction, arg: str) -> ClassFeature:
-        result: ClassFeature = search(compendium.cfeats + compendium.optional_cfeats, arg, lambda e: e.name)[0]
+        result: ClassFeature = search(compendium.cfeats + compendium.optional_cfeats, arg, slash_match_key)[0]
         if result is None:
             raise ValueError("That class feature doesn't exist")
         return result

--- a/gamedata/shared.py
+++ b/gamedata/shared.py
@@ -119,9 +119,11 @@ class LimitedUse(Sourced):
 
 
 class CachedSourced(Sourced):
-    def __init__(self, name, entity_type, **kwargs):
+    def __init__(self, name, entity_type, has_image=False, has_token=False, **kwargs):
         self.name = name
         self.entity_type = entity_type
+        self.has_image = has_image
+        self.has_token = has_token
         Sourced.__init__(
             self,
             homebrew=kwargs["homebrew"],
@@ -138,6 +140,8 @@ class CachedSourced(Sourced):
         return cls(
             d["name"],
             d["entity_type"],
+            d.get("has_image", False),
+            d.get("has_token", False),
             homebrew=d["homebrew"],
             source=d["source"],
             entity_id=d["entity_id"],
@@ -149,6 +153,8 @@ class CachedSourced(Sourced):
         return {
             "name": self.name,
             "entity_type": self.entity_type,
+            "has_image": self.has_image,
+            "has_token": self.has_token,
             "homebrew": self.homebrew,
             "source": self.source,
             "entity_id": self.entity_id,

--- a/gamedata/shared.py
+++ b/gamedata/shared.py
@@ -1,6 +1,6 @@
 import abc
 
-__all__ = ("Sourced", "Trait", "LimitedUse")
+__all__ = ("Sourced", "Trait", "LimitedUse", "CachedSourced")
 
 
 class Sourced(abc.ABC):
@@ -116,3 +116,42 @@ class LimitedUse(Sourced):
             entitlement_entity_id=parent.entitlement_entity_id,
             entitlement_entity_type=parent.entitlement_entity_type,
         )
+
+
+class CachedSourced(Sourced):
+    def __init__(self, name, entity_type, **kwargs):
+        self.name = name
+        self.entity_type = entity_type
+        Sourced.__init__(
+            self,
+            homebrew=kwargs["homebrew"],
+            source=kwargs["source"],
+            entity_id=kwargs.get("entity_id"),
+            page=kwargs.get("page"),
+            url=kwargs.get("url"),
+            is_free=kwargs.get("is_free"),
+            is_legacy=kwargs.get("is_legacy"),
+        )
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(
+            d["name"],
+            d["entity_type"],
+            homebrew=d["homebrew"],
+            source=d["source"],
+            entity_id=d["entity_id"],
+            is_free=d["is_free"],
+            is_legacy=d["is_legacy"],
+        )
+
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "entity_type": self.entity_type,
+            "homebrew": self.homebrew,
+            "source": self.source,
+            "entity_id": self.entity_id,
+            "is_free": self.is_free,
+            "is_legacy": self.is_legacy,
+        }


### PR DESCRIPTION
### Summary

- Adds slash commands to the various lookup commands.
- Ensures that entitlements are validated against and enforced on lookup, and works for homebrew as well.
- Caches a minimal version of monsters, spells, and items to reduce load for servers with a lot of homebrew.
- Allows the user to search by source slug (`/lookup subclass tcoe`) or by homebrew (`/lookup monster homebrew`)
  - This won't purely limit the results, but will focus it down more

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
