### PR TITLE
Fix edge case rounding error in coinpurse autoconvert methods

### DIFF
--- a/tests/unit/coinpurse_test.py
+++ b/tests/unit/coinpurse_test.py
@@ -75,6 +75,7 @@ async def test_coin_autoconvert_up():
     assert Coinpurse(pp=10, gp=9, ep=1, sp=4, cp=1234).consolidate_coins() == CoinsArgs(
         pp=2, gp=-7, ep=-1, sp=-2, cp=-1230
     )
+    assert Coinpurse(pp=0, gp=410, ep=1, sp=4, cp=9).consolidate_coins() == CoinsArgs(pp=41, gp=-410)
 
 
 async def test_coin_compactstring():


### PR DESCRIPTION
### Summary
Sometimes the convert methods would be off by 1cp due to floating point rounding errors; this makes them all operate using integer arithmetic. I haven't tested this locally but I did add a unit test for one random coinpurse that did make it round (encountered in the wild).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
