### PR TITLE
Jokeen/2022w50

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -744,7 +744,7 @@ class AliasAction:
 
         :rtype: int or None
         """
-        return self.activation_type.value if self.activation_type is not None else None
+        return self._action.activation_type.value if self._action.activation_type is not None else None
 
     @property
     def activation_type_name(self):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1063,7 +1063,7 @@ class InitTracker(commands.Cog):
         Rolls an attack against another combatant.
         __**Valid Arguments**__
         {VALID_AUTOMATION_ARGS}
-        -custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
+        custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
         """,
     )
     async def attack(self, ctx, atk_name=None, *, args=""):
@@ -1092,7 +1092,7 @@ class InitTracker(commands.Cog):
         Rolls an attack as another combatant.
         __**Valid Arguments**__
         {VALID_AUTOMATION_ARGS}
-        -custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
+        custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
         """,
     )
     async def aoo(self, ctx, combatant_name, atk_name=None, *, args=""):

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -704,10 +704,15 @@ class Lookup(commands.Cog):
         embed_queue[0].set_thumbnail(url=monster.get_image_url())
         await Stats.increase_stat(ctx, "monsters_looked_up_life")
 
-        if pm or (visible and pm_dm and req_dm_monster):
-            await ctx.author.send(embeds=embed_queue)
-        else:
-            await destination.send(embeds=embed_queue)
+        for i, embed in enumerate(embed_queue):
+            if pm or (visible and pm_dm and req_dm_monster):
+                await ctx.author.send(embed=embed)
+            elif i == 0:
+                # Ensure the first embed is sent as a reply
+                await destination.send(embed=embed)
+            else:
+                # and the rest are to the channel
+                await destination.channel.send(embed=embed)
 
     @commands.command()
     async def monimage(self, ctx, *, name: str):
@@ -957,7 +962,14 @@ class Lookup(commands.Cog):
             embed_queue[0].set_thumbnail(url=spell.image)
 
         await Stats.increase_stat(ctx, "spells_looked_up_life")
-        await destination.send(embeds=embed_queue)
+
+        for i, embed in enumerate(embed_queue):
+            if i == 0:
+                # Ensure the first embed is sent as a reply
+                await destination.send(embed=embed)
+            else:
+                # and the rest are to the channel
+                await destination.channel.send(embed=embed)
 
     # ==== items ====
     @commands.command(name="item")

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -248,7 +248,7 @@ class Lookup(commands.Cog):
                 await inter.send("Race not found.", ephemeral=True)
                 return
             name = name[0]
-        await self._check_access(inter, name, ["race"])
+        await self._check_access(inter, name, ["race", "subrace"])
         return await self._race(inter, name)
 
     @slash_race.autocomplete("name")

--- a/cogs5e/models/embeds.py
+++ b/cogs5e/models/embeds.py
@@ -217,14 +217,17 @@ def add_fields_from_args(embed, _fields):
     return embed
 
 
-def get_long_field_args(text, title, inline=False, chunk_size=1024):
+def get_long_field_args(text, title, inline=False, chunk_size=1019):
     """Returns a list of dicts (to pass as kwargs) given a long text."""
     chunks = chunk_text(text, chunk_size)
     if not chunks:
         return []
-    out = [{"name": title, "value": chunks[0].strip(), "inline": inline}]
+    opened_block = chunks[0].count("```") % 2
+    out = [{"name": title, "value": chunks[0].strip() + ("\n```" * opened_block), "inline": inline}]
     for chunk in chunks[1:]:
-        out.append({"name": "** **", "value": chunk.strip(), "inline": inline})
+        chunk = ("```\n" * opened_block) + chunk
+        opened_block = chunk.count("```") % 2
+        out.append({"name": "** **", "value": chunk.strip() + ("\n```" * opened_block), "inline": inline})
     return out
 
 

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -470,6 +470,17 @@ class DicecloudV2Parser(SheetLoaderABC):
                         if vname in SKILL_NAMES:
                             skills[vname] = skill_obj
 
+        if missing_skills := set(SKILL_NAMES) - set(skills):
+            raise ExternalImportError(
+                f"Your sheet is missing the following skill{'s' if len(missing_skills)>1 else ''}:"
+                f" {', '.join(missing_skills)}"
+            )
+        if missing_saves := set(SAVE_NAMES) - set(saves):
+            raise ExternalImportError(
+                f"Your sheet is missing the following save{'s' if len(missing_saves)>1 else ''}:"
+                f" {', '.join(missing_saves)}"
+            )
+
         return Skills(skills), Saves(saves)
 
     def get_resistances(self) -> Resistances:
@@ -676,7 +687,8 @@ class DicecloudV2Parser(SheetLoaderABC):
         return attack
 
     def persist_actions_for_name(self, name):
-        """Since compendium actions can be found in spells, actions, and features, we need to keep track of what we've seen"""
+        """Since compendium actions can be found in spells, actions, and features, we need to keep track of what we've seen
+        """
         actions = []
         if (g_actions := get_actions_for_name(name)) and len(g_actions) <= 20:
             for g_action in g_actions:

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -687,7 +687,8 @@ class DicecloudV2Parser(SheetLoaderABC):
         return attack
 
     def persist_actions_for_name(self, name):
