### PR TITLE
Improvements to Dicecloud V2's AutoParser

### DIFF
--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import re
 
@@ -6,9 +5,6 @@ from cogs5e.models.automation import Automation
 from cogs5e.models.dicecloud.errors import AutoParserException
 from utils.constants import STAT_ABBREVIATIONS
 from utils.functions import chunk_text
-
-# because I like attributes
-Effects = collections.namedtuple("Effects", ["damage", "saves", "save_damage"])
 
 # various regex for annotated strings
 NO_DICE_COUNT = re.compile(r"(?=\s|^)d(?=[\d{])")

--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -54,10 +54,12 @@ class DCV2AutoParser:
         # add all the text as text effects
         for text in self.text:
             for chunk in chunk_text(text):
+                # fmt: off
                 self.auto.append({
                     "type": "text",
-                    "text": chunk
+                    "text": chunk,
                 })
+                # fmt: on
 
         return Automation.from_data(self.auto)
 
@@ -97,32 +99,38 @@ class DCV2AutoParser:
 
     def add_resource(self, name, amt=1):
         # initial action resources are only processed once, so we want to do them all at once
+        # fmt: off
         self.auto.insert(0, {
             "type": "counter",
             "counter": name,
-            "amount": str(amt)
+            "amount": str(amt),
         })
+        # fmt: on
 
     # makes sure that the current target hasn't changed, handling it if it has
     def set_target(self, target):
         target = "self" if target == "self" or self.meta["always_self"] else "all"
+
+        # fmt: off
         target_node = {
             "type": "target",
             "target": target,
-            "effects": []
+            "effects": [],
         }
+        # fmt: on
+
         # handles the swapping of targets, since Avrae does not allow target switching
         if self.target and (self.target["target"] != target) and self.target in self.stack_effects:
             # internal variable to only run this target if we reach this part on the original
             variable_name = f"DCV2_TARGET{self.meta['target_count']}"
             self.meta["target_count"] += 1
+
+            # fmt: off
             variable = {
                 "type": "variable",
                 "name": variable_name,
-                "value": "True"
+                "value": "True",
             }
-
-            self.stack[-1].append(variable)
 
             # branch that actually handles the check
             branch = {
@@ -130,8 +138,11 @@ class DCV2AutoParser:
                 "condition": f"{variable_name}",
                 "onTrue": [],
                 "onFalse": [],
-                "errorBehaviour": "false"
+                "errorBehaviour": "false",
             }
+            # fmt: on
+
+            self.stack[-1].append(variable)
             self.auto.append(branch)
             branch["onTrue"].append(target_node)
         else:
@@ -172,12 +183,14 @@ class DCV2AutoParser:
 
         # creates the attack effect
         if atk_roll := prop.get("attackRoll"):
+            # fmt: off
             attack = {
                 "type": "attack",
                 "hit": [],
                 "miss": [],
-                "attackBonus": str(atk_roll["value"])
+                "attackBonus": str(atk_roll["value"]),
             }
+            # fmt: on
 
             # keep a reference to the attack node for branches
             self.attacks.append(attack)
@@ -197,13 +210,15 @@ class DCV2AutoParser:
         if stat not in STAT_ABBREVIATIONS:
             raise AutoParserException(prop, "Save did not have a valid stat type")
 
+        # fmt: off
         save = {
             "type": "save",
             "stat": stat,
             "fail": [],
             "success": [],
-            "dc": prop["dc"]["value"]
+            "dc": prop["dc"]["value"],
         }
+        # fmt: on
 
         # keep a reference to the save node for branches
         self.saves.append(save)
@@ -232,10 +247,12 @@ class DCV2AutoParser:
         # handle all the annotated string stuff, as well as a few funcs
         damage_dice = self.convert_to_annostr(damage_dice) + f" [{'magical ' if magical else ''}{prop['damageType']}]"
 
+        # fmt: off
         damage = {
             "type": "damage",
             "damage": damage_dice,
         }
+        # fmt: on
 
         self.stack[-1].append(damage)
         log.debug(f"Parsing damage: {damage}")
@@ -253,13 +270,15 @@ class DCV2AutoParser:
                 pop_stack = True
                 condition = prop["condition"]["value"]
 
+                # fmt: off
                 branch = {
                     "type": "condition",
                     "condition": condition,
                     "onTrue": [],
                     "onFalse": [],
-                    "errorBehaviour": "false"
+                    "errorBehaviour": "false",
                 }
