### PR TITLE
Jokeen/2023w11

### DIFF
--- a/aliasing/api/character.py
+++ b/aliasing/api/character.py
@@ -181,7 +181,7 @@ class AliasCharacter(AliasStatBlock):
         :param str minVal: The minimum value of the counter. Supports :ref:`cvar-table` parsing.
         :param str maxVal: The maximum value of the counter. Supports :ref:`cvar-table` parsing.
         :param str reset: One of ``'short'``, ``'long'``, ``'hp'``, ``'none'``, or ``None``.
-        :param str dispType: Either ``None``, ``'bubble'``, or ``'square'``.
+        :param str dispType: Either ``None``, ``'bubble'``, ``'square'``, ``'hex'``, or ``'star'``.
         :param str reset_to: The value the counter should reset to. Supports :ref:`cvar-table` parsing.
         :param str reset_by: How much the counter should change by on a reset. Supports dice but not cvars.
         :param str title: The title of the counter.
@@ -217,7 +217,7 @@ class AliasCharacter(AliasStatBlock):
         :param str minVal: The minimum value of the counter. Supports :ref:`cvar-table` parsing.
         :param str maxVal: The maximum value of the counter. Supports :ref:`cvar-table` parsing.
         :param str reset: One of ``'short'``, ``'long'``, ``'hp'``, ``'none'``, or ``None``.
-        :param str dispType: Either ``None``, ``'bubble'``, or ``'square'``.
+        :param str dispType: Either ``None``, ``'bubble'``, ``'square'``, ``'hex'``, or ``'star'``.
         :param str reset_to: The value the counter should reset to. Supports :ref:`cvar-table` parsing.
         :param str reset_by: How much the counter should change by on a reset. Supports dice but not cvars.
         :param str title: The title of the counter.
@@ -527,7 +527,7 @@ class AliasCustomCounter:
     @property
     def display_type(self):
         """
-        Returns the cc's display type. (None, 'bubble', 'square')
+        Returns the cc's display type. (None, 'bubble', 'square', 'hex', or 'star')
 
         :rtype: str
         """

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -21,7 +21,7 @@ from cogs5e.utils import actionutils, checkutils, gameutils, targetutils
 from cogs5e.utils.gameutils import resolve_strict_coins
 from cogs5e.utils.help_constants import *
 from gamedata.lookuputils import get_spell_choices, select_spell_full
-from utils import constants
+from utils.constants import COUNTER_BUBBLES
 from utils.argparser import argparse
 from utils.functions import confirm, maybe_mod, search, search_and_select, try_delete
 
@@ -89,16 +89,16 @@ class GameTrack(commands.Cog):
                 f"{character.spellbook.slots_str(level)} ({(value - old_slots):+})"
             )
 
+        bubble = COUNTER_BUBBLES["bubble"]
+        pact = COUNTER_BUBBLES["square"]
+
         # footer - pact vs non pact
         if character.spellbook.max_pact_slots is not None:
             embed.set_footer(
-                text=(
-                    f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used\n"
-                    f"{constants.FILLED_BUBBLE_ALT} / {constants.EMPTY_BUBBLE_ALT} = Pact Slot"
-                )
+                text=f"{bubble.filled} = Available / {bubble.empty} = Used\n{pact.filled} / {pact.empty} = Pact Slot"
             )
         else:
-            embed.set_footer(text=f"{constants.FILLED_BUBBLE} = Available / {constants.EMPTY_BUBBLE} = Used")
+            embed.set_footer(text=f"{bubble.filled} = Available / {bubble.filled} = Used")
 
         await ctx.send(embed=embed)
 
@@ -629,7 +629,7 @@ class GameTrack(commands.Cog):
         `-max <max value>` - The maximum value of the counter.
         `-min <min value>` - The minimum value of the counter.
         `-value <value>` - The initial value for the counter.
