### PR TITLE
RollEffectMetaVars can have unop and binops applied

### DIFF
--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -146,8 +146,8 @@ class RollEffectMetaVar:
         return self
 
     def __ceil__(self):
-        if diff := (self._total % 1):
-            return self + (1 - diff)
+        if self._total % 1:
+            return self // 1 + 1
         return self
 
     def __add__(self, other):

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -123,55 +123,86 @@ class RollEffectMetaVar:
         return bool(self._total)
 
     def __eq__(self, other):
-        return self._bin_op(other, "==")
+        return self._lbin_op(other, "==")
 
     def __lt__(self, other):
-        return self._bin_op(other, "<")
+        return self._lbin_op(other, "<")
 
     def __le__(self, other):
-        return self._bin_op(other, "<=")
+        return self._lbin_op(other, "<=")
 
     def __ne__(self, other):
-        return self._bin_op(other, "!=")
+        return self._lbin_op(other, "!=")
 
     def __gt__(self, other):
-        return self._bin_op(other, ">")
+        return self._lbin_op(other, ">")
 
     def __ge__(self, other):
-        return self._bin_op(other, ">=")
+        return self._lbin_op(other, ">=")
 
     def __floor__(self):
+        if self._total % 1:
+            return self // 1
         return self
 
     def __ceil__(self):
+        if diff := (self._total % 1):
+            return self + (1 - diff)
         return self
 
     def __add__(self, other):
-        return self._bin_op(other, "+")
+        return self._lbin_op(other, "+")
 
     def __sub__(self, other):
-        return self._bin_op(other, "-")
+        return self._lbin_op(other, "-")
 
     def __mul__(self, other):
-        return self._bin_op(other, "*")
+        return self._lbin_op(other, "*")
 
     def __floordiv__(self, other):
-        return self._bin_op(other, "/")
+        return self._lbin_op(other, "//")
 
     def __truediv__(self, other):
-        return self._bin_op(other, "/")
+        return self._lbin_op(other, "/")
 
     def __mod__(self, other):
-        return self._bin_op(other, "%")
+        return self._lbin_op(other, "%")
 
-    def _bin_op(self, other, op):
+    def __radd__(self, other):
+        return self._rbin_op(other, "+")
+
+    def __rsub__(self, other):
+        return self._rbin_op(other, "-")
+
+    def __rmul__(self, other):
+        return self._rbin_op(other, "*")
+
+    def __rfloordiv__(self, other):
+        return self._rbin_op(other, "//")
+
+    def __rtruediv__(self, other):
+        return self._rbin_op(other, "/")
+
+    def __rmod__(self, other):
+        return self._rbin_op(other, "%")
+
+    def _lbin_op(self, other, op):
         if isinstance(other, (int, float)):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, d20.Literal(other)), self._expr.comment))
         elif isinstance(other, d20.Number):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, other), self._expr.comment))
         elif isinstance(other, RollEffectMetaVar):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, other._expr), self._expr.comment))
-        raise TypeError("Rolls cannot operate with this type")
+        raise NotImplementedError
+
+    def _rbin_op(self, other, op):
+        if isinstance(other, (int, float)):
+            return RollEffectMetaVar(d20.Expression(d20.BinOp(d20.Literal(other), op, self._expr), self._expr.comment))
+        elif isinstance(other, d20.Number):
+            return RollEffectMetaVar(d20.Expression(d20.BinOp(other, op, self._expr), self._expr.comment))
+        elif isinstance(other, RollEffectMetaVar):
+            return RollEffectMetaVar(d20.Expression(d20.BinOp(other._expr, op, self._expr), self._expr.comment))
+        raise NotImplementedError
 
     def __pos__(self):
         return RollEffectMetaVar(d20.Expression(d20.UnOp("+", self._expr), self._expr.comment))

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -119,5 +119,62 @@ class RollEffectMetaVar:
     def __float__(self):
         return float(self._total)
 
+    def __bool__(self):
+        return bool(self._total)
+
     def __eq__(self, other):
