### PR TITLE
Jan 9th Hotfix

### DIFF
--- a/cogs5e/models/embeds.py
+++ b/cogs5e/models/embeds.py
@@ -44,7 +44,7 @@ class EmbedWithCharacter(disnake.Embed):
         super().__init__(**kwargs)
         if name:
             self.set_author(name=character.name)
-        if character.options.embed_image and image:
+        if character.options.embed_image and image and character.image:
             self.set_thumbnail(url=character.image)
         self.colour = character.get_color()
 

--- a/cogsmisc/tutorials/models.py
+++ b/cogsmisc/tutorials/models.py
@@ -181,7 +181,7 @@ class TutorialEmbed(EmbedWithAuthor):
                 text=f"{tstate.tutorial.name} | {ctx.prefix}tutorial skip to skip | {ctx.prefix}tutorial end to end"
             )
 
-        self._description = self.Empty
+        self._description = None
 
     # custom description handler that strips/dedents so we can use triple-quoted strings in our code
     @property

--- a/dbot.py
+++ b/dbot.py
@@ -16,6 +16,7 @@ from aiohttp import ClientOSError, ClientResponseError
 from disnake import ApplicationCommandInteraction
 from disnake.errors import Forbidden, HTTPException, NotFound
 from disnake.ext import commands
+from disnake.ext.commands import CommandSyncFlags
 from disnake.ext.commands.errors import CommandInvokeError
 
 from aliasing.errors import CollectableRequiresLicenses, EvaluationError
@@ -59,12 +60,15 @@ async def get_prefix(the_bot, message):
 
 class Avrae(commands.AutoShardedBot):
     def __init__(self, prefix, description=None, **options):
+        sync_flags = CommandSyncFlags(
+            sync_commands=False,  # this is set by launch_shard below, to prevent multiple clusters racing).
+            sync_commands_debug=config.TESTING,
+        )
         super().__init__(
             prefix,
             help_command=help_command,
             description=description,
-            sync_commands=False,  # this is set by launch_shard below, to prevent multiple clusters racing
-            sync_commands_debug=bool(config.TESTING),
+            command_sync_flags=sync_flags,
             activity=options.get("activity"),
             allowed_mentions=options.get("allowed_mentions"),
             intents=options.get("intents"),

--- a/dbot.py
+++ b/dbot.py
@@ -64,7 +64,7 @@ class Avrae(commands.AutoShardedBot):
             help_command=help_command,
             description=description,
             sync_commands=False,  # this is set by launch_shard below, to prevent multiple clusters racing
-            sync_commands_debug=config.TESTING,
+            sync_commands_debug=bool(config.TESTING),
             activity=options.get("activity"),
             allowed_mentions=options.get("allowed_mentions"),
             intents=options.get("intents"),

--- a/dbot.py
+++ b/dbot.py
@@ -14,7 +14,7 @@ import psutil
 import sentry_sdk
 from aiohttp import ClientOSError, ClientResponseError
 from disnake import ApplicationCommandInteraction
-from disnake.errors import Forbidden, HTTPException, InvalidArgument, NotFound
+from disnake.errors import Forbidden, HTTPException, NotFound
 from disnake.ext import commands
 from disnake.ext.commands.errors import CommandInvokeError
 
@@ -65,8 +65,13 @@ class Avrae(commands.AutoShardedBot):
             description=description,
             sync_commands=False,  # this is set by launch_shard below, to prevent multiple clusters racing
             sync_commands_debug=config.TESTING,
-            **options,
+            activity=options.get("activity"),
+            allowed_mentions=options.get("allowed_mentions"),
+            intents=options.get("intents"),
+            chunk_guilds_at_startup=options.get("chunk_guilds_at_startup"),
         )
+        self.pm_help = options.get("pm_help")
+        self.testing = options.get("testing")
         self.state = "init"
 
         # dbs
@@ -143,7 +148,7 @@ class Avrae(commands.AutoShardedBot):
                     scope.set_tag("guild.name", str(ctx.guild))
             sentry_sdk.capture_exception(exception)
 
-    async def launch_shards(self):
+    async def launch_shards(self, ignore_session_start_limit: bool = False):
         # set up my shard_ids
         async with clustering.coordination_lock(self.rdb):
             await clustering.coordinate_shards(self)
@@ -317,7 +322,7 @@ async def command_errors(ctx, error):
         elif isinstance(original, NotFound):
             return await ctx.send("Error: I tried to edit or delete a message that no longer exists.")
 