+                # fmt: on
 
                 self.stack[-1].append(branch)
                 self.stack.append(branch["onTrue"])
@@ -284,11 +303,15 @@ class DCV2AutoParser:
                     child_count = len(prop["children"])
                     # if the list is random, make a variable that stores a random number
                     index = f"DCV2_RANDOM{self.meta['random_count']}"
+
+                    # fmt: off
                     variable = {
                         "type": "variable",
                         "name": index,
-                        "value": f"random(1, {child_count + 1})"
+                        "value": f"random(1, {child_count + 1})",
                     }
+                    # fmt: on
+
                     self.meta["random_count"] += 1
 
                     self.stack[-1].append(variable)
@@ -300,13 +323,17 @@ class DCV2AutoParser:
                 # create all the branches to handle each result
                 for i, child_id in enumerate(prop["children"]):
                     condition = f"({index}) == {i + 1}"
+
+                    # fmt: off
                     branch = {
                         "type": "condition",
                         "condition": condition,
                         "onTrue": [],
                         "onFalse": [],
-                        "errorBehaviour": "false"
+                        "errorBehaviour": "false",
                     }
+                    # fmt: on
+
                     self.stack[-1].append(branch)
                     self.stack.append(branch["onTrue"])
                     self.stack_effects.append(branch)
@@ -324,11 +351,14 @@ class DCV2AutoParser:
     # create the roll effect from the property, pretty straightforward
     def parse_roll(self, prop):
         if name := prop.get("variableName"):
+            # fmt: off
             roll = {
                 "type": "roll",
                 "dice": self.convert_to_annostr(str(prop["roll"]["value"])),
                 "name": name,
             }
+            # fmt: on
+
             if d_name := prop.get("name"):
                 roll["displayName"] = d_name
 
@@ -338,13 +368,15 @@ class DCV2AutoParser:
     def parse_buff(self, prop):
         self.set_target(prop["target"])
 
+        # fmt: off
         ieffect = {
             "type": "ieffect2",
             "name": prop["name"],
             "effects": {},
             "attacks": [],
-            "stacking": True
+            "stacking": True,
         }
+        # fmt: on
 
         # TODO: not implemented yet
         # self.ieffects.append(ieffect)

--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -54,7 +54,10 @@ class DCV2AutoParser:
         # add all the text as text effects
         for text in self.text:
             for chunk in chunk_text(text):
-                self.auto.append({"type": "text", "text": chunk})
+                self.auto.append({
+                    "type": "text",
+                    "text": chunk
+                })
 
         return Automation.from_data(self.auto)
 
@@ -94,18 +97,30 @@ class DCV2AutoParser:
 
     def add_resource(self, name, amt=1):
         # initial action resources are only processed once, so we want to do them all at once
-        self.auto.insert(0, {"type": "counter", "counter": name, "amount": str(amt)})
+        self.auto.insert(0, {
+            "type": "counter",
+            "counter": name,
+            "amount": str(amt)
+        })
 
     # makes sure that the current target hasn't changed, handling it if it has
     def set_target(self, target):
         target = "self" if target == "self" or self.meta["always_self"] else "all"
-        target_node = {"type": "target", "target": target, "effects": []}
+        target_node = {
+            "type": "target",
+            "target": target,
+            "effects": []
+        }
         # handles the swapping of targets, since Avrae does not allow target switching
         if self.target and (self.target["target"] != target) and self.target in self.stack_effects:
             # internal variable to only run this target if we reach this part on the original
             variable_name = f"DCV2_TARGET{self.meta['target_count']}"
             self.meta["target_count"] += 1
-            variable = {"type": "variable", "name": variable_name, "value": "True"}
+            variable = {
+                "type": "variable",
+                "name": variable_name,
+                "value": "True"
+            }
 
             self.stack[-1].append(variable)
 
@@ -115,7 +130,7 @@ class DCV2AutoParser:
                 "condition": f"{variable_name}",
                 "onTrue": [],
                 "onFalse": [],
-                "errorBehaviour": "false",
+                "errorBehaviour": "false"
             }
             self.auto.append(branch)
             branch["onTrue"].append(target_node)
@@ -157,7 +172,12 @@ class DCV2AutoParser:
 
         # creates the attack effect
         if atk_roll := prop.get("attackRoll"):
