### PR TITLE
DCv2, a few more problems

### DIFF
--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -179,7 +179,11 @@ class DCV2AutoParser:
                     # all the checks for what exactly we're doing here
                     magical = "magical" in prop["tags"]
                     healing = prop["damageType"] == "healing"
-                    effects = [str(effect["amount"]["value"]).strip() for effect in prop["amount"].get("effects", [])]
+                    effects = [
+                        str(effect["amount"]["value"]).strip()
+                        for effect in prop["amount"].get("effects", [])
+                        if effect["amount"]["value"] is not None
+                    ]
                     damage_dice = str(prop["amount"]["value"]) + "".join(
                         effect if effect[0] in "+-" else f"+{effect}" for effect in effects
                     )

--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -215,7 +215,7 @@ class DCV2AutoParser:
                     self.parse_children(prop["children"], save=save)
                 case "note":
                     # we only use the summary here, since it's all DC would display
-                    desc = prop.get("summary")
+                    desc = prop.get("summary", {}).get("value")
                     if desc is not None:
                         self.text.append(desc)
                     self.parse_children(prop["children"], save=save)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -675,7 +675,7 @@ class SheetManager(commands.Cog):
             Share your character with `avrae` on Dicecloud v1 to import private sheets, and give edit permissions for live updates.
 
         Dicecloud v2:
-            Share your character with `avrae` on Dicecloud v2 to import private sheets. Tag actions with `avrae:no_import` if you don't want them to be imported, and `avrae:parse_only` if you don't want them to be loaded from Beyond.
+            Share your character with `avrae` on Dicecloud v2 to import private sheets. Tag actions, spells, and features with `avrae:no_import` if you don't want them to be imported, and actions with `avrae:parse_only` if you don't want them to be loaded from Beyond.
 
         Gsheet:
             The sheet must be shared with directly with Avrae or be publicly viewable to anyone with the link.

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -469,7 +469,9 @@ class DicecloudV2Parser(SheetLoaderABC):
         # calculate skills and saves from skill properties
         for skill in self._by_type["skill"]:
             if not skill.get("inactive"):
-                vname = skill["variableName"]
+                vname = skill.get("variableName")
+                if not vname:
+                    continue
                 skill_obj = Skill(
                     # proficiency can be 0.49 or 0.5 for half round down or up, but we just want 0.5
                     skill["value"],

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -530,7 +530,7 @@ class DicecloudV2Parser(SheetLoaderABC):
     def get_actions(self):
         actions = []
         for f in self._by_type["feature"]:
-            if not f.get("inactive"):
+            if not f.get("inactive") and "avrae:no_import" not in f["tags"]:
                 actions += self.persist_actions_for_name(f.get("name"))
 
         return actions
@@ -568,6 +568,8 @@ class DicecloudV2Parser(SheetLoaderABC):
         actions = []
 
         for spell in self._by_type["spell"]:
+            if "avrae:no_import" in spell["tags"]:
+                continue
             # unprepared spells are inactive, so we need to specifically check how it is deactivated
             if not (spell.get("deactivatedByAncestor") or spell.get("deactivatedByToggle")):
                 spell_actions = self.persist_actions_for_name(spell["name"])


### PR DESCRIPTION
### Summary
Instead of raising an exception if no variable name is found for a skill, just skip it.

The value of the summary of notes should be used, rather than just the summary, as it is a dict, but we want a string.

Effects that have no value are returned as None rather than 0, so we should be sure to recognize these and skip them when they crop up.

Features and spells should also be taggable with no_import, so that features such as Crimson Rite doesn't end up importing all of the separate features.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
