### PR TITLE
addressing issue regarding AC setting effects

### DIFF
--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -183,7 +183,7 @@ class Combatant(BaseCombatant, StatBlock):
         base_ac = self._ac or 0
         base_effect_ac = self.active_effects(mapper=lambda effect: effect.effects.ac_value, reducer=max, default=0)
         bonus_effect_ac = self.active_effects(mapper=lambda effect: effect.effects.ac_bonus, reducer=sum, default=0)
-        return max(base_effect_ac, base_ac) + bonus_effect_ac
+        return (base_effect_ac or base_ac) + bonus_effect_ac
 
     @ac.setter
     def ac(self, new_ac):


### PR DESCRIPTION
Fixes the issue that prevented base AC setting effects from reducing the base ac

### Summary
Here goes a short summary about what the PR is about.
Changed the combatant AC determination to use the effect's base ac if it is present, rather than using the higher of the effect's base ac, and the combatant's natural base.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
