### PR TITLE
Jokeen/2023w17

### DIFF
--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -169,8 +169,9 @@ async def get_collectable_named(
         return personal_obj
     # conflicting name errors
     if personal_obj is not None and subscribed_obj_ids:
+        subbed_name = obj_name if len(subscribed_obj_ids) == 1 else obj_name_pl
         raise AliasNameConflict(
-            f"I found both a personal {obj_name} and {len(subscribed_obj_ids)} workshop {obj_name}(es) "
+            f"I found both a local {obj_name} and {len(subscribed_obj_ids)} workshop {subbed_name} "
             f"named {ctx.prefix}{name}. Use `{ctx.prefix}{obj_command_name} autofix` to automatically assign "
             f"all conflicting {obj_name_pl} unique names, or `{ctx.prefix}{obj_command_name} rename {name} <new name>` "
             "to manually rename it."


### PR DESCRIPTION
### Summary
Clarifies the wording on the conflict message when you have a local and workshop alias/snippet with the same name.
Reworks the display for contested ability checks to make it significantly more clear who is winning or losing the check

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
