### PR TITLE
Feb 22, 2023 Hotfix

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -800,7 +800,7 @@ class AliasCoinpurse:
 
     def __getattr__(self, item):
         if item not in COIN_TYPES:
-            raise ValueError(f"{item} is not valid coin.")
+            raise AttributeError(f"{item} is not valid coin.")
         return getattr(self._coinpurse, item)
 
     def __getitem__(self, item):

--- a/aliasing/api/statblock.py
+++ b/aliasing/api/statblock.py
@@ -563,7 +563,7 @@ class AliasSkills:
 
     def __getattr__(self, item):
         if item not in self._skills.skills:
-            raise ValueError(f"{item} is not a skill.")
+            raise AttributeError(f"{item} is not a skill.")
         return AliasSkill(self._skills.__getattr__(item))
 
     def __getitem__(self, item):


### PR DESCRIPTION
### Summary
Change ValueError's to AttributeErrors to fix an issue with the Starred operator

The issue apparently existed beforehand, when going to assign either `AliasSkills` or `AliasCoinpurse` inside of a tuple, list, etc, but the Starred operator causes it to break if either was in a multiassignment as well, making it a much more noticeable and prevalent issue.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
