### PR TITLE
DCv2 post launch touch ups

### DIFF
--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -229,6 +229,8 @@ class DCV2AutoParser:
                 case _:
                     self.parse_children(prop["children"], save=save)
         except Exception as e:
+            if isinstance(e, AutoParserException):
+                raise e
             raise AutoParserException(prop, "Auto Parser encounter an error parsing a property") from e
 
     def parse_children(self, children, *, save=False):

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -644,8 +644,11 @@ class SheetManager(commands.Cog):
         D&D Beyond:
             Private sheets can be imported if you have linked your DDB and Discord accounts.  Otherwise, the sheet needs to be publicly shared.
 
-        Dicecloud:
-            Share your character with `avrae` on Dicecloud to import private sheets. In v1, give `avrae` edit permissions for live updates.
+        Dicecloud v1:
+            Share your character with `avrae` on Dicecloud v1 to import private sheets, and give edit permissions for live updates.
+
+        Dicecloud v2:
+            Share your character with `avrae` on Dicecloud v2 to import private sheets. Tag actions with `avrae:no_import` if you don't want them to be imported, and `avrae:parse_only` if you don't want them to be loaded from Beyond.
 
         Gsheet:
             The sheet must be shared with directly with Avrae or be publicly viewable to anyone with the link.

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -404,8 +404,9 @@ class DicecloudV2Parser(SheetLoaderABC):
         actions = []
         consumables = []
         for attack in self._by_type["action"]:
+            tags = attack["tags"]
             # we don't want to parse inactive actions
-            if not attack.get("inactive"):
+            if not attack.get("inactive") and "avrae:no_import" not in tags:
                 try:
                     aname = attack["name"]
                 except KeyError:
@@ -428,7 +429,7 @@ class DicecloudV2Parser(SheetLoaderABC):
                 consumables += self._consumables_from_resources(attack["resources"])
 
                 # don't bother parsing if a compendium action is found
-                if atk_actions := self.persist_actions_for_name(aname):
+                if "avrae:parse_only" not in tags and (atk_actions := self.persist_actions_for_name(aname)):
                     actions += atk_actions
                     continue
                 atk = self.parse_attack(attack)

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -317,7 +317,7 @@ class DicecloudV2Parser(SheetLoaderABC):
                                 "value": int(attr.get("value", uses)),
                                 "minv": "0",
                                 "maxv": str(uses),
-                                "reset": RESET_MAP[attr.get("reset")],
+                                "reset": RESET_MAP.get(attr.get("reset")),
                                 "display_type": display_type,
                             }
                         )
@@ -420,7 +420,7 @@ class DicecloudV2Parser(SheetLoaderABC):
                             "value": attack.get("usesLeft", uses),
                             "minv": "0",
                             "maxv": str(uses),
-                            "reset": RESET_MAP[attack.get("reset")],
+                            "reset": RESET_MAP.get(attack.get("reset")),
                             "display_type": display_type,
                         }
                     )
@@ -572,7 +572,7 @@ class DicecloudV2Parser(SheetLoaderABC):
                             "value": spell.get("usesLeft", 0),
                             "minv": "0",
                             "maxv": str(uses),
-                            "reset": RESET_MAP[spell.get("reset")],
+                            "reset": RESET_MAP.get(spell.get("reset")),
                             "display_type": display_type,
                         }
                     )
@@ -656,12 +656,12 @@ class DicecloudV2Parser(SheetLoaderABC):
             node = e.node
             if isinstance(e.__cause__, KeyError):
                 raise ExternalImportError(
-                    f"{node['type']} {node.get('name') or node.get('variableName') or node['_id']} could not get key"
-                    f" {e.__cause__.args[0]}"
+                    f"{node['type']} {node.get('name') or node.get('variableName') or node['_id']} in"
+                    f" {atk_prop.get('name') or atk_prop['id']} could not get key {e.__cause__.args[0]}"
                 )
             raise ExternalImportError(
-                f"{node['type']} {node.get('name') or node.get('variableName') or node['_id']} could not import"
-                " properly"
+                f"{node['type']} {node.get('name') or node.get('variableName') or node['_id']} in"
+                f" {atk_prop.get('name') or atk_prop['id']} could not import properly"
             ) from e
         if auto is None:
             log.debug("Oops! Automation is None!")
@@ -709,7 +709,7 @@ class DicecloudV2Parser(SheetLoaderABC):
                         "value": full_attr.get("value", uses),
                         "minv": "0",
                         "maxv": str(uses),
-                        "reset": RESET_MAP[full_attr.get("reset")],
+                        "reset": RESET_MAP.get(full_attr.get("reset")),
                         "display_type": display_type,
                     }
                 )


### PR DESCRIPTION
### Summary
Reset types that are non-standard (events that do not coincide with long or short rest) now default to None, rather than raising an error.

Errors in action parsing now show both the action/spell and the property that caused the error (before it would just show the action/spell because the exception kept getting reraised with the new parent property)

If an action is tagged with `avrae:no_import` then it will not be imported or parsed, and if it's tagged with `avrae:parse_only` then it will not be attempted to be loaded from compendium, only parsed.
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