-        return self._total == other
+        return self._bin_op(other, "==")
+
+    def __lt__(self, other):
+        return self._bin_op(other, "<")
+
+    def __le__(self, other):
+        return self._bin_op(other, "<=")
+
+    def __ne__(self, other):
+        return self._bin_op(other, "!=")
+
+    def __gt__(self, other):
+        return self._bin_op(other, ">")
+
+    def __ge__(self, other):
+        return self._bin_op(other, ">=")
+
+    def __floor__(self):
+        return self
+
+    def __ceil__(self):
+        return self
+
+    def __add__(self, other):
+        return self._bin_op(other, "+")
+
+    def __sub__(self, other):
+        return self._bin_op(other, "-")
+
+    def __mul__(self, other):
+        return self._bin_op(other, "*")
+
+    def __floordiv__(self, other):
+        return self._bin_op(other, "/")
+
+    def __truediv__(self, other):
+        return self._bin_op(other, "/")
+
+    def __mod__(self, other):
+        return self._bin_op(other, "%")
+
+    def _bin_op(self, other, op):
+        if isinstance(other, (int, float)):
+            return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, d20.Literal(other)), self._expr.comment))
+        elif isinstance(other, d20.Number):
+            return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, other), self._expr.comment))
+        elif isinstance(other, RollEffectMetaVar):
+            return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, other._expr), self._expr.comment))
+        raise TypeError("Rolls cannot operate with this type")
+
+    def __pos__(self):
+        return RollEffectMetaVar(d20.Expression(d20.UnOp("+", self._expr), self._expr.comment))
+
+    def __neg__(self):
+        return RollEffectMetaVar(d20.Expression(d20.UnOp("-", self._expr), self._expr.comment))

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -124,22 +124,22 @@ class RollEffectMetaVar:
         return bool(self._total)
 
     def __eq__(self, other):
-        return self._lbin_op(other, "==")
+        return self._total == other
 
     def __lt__(self, other):
-        return self._lbin_op(other, "<")
+        return self._total < other
 
     def __le__(self, other):
-        return self._lbin_op(other, "<=")
+        return self._total <= other
 
     def __ne__(self, other):
-        return self._lbin_op(other, "!=")
+        return self._total != other
 
     def __gt__(self, other):
-        return self._lbin_op(other, ">")
+        return self._total > other
 
     def __ge__(self, other):
-        return self._lbin_op(other, ">=")
+        return self._total >= other
 
     def __floor__(self):
         return math.floor(self._total)

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -189,8 +189,6 @@ class RollEffectMetaVar:
     def _lbin_op(self, other, op):
         if isinstance(other, (int, float)):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, d20.Literal(other)), self._expr.comment))
-        elif isinstance(other, d20.Number):
-            return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, other), self._expr.comment))
         elif isinstance(other, RollEffectMetaVar):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(self._expr, op, other._expr), self._expr.comment))
         raise NotImplementedError
@@ -198,8 +196,6 @@ class RollEffectMetaVar:
     def _rbin_op(self, other, op):
         if isinstance(other, (int, float)):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(d20.Literal(other), op, self._expr), self._expr.comment))
-        elif isinstance(other, d20.Number):
-            return RollEffectMetaVar(d20.Expression(d20.BinOp(other, op, self._expr), self._expr.comment))
         elif isinstance(other, RollEffectMetaVar):
             return RollEffectMetaVar(d20.Expression(d20.BinOp(other._expr, op, self._expr), self._expr.comment))
         raise NotImplementedError

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -3,6 +3,7 @@ from functools import cached_property
 
 import d20
 import draconic
+import math
 
 from utils.dice import RerollableStringifier
 from . import Effect
@@ -141,14 +142,10 @@ class RollEffectMetaVar:
         return self._lbin_op(other, ">=")
 
     def __floor__(self):
-        if self._total % 1:
-            return self // 1
-        return self
+        return math.floor(self._total)
 
     def __ceil__(self):
-        if self._total % 1:
-            return self // 1 + 1
-        return self
+        return math.ceil(self._total)
 
     def __add__(self, other):
         return self._lbin_op(other, "+")


### PR DESCRIPTION
### Summary
Allows RollEffectMetaVars to be operated on directly with pythonic operations, making automation simpler to import and write.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
