### PR TITLE
Handle sending /lookup spell to PM's better

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -916,6 +916,16 @@ class Lookup(commands.Cog):
 
     async def _spell(self, ctx, spell: gamedata.spell):
         destination = await self._get_destination(ctx)
+
+        if ctx.guild is not None:
+            if hasattr(ctx, "get_server_settings"):
+                guild_settings = await ctx.get_server_settings()
+            else:
+                guild_settings = await ServerSettings.for_guild(mdb=ctx.bot.mdb, guild_id=ctx.guild.id)
+            pm = guild_settings.lookup_pm_result
+        else:
+            pm = False
+
         embed = EmbedWithAuthor(ctx)
         embed.url = spell.url
         color = embed.colour
@@ -966,7 +976,9 @@ class Lookup(commands.Cog):
         await Stats.increase_stat(ctx, "spells_looked_up_life")
 
         for i, embed in enumerate(embed_queue):
-            if i == 0:
+            if pm:
+                await ctx.author.send(embed=embed)
+            elif i == 0:
                 # Ensure the first embed is sent as a reply
                 await destination.send(embed=embed)
             else:


### PR DESCRIPTION
### Summary
Ensures that all embeds for spells get sent to DM's instead of just the first when looking them up via `/lookup spell`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