-        """Since compendium actions can be found in spells, actions, and features, we need to keep track of what we've seen
+        """
+        Since compendium actions can be found in spells, actions, and features, we need to keep track of what we've seen
         """
         actions = []
         if (g_actions := get_actions_for_name(name)) and len(g_actions) <= 20:

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -788,7 +788,9 @@ class Customization(commands.Cog):
             cvar = character.get_scope_locals().get(name)
             if cvar is None:
                 return await ctx.send("This cvar is not defined.")
-            return await send_long_code_text(ctx, outside_codeblock=f"**{name}**:", inside_codeblock=cvar)
+            return await send_long_code_text(
+                ctx, outside_codeblock=f"**{name}**:".replace("_", "\_"), inside_codeblock=cvar
+            )
 
         helpers.set_cvar(character, name, value)
 
@@ -830,7 +832,9 @@ class Customization(commands.Cog):
         """Lists all cvars for the currently active character."""
         character: Character = await ctx.get_character()
         await ctx.send(
-            "{}'s character variables:\n{}".format(character.name, ", ".join(sorted(character.cvars.keys())))
+            "{}'s character variables:\n{}".format(character.name, ", ".join(sorted(character.cvars.keys()))).replace(
+                "_", "\_"
+            )
         )
 
     @commands.group(invoke_without_command=True, aliases=["uvar"])

--- a/tests/e2e/cogs/initTracker_test.py
+++ b/tests/e2e/cogs/initTracker_test.py
@@ -169,10 +169,10 @@ class TestYourStandardInitiative:
             await dhttp.drain()
 
             avrae.message(f'!i hp "{combatant}" set 100')
-            avrae.message(f'!i a test -t "{combatant}" hit -custom -d 10[foo] silvered')
+            avrae.message(f'!i a test -t "{combatant}" hit custom -d 10[foo] silvered')
             await dhttp.drain()
             assert (await active_combat(avrae)).get_combatant(combatant).hp == 90
-            avrae.message(f'!i a test -t "{combatant}" hit -custom -d 10[foo]')
+            avrae.message(f'!i a test -t "{combatant}" hit custom -d 10[foo]')
             await dhttp.drain()
             assert (await active_combat(avrae)).get_combatant(combatant).hp == 85
 
@@ -183,10 +183,10 @@ class TestYourStandardInitiative:
             await dhttp.drain()
 
             avrae.message(f'!i hp "{combatant}" set 100')
-            avrae.message(f'!i a test -t "{combatant}" hit -custom -d 10[bar] magical')
+            avrae.message(f'!i a test -t "{combatant}" hit custom -d 10[bar] magical')
             await dhttp.drain()
             assert (await active_combat(avrae)).get_combatant(combatant).hp == 90
-            avrae.message(f'!i a test -t "{combatant}" hit -custom -d 10[bar]')
+            avrae.message(f'!i a test -t "{combatant}" hit custom -d 10[bar]')
             await dhttp.drain()
             assert (await active_combat(avrae)).get_combatant(combatant).hp == 85
 

--- a/utils/help.py
+++ b/utils/help.py
@@ -66,6 +66,8 @@ class AvraeHelp(HelpCommand):
             self.embed_paginator.extend_field(command.description)
 
         if command.help:
+            # Strip left spaces (but not tabs) from help docs, as Discord inconsistently does this based on device
+            command.help = "\n".join([line.lstrip(" ") for line in command.help.splitlines()])
             try:
                 self.embed_paginator.extend_field(command.help)
             except ValueError:


### PR DESCRIPTION
### Summary

- Fixes an infinite loop on `character().actions`
- Goes back to using an embed queue for larger lookup commands
- Escapes underscores in cvar names on `!cvar list` and `!cvar <name>`
- Removes the `-` in the `custom` arg from the various helps that mention it
- Strips spaces from each life of help on display, to fix an inconsistency with how Discord outputs text on different devices
- Added basic method to try and fix issues with longer output splitting in the middle of code block tables
- Checks properly for subraces in `/lookup race` - Fixes #1896 
- Ensures Dicecloud v2 sheets actually have all of the necessary skills and saves

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