-            attack = {"type": "attack", "hit": [], "miss": [], "attackBonus": str(atk_roll["value"])}
+            attack = {
+                "type": "attack",
+                "hit": [],
+                "miss": [],
+                "attackBonus": str(atk_roll["value"])
+            }
 
             # keep a reference to the attack node for branches
             self.attacks.append(attack)
@@ -177,7 +197,13 @@ class DCV2AutoParser:
         if stat not in STAT_ABBREVIATIONS:
             raise AutoParserException(prop, "Save did not have a valid stat type")
 
-        save = {"type": "save", "stat": stat, "fail": [], "success": [], "dc": prop["dc"]["value"]}
+        save = {
+            "type": "save",
+            "stat": stat,
+            "fail": [],
+            "success": [],
+            "dc": prop["dc"]["value"]
+        }
 
         # keep a reference to the save node for branches
         self.saves.append(save)
@@ -232,7 +258,7 @@ class DCV2AutoParser:
                     "condition": condition,
                     "onTrue": [],
                     "onFalse": [],
-                    "errorBehaviour": "false",
+                    "errorBehaviour": "false"
                 }
 
                 self.stack[-1].append(branch)
@@ -258,7 +284,11 @@ class DCV2AutoParser:
                     child_count = len(prop["children"])
                     # if the list is random, make a variable that stores a random number
                     index = f"DCV2_RANDOM{self.meta['random_count']}"
-                    variable = {"type": "variable", "name": index, "value": f"random(1, {child_count + 1})"}
+                    variable = {
+                        "type": "variable",
+                        "name": index,
+                        "value": f"random(1, {child_count + 1})"
+                    }
                     self.meta["random_count"] += 1
 
                     self.stack[-1].append(variable)
@@ -275,7 +305,7 @@ class DCV2AutoParser:
                         "condition": condition,
                         "onTrue": [],
                         "onFalse": [],
-                        "errorBehaviour": "false",
+                        "errorBehaviour": "false"
                     }
                     self.stack[-1].append(branch)
                     self.stack.append(branch["onTrue"])
@@ -308,7 +338,13 @@ class DCV2AutoParser:
     def parse_buff(self, prop):
         self.set_target(prop["target"])
 
-        ieffect = {"type": "ieffect2", "name": prop["name"], "effects": {}, "attacks": [], "stacking": True}
+        ieffect = {
+            "type": "ieffect2",
+            "name": prop["name"],
+            "effects": {},
+            "attacks": [],
+            "stacking": True
+        }
 
         # TODO: not implemented yet
         # self.ieffects.append(ieffect)

--- a/cogs5e/models/dicecloud/autoparser.py
+++ b/cogs5e/models/dicecloud/autoparser.py
@@ -54,10 +54,7 @@ class DCV2AutoParser:
         # add all the text as text effects
         for text in self.text:
             for chunk in chunk_text(text):
-                self.auto.append({
-                    "type": "text",
-                    "text": chunk
-                })
+                self.auto.append({"type": "text", "text": chunk})
 
         return Automation.from_data(self.auto)
 
@@ -97,30 +94,18 @@ class DCV2AutoParser:
 
     def add_resource(self, name, amt=1):
         # initial action resources are only processed once, so we want to do them all at once
-        self.auto.insert(0, {
-            "type": "counter",
-            "counter": name,
-            "amount": str(amt)
-        })
+        self.auto.insert(0, {"type": "counter", "counter": name, "amount": str(amt)})
 
     # makes sure that the current target hasn't changed, handling it if it has
     def set_target(self, target):
         target = "self" if target == "self" or self.meta["always_self"] else "all"
-        target_node = {
-            "type": "target",
-            "target": target,
-            "effects": []
-        }
+        target_node = {"type": "target", "target": target, "effects": []}
         # handles the swapping of targets, since Avrae does not allow target switching
         if self.target and (self.target["target"] != target) and self.target in self.stack_effects:
             # internal variable to only run this target if we reach this part on the original
             variable_name = f"DCV2_TARGET{self.meta['target_count']}"
             self.meta["target_count"] += 1
-            variable = {
-                "type": "variable",
-                "name": variable_name,
-                "value": "True"
-            }
+            variable = {"type": "variable", "name": variable_name, "value": "True"}
 
             self.stack[-1].append(variable)
 
@@ -130,7 +115,7 @@ class DCV2AutoParser:
                 "condition": f"{variable_name}",
                 "onTrue": [],
                 "onFalse": [],