-        elif isinstance(original, (ClientResponseError, InvalidArgument, asyncio.TimeoutError, ClientOSError)):
+        elif isinstance(original, (ClientResponseError, TypeError, ValueError, asyncio.TimeoutError, ClientOSError)):
             return await ctx.send("Error in Discord API. Please try again.")
 
         elif isinstance(original, HTTPException):

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -119,7 +119,7 @@ def handle_source_footer(
     :param allow_overwrite: Whether or not to allow overwriting an existing footer text.
     """
     text_pieces = []
-    icon_url = embed.Empty
+    icon_url = None
     book = compendium.book_by_source(sourced.source)
     if text is not None:
         text_pieces.append(text)
@@ -147,7 +147,7 @@ def handle_source_footer(
         text_pieces.append("Legacy content.")
 
     # do the writing
-    text = " | ".join(text_pieces) or embed.Empty
+    text = " | ".join(text_pieces) or None
     if not allow_overwrite:
         if embed.footer.text:
             text = embed.footer.text

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -353,7 +353,7 @@ class Monster(StatBlock, Sourced):
 
     def get_image_url(self):
         """Returns a monster's image URL."""
-        return self.image_url or ""
+        return self.image_url or None
 
     def get_token_url(self, is_sub=False):
         """Returns a monster's token URL."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ d20==1.1.2
 aiobotocore==2.1.0
 aioredis==1.3.1
 cachetools==4.2.2
-disnake~=2.5.1
+disnake~=2.7.0
 gspread==3.7.0
 httplib2==0.19.0
 launchdarkly-server-sdk==7.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,12 +37,12 @@ def event_loop():
 
 # the http fixture
 @pytest.fixture(scope="session")
-def dhttp():
+def dhttp(event_loop):
     """
     The HTTP proxy
     We use this to check what the bot has sent and make sure it's right
     """
-    return MockDiscordHTTP()
+    return MockDiscordHTTP(loop=event_loop)
 
 
 # the ldclient fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -176,9 +176,9 @@ def compare_embeds(request_embed, embed, *, regex: bool = True):
 def embed_assertions(embed):
     """Checks to ensure that the embed is valid."""
     assert len(embed) <= 6000
-    assert len(embed.title) <= 256
-    assert len(embed.description) <= 4096
-    assert len(embed.fields) <= 25
+    assert embed.title is None or len(embed.title) <= 256
+    assert embed.description is None or len(embed.description) <= 4096
+    assert embed.fields is None or len(embed.fields) <= 25
     for field in embed.fields:
         assert 0 < len(field.name) <= 256
         assert 0 < len(field.value) <= 1024
@@ -198,9 +198,10 @@ def message_content_check(request: "Request", content: str = None, *, regex: boo
             assert request.data.get("content") == content
     if embed:
         embed_data = request.data.get("embeds")
-        assert embed_data is not None and embed_data
-        embed_assertions(disnake.Embed.from_dict(embed_data[0]))
-        compare_embeds(embed_data[0], embed.to_dict(), regex=regex)
+        if embed_data is not None:
+            assert embed_data
+            embed_assertions(disnake.Embed.from_dict(embed_data[0]))
+            compare_embeds(embed_data[0], embed.to_dict(), regex=regex)
     return match
 
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -3,7 +3,7 @@ import sys
 
 # ==== bot config constants / env vars ====
 TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
-TESTING = os.environ.get("TESTING") or "test" in sys.argv
+TESTING = bool(os.environ.get("TESTING")) or "test" in sys.argv
 ENVIRONMENT = os.getenv("ENVIRONMENT", "production" if not TESTING else "development")
 GIT_COMMIT_SHA = os.getenv("GIT_COMMIT_SHA")
 NUM_CLUSTERS = int(os.getenv("NUM_CLUSTERS")) if "NUM_CLUSTERS" in os.environ else None

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -498,9 +498,9 @@ def reconcile_adv(adv=False, dis=False, eadv=False) -> enums.AdvantageType:
 
 
 def maybe_http_url(url: str):
-    """Returns a url if one found, otherwise blank string."""
+    """Returns a url if one found, otherwise None."""
     # Mainly used for embed.set_thumbnail(url=url)
-    return url if "http" in url else ""
+    return url if "http" in url else None
 
 
 def exactly_one(iterable):


### PR DESCRIPTION
### Summary
Discord's API updated earlier tonight to have stricter type enforcement on Falsey values, which broke a number of base commands and a significant amount of user aliases. This updates Avrae to the newest 2.7.0 version of Disnake, which supports that API change. 

In addition to changes required to handle those Falsey values, the library update also changed the `AutoShardedBot` class to not use `**kwargs`, and so this also updates the code to use specific kwargs in the `super().__init__()` and not just star unpacking all of them.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