-        `-type <bubble|square|default>` - Whether the counter displays bubbles/squares to show remaining uses or numbers. Default - numbers.
+        `-type <bubble|square|hex|star|default>` - Whether the counter displays bubbles/squares/hexes/stars to show remaining uses or numbers. Default - numbers.
         `-resetto <value>` - The value to reset the counter to. Default - maximum.
         `-resetby <value>` - Rather than resetting to a certain value, modify the counter by this much per reset. Supports dice.
         """  # noqa: E501

--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -159,7 +159,7 @@ class CustomCounter:
             raise InvalidArgument("Invalid reset.")
         if any(c in name for c in ".$"):
             raise InvalidArgument("Invalid character in CC name.")
-        if display_type in ("bubble", "square") and (maxv is None or minv is None):
+        if display_type in constants.COUNTER_BUBBLES and (maxv is None or minv is None):
             raise InvalidArgument(f"{display_type.title()} display requires a max and min value.")
 
         # sanity checks
@@ -173,7 +173,7 @@ class CustomCounter:
         min_value = None
         if minv is not None:
             min_value = character.evaluate_math(minv)
-            if display_type in ("bubble", "square") and (min_value < 0):
+            if display_type in constants.COUNTER_BUBBLES and (min_value < 0):
                 raise InvalidArgument(f"{display_type.title()} display requires a min value of >= 0.")
 
         max_value = None
@@ -323,14 +323,9 @@ class CustomCounter:
         _max = self.get_max()
         _reset = self.RESET_MAP.get(self.reset_on)
 
-        if self.display_type == "bubble":
+        if self.display_type in constants.COUNTER_BUBBLES:
             assert self.max is not None
-            val = f"{bubble_format(self.value, _max)}\n"
-        elif self.display_type == "square":
-            assert self.max is not None
-            val = (
-                f"{bubble_format(self.value, _max, used_char=constants.EMPTY_BUBBLE_ALT, unused_char=constants.FILLED_BUBBLE_ALT)}\n"
-            )
+            val = f"{bubble_format(self.value, _max, chars=constants.COUNTER_BUBBLES[self.display_type])}\n"
         else:
             val = f"**Current Value**: {self.value}\n"
             if self.min is not None and self.max is not None:
@@ -350,14 +345,9 @@ class CustomCounter:
     def __str__(self):
         _max = self.get_max()
 
-        if self.display_type == "bubble":
+        if self.display_type in constants.COUNTER_BUBBLES:
             assert self.max is not None
-            out = bubble_format(self.value, _max)
-        elif self.display_type == "square":
-            assert self.max is not None
-            out = bubble_format(
-                self.value, _max, used_char=constants.EMPTY_BUBBLE_ALT, unused_char=constants.FILLED_BUBBLE_ALT
-            )
+            out = bubble_format(self.value, _max, chars=constants.COUNTER_BUBBLES[self.display_type])
         else:
             if self.max is not None:
                 out = f"{self.value}/{_max}"

--- a/cogs5e/models/sheet/spellcasting.py
+++ b/cogs5e/models/sheet/spellcasting.py
@@ -72,8 +72,7 @@ class Spellbook:
             pact_slot_bubbles = bubble_format(
                 self.num_pact_slots,
                 self.max_pact_slots,
-                used_char=constants.EMPTY_BUBBLE_ALT,
-                unused_char=constants.FILLED_BUBBLE_ALT,
+                chars=constants.COUNTER_BUBBLES["square"],
             )
             return f"`{level}` {nonpact_slot_bubbles}{pact_slot_bubbles}"
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -245,7 +245,11 @@ class SheetManager(commands.Cog):
     )
     async def save(self, ctx, skill, *args):
         if skill == "death":
-            ds_cmd = self.bot.get_command("game deathsave")
+            base_cmd = "game deathsave"
+            if args and (sub_cmd := args[0].lower()) in ("fail", "success", "reset"):
+                base_cmd += f" {sub_cmd}"
+                args = []
+            ds_cmd = self.bot.get_command(base_cmd)
             if ds_cmd is None:
                 return await ctx.send("Error: GameTrack cog not loaded.")
             return await ctx.invoke(ds_cmd, *args)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 # ==== useful constants ====
 RESIST_TYPES = ("resist", "immune", "vuln", "neutral")
 DAMAGE_TYPES = (
@@ -137,14 +139,19 @@ COIN_TYPES = {
     },
 }
 
+CounterBubbles = namedtuple("CounterBubbles", ("empty", "filled"))
+
 # ==== emojis, icons, other discord things ====
 DDB_LOGO_EMOJI = "<:beyond:783780183559372890>"
 DDB_LOGO_ICON = "https://cdn.discordapp.com/emojis/783780183559372890.png?v=1"
-EMPTY_BUBBLE = "\u3007"
-FILLED_BUBBLE = "\u25c9"
-# pact slots
-EMPTY_BUBBLE_ALT = "\u25a2"
-FILLED_BUBBLE_ALT = "\u25a3"
+
+COUNTER_BUBBLES = {
+    "bubble": CounterBubbles(empty="\u3007", filled="\u25c9"),  # 〇◉, spell slots
+    "square": CounterBubbles(empty="\u25a2", filled="\u25a3"),  # ▢▣, pact slots
+    "hex": CounterBubbles(empty="\u2B21", filled="\u2B22"),  # ⬡⬢
+    "star": CounterBubbles(empty="\u2606", filled="\u2605"),  # ☆★
+}
+
 # homebrew
 HOMEBREW_EMOJI = "<:homebrew:783780183525818418>"
 HOMEBREW_ICON = "https://avrae.io/assets/img/homebrew.png"

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -306,15 +306,15 @@ def camel_to_title(string):
 
 
 def bubble_format(
-    value: int, max_: int, fill_from_right=False, used_char=constants.EMPTY_BUBBLE, unused_char=constants.FILLED_BUBBLE
+    value: int, max_: int, fill_from_right=False, chars: constants.CounterBubbles = constants.COUNTER_BUBBLES["bubble"]
 ):
     """Returns a bubble string to represent a counter's value."""
     if max_ > 100:
         return f"{value}/{max_}"
 
     used = max_ - value
-    filled = unused_char * value
-    empty = used_char * used
+    filled = chars.filled * value
+    empty = chars.empty * used
     if fill_from_right:
         return f"{empty}{filled}"
     return f"{filled}{empty}"


### PR DESCRIPTION
### Summary

- Adds support for using `!save death fail`/`!save death success` as an alternative to `!game deathsave fail`/`!game deathsave success`
- Added support for using hex and stars for counter displays
  - This involved a refactor that is technically a breaking internal change, but allows for much easier updates in the future

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
