### PR TITLE
Jokeen/2023w13

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -98,7 +98,7 @@ class GameTrack(commands.Cog):
                 text=f"{bubble.filled} = Available / {bubble.empty} = Used\n{pact.filled} / {pact.empty} = Pact Slot"
             )
         else:
-            embed.set_footer(text=f"{bubble.filled} = Available / {bubble.filled} = Used")
+            embed.set_footer(text=f"{bubble.filled} = Available / {bubble.empty} = Used")
 
         await ctx.send(embed=embed)
 
@@ -688,7 +688,7 @@ class GameTrack(commands.Cog):
         `-reset <short|long|none>` - Counter will reset to max on a short/long rest, or not ever when "none". Default - will reset on a call of `!cc reset`.
         `-max <max value>` - The maximum value of the counter.
         `-min <min value>` - The minimum value of the counter.
-        `-type <bubble|square|default>` - Whether the counter displays bubbles/squares to show remaining uses or numbers. Default - numbers.
+        `-type <bubble|square|hex|stars|default>` - Whether the counter displays bubbles/squares/hexes/stars to show remaining uses or numbers. Default - numbers.
         `-resetto <value>` - The value to reset the counter to. Default - maximum.
         `-resetby <value>` - Rather than resetting to a certain value, modify the counter by this much per reset. Supports dice.
         """  # noqa: E501

--- a/cogs5e/models/automation/__init__.py
+++ b/cogs5e/models/automation/__init__.py
@@ -138,7 +138,8 @@ class Automation:
         inner = Effect.build_child_str(self.effects, caster, evaluator)
         if not inner:
             inner = ", ".join(e.type for e in self.effects)
-        return disnake.utils.escape_markdown(f"{inner[0].upper()}{inner[1:]}.", as_needed=True)
+        escaped = disnake.utils.escape_markdown(f"{inner[0].upper()}{inner[1:]}.", as_needed=True)
+        return escaped.replace("<<Variable>>", "*Variable*")
 
     def __str__(self):
         return f"Automation ({len(self.effects)} effects)"

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+import re
 
 import disnake
 
@@ -243,6 +244,7 @@ class IEffect(Effect):
             desc = None
 
         duration = autoctx.args.last("dur", duration, int)
+        parsed_name = autoctx.parse_annostr(self.name)
         if self.effects is not None:
             effects = self.effects.resolve(autoctx)
         else:
@@ -256,7 +258,7 @@ class IEffect(Effect):
             effect = init.InitiativeEffect.new(
                 combat=combatant.combat,
                 combatant=combatant,
-                name=self.name,
+                name=parsed_name,
                 duration=duration,
                 passive_effects=effects,
                 attacks=attacks,
@@ -278,10 +280,10 @@ class IEffect(Effect):
             # find the next correct name for the effect and create a new one, without conflicting pieces
             if self.stacking and (stack_parent := combatant.get_effect(effect.name, strict=True)):
                 count = 2
-                new_name = f"{self.name} x{count}"
+                new_name = f"{parsed_name} x{count}"
                 while combatant.get_effect(new_name, strict=True):
                     count += 1
-                    new_name = f"{self.name} x{count}"
+                    new_name = f"{parsed_name} x{count}"
                 effect = init.InitiativeEffect.new(
                     combat=combatant.combat,
                     combatant=combatant,
@@ -328,7 +330,7 @@ class IEffect(Effect):
             effect = init.InitiativeEffect.new(
                 combat=None,
                 combatant=None,
-                name=self.name,
+                name=parsed_name,
                 duration=duration,
                 passive_effects=effects,
                 attacks=attacks,
@@ -343,7 +345,8 @@ class IEffect(Effect):
 
     def build_str(self, caster, evaluator):
         super().build_str(caster, evaluator)
-        return f"Effect: {self.name}"
+        clean_name = re.sub(r"{+.+?}+", "<<Variable>>", self.name)
+        return f"Effect: {clean_name}"
 
 
 # ==== metavars ====

--- a/cogs5e/models/automation/effects/text.py
+++ b/cogs5e/models/automation/effects/text.py
@@ -6,12 +6,15 @@ from ..results import TextResult
 
 
 class Text(Effect):
-    def __init__(self, text, **kwargs):
+    def __init__(self, text, title=None, **kwargs):
         """
         :type text: str or EntityReference
         """
         super().__init__("text", **kwargs)
         self.text = text
+        self.title = title
+        if not self.title:
+            self.title = "Effect"
 
     @classmethod
     def from_data(cls, data):
@@ -21,7 +24,8 @@ class Text(Effect):
     def to_dict(self):
         out = super().to_dict()
         text = self.text if isinstance(self.text, str) else self.text.to_dict()
-        out.update({"text": text})
+        title = self.title
+        out.update({"text": text, "title": title})
         return out
 
     async def preflight(self, autoctx):
@@ -58,11 +62,12 @@ class Text(Effect):
             text = f"{text[:1020]}..."
 
         if not hide:
-            autoctx.effect_queue(text)
+            print(self.title)
+            autoctx.effect_queue(text, self.title)
         else:
             autoctx.add_pm(str(autoctx.ctx.author.id), text)
 
-        return TextResult(text=text)
+        return TextResult(text=text, title=self.title)
 
     def build_str(self, caster, evaluator):
         super().build_str(caster, evaluator)

--- a/cogs5e/models/automation/effects/text.py
+++ b/cogs5e/models/automation/effects/text.py
@@ -62,7 +62,6 @@ class Text(Effect):
             text = f"{text[:1020]}..."
 
         if not hide:
-            print(self.title)
             autoctx.effect_queue(text, self.title)
         else:
             autoctx.add_pm(str(autoctx.ctx.author.id), text)

--- a/cogs5e/models/automation/results.py
+++ b/cogs5e/models/automation/results.py
@@ -225,6 +225,7 @@ class RollResult(EffectResult):
 class TextResult(EffectResult):
     type = "text"
     text: str
+    title: str = "Effect"
 
 
 @dataclass(frozen=True)

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -123,10 +123,10 @@ class AutomationContext:
         """Adds a line of text to the embed footer."""
         self._footer_queue.append(text)
 
-    def effect_queue(self, text):
+    def effect_queue(self, text, title="Effect"):
         """Adds a line of text to the Effect field (lines are unique)."""
         if text not in self._effect_queue:
-            self._effect_queue.append(text)
+            self._effect_queue.append((title, text))
 
     def postflight_queue_field(self, name, value, merge=True):
         """