-                "errorBehaviour": "false"
+                "errorBehaviour": "false",
             }
             self.auto.append(branch)
             branch["onTrue"].append(target_node)
@@ -172,12 +157,7 @@ class DCV2AutoParser:
 
         # creates the attack effect
         if atk_roll := prop.get("attackRoll"):
-            attack = {
-                "type": "attack",
-                "hit": [],
-                "miss": [],
-                "attackBonus": str(atk_roll["value"])
-            }
+            attack = {"type": "attack", "hit": [], "miss": [], "attackBonus": str(atk_roll["value"])}
 
             # keep a reference to the attack node for branches
             self.attacks.append(attack)
@@ -197,13 +177,7 @@ class DCV2AutoParser:
         if stat not in STAT_ABBREVIATIONS:
             raise AutoParserException(prop, "Save did not have a valid stat type")
 
-        save = {
-            "type": "save",
-            "stat": stat,
-            "fail": [],
-            "success": [],
-            "dc": prop["dc"]["value"]
-        }
+        save = {"type": "save", "stat": stat, "fail": [], "success": [], "dc": prop["dc"]["value"]}
 
         # keep a reference to the save node for branches
         self.saves.append(save)
@@ -258,7 +232,7 @@ class DCV2AutoParser:
                     "condition": condition,
                     "onTrue": [],
                     "onFalse": [],
-                    "errorBehaviour": "false"
+                    "errorBehaviour": "false",
                 }
 
                 self.stack[-1].append(branch)
@@ -284,11 +258,7 @@ class DCV2AutoParser:
                     child_count = len(prop["children"])
                     # if the list is random, make a variable that stores a random number
                     index = f"DCV2_RANDOM{self.meta['random_count']}"
-                    variable = {
-                        "type": "variable",
-                        "name": index,
-                        "value": f"random(1, {child_count + 1})"
-                    }
+                    variable = {"type": "variable", "name": index, "value": f"random(1, {child_count + 1})"}
                     self.meta["random_count"] += 1
 
                     self.stack[-1].append(variable)
@@ -305,7 +275,7 @@ class DCV2AutoParser:
                         "condition": condition,
                         "onTrue": [],
                         "onFalse": [],
-                        "errorBehaviour": "false"
+                        "errorBehaviour": "false",
                     }
                     self.stack[-1].append(branch)
                     self.stack.append(branch["onTrue"])
@@ -338,13 +308,7 @@ class DCV2AutoParser:
     def parse_buff(self, prop):
         self.set_target(prop["target"])
 
-        ieffect = {
-            "type": "ieffect2",
-            "name": prop["name"],
-            "effects": {},
-            "attacks": [],
-            "stacking": True
-        }
+        ieffect = {"type": "ieffect2", "name": prop["name"], "effects": {}, "attacks": [], "stacking": True}
 
         # TODO: not implemented yet
         # self.ieffects.append(ieffect)

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -706,7 +706,7 @@ class DicecloudV2Parser(SheetLoaderABC):
             ("casts", True)
             if atk_prop["type"] == "spell"
             else ("uses", False)
-            if atk_prop["target"] == "self"
+            if atk_prop["actionType"] != "attack"
             else (None, False)
         )
         log.debug(f"Parsing {atk_prop['type']}")

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -702,7 +702,13 @@ class DicecloudV2Parser(SheetLoaderABC):
             log.debug("Oops! Automation is None!")
 
         name = atk_prop["name"]
-        verb, proper = ("casts", True) if atk_prop["type"] == "spell" else (None, False)
+        verb, proper = (
+            ("casts", True)
+            if atk_prop["type"] == "spell"
+            else ("uses", False)
+            if atk_prop["target"] == "self"
+            else (None, False)
+        )
         log.debug(f"Parsing {atk_prop['type']}")
         activation = ACTIVATION_MAP.get(atk_prop["actionType"], ActivationType.SPECIAL)
         attack = Attack(name, auto, verb=verb, proper=proper, activation_type=activation)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[pycodestyle]
+max-line-length = 120
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
### Summary
Completely overhaul Dicecloud V2's AutoParser, allowing more complex behaviours to be properly captured, like hit and miss effects, proper saving throws, conditional effects, and even indexed lists of effects.

Also includes a setup.cfg to make flake8 and pycodestyle respect line length.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