@@ -174,8 +174,8 @@ class AutomationContext:
         # add fields
         for field in self._field_queue:
             self.embed.add_field(**field)
-        for effect in self._effect_queue:
-            self.embed.add_field(name="Effect", value=effect, inline=False)
+        for title, effect in self._effect_queue:
+            self.embed.add_field(name=title, value=effect, inline=False)
         for field in self._postflight_queue:
             self.embed.add_field(**field)
         self.embed.set_footer(text="\n".join(self._footer_queue))

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -274,7 +274,7 @@ IEffect
 
     {
         type: "ieffect2";
-        name: string;
+        name: AnnotatedString;
         duration?: int | IntExpression;
         effects?: PassiveEffects;
         attacks?: AttackInteraction[];
@@ -299,7 +299,7 @@ It must be inside a Target effect.
 
     .. attribute:: name
 
-        The name of the effect to add.
+        The name of the effect to add. Annotations will show as *Variable* in the attack string.
 
     .. attribute:: duration
 
@@ -691,6 +691,7 @@ Text
     {
         type: "text";
         text: AnnotatedString | AbilityReference;
+        title: string
     }
 
 Outputs a short amount of text in the resulting embed.
@@ -703,6 +704,10 @@ Outputs a short amount of text in the resulting embed.
 
         - An AnnotatedString (the text to display).
         - An AbilityReference (see :ref:`AbilityReference`). Displays the ability's description in whole.
+
+    .. attribute:: title
+
+        *optional* - Allows you to set the name of the field. Defaults to "Effect"
 
 .. _set-variable:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v4.1.5
+git+https://github.com/avrae/automation-common@v4.1.6
 d20==1.1.2
 
 # top-level deps


### PR DESCRIPTION
### Summary

- Adds the new hex/star types to the help of `!cc edit`
- Fixes the bubble display in `!g ss`
- Annotates the name of ieffects2
  - Any annotations are replaced with *Variable* in the attacks string
  - So "Stunning {target.name}" would show "Stunning *Variable*"
- Added the ability to set the title of text effects in automation
  - Defaults to Effect

Relies on https://github.com/avrae/automation-common/pull/4

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
