### PR TITLE
Allow ieffects to give bonuses to save DCs

### DIFF
--- a/aliasing/api/validators.py
+++ b/aliasing/api/validators.py
@@ -34,6 +34,7 @@ class PassiveEffects(BaseModel):
     check_bonus: Optional[str255]
     check_adv: Optional[Set[str]]
     check_dis: Optional[Set[str]]
+    dc_bonus: Optional[int]
 
     @validator("save_adv", "save_dis")
     def check_valid_save_keys(cls, value):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -967,6 +967,7 @@ class InitTracker(commands.Cog):
         __Checks/Saves__
         `-sb <save bonus>` - Adds a bonus to all saving throws.
         `-sadv/sdis <ability>` - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
+        `-dc <dc>` - Adds a bonus to all saving throw DCs.
         `-cb <check bonus>` - Adds a bonus to all ability checks.
         `-cadv/cdis <ability>` - Gives advantage/disadvantage on ability checks for the provided ability, or "all" for all checks. If a base ability is passed, affects all skills based on that ability.
         __General__

--- a/cogs5e/initiative/effects/passive.py
+++ b/cogs5e/initiative/effects/passive.py
@@ -5,7 +5,7 @@ from cogs5e.models.sheet.resistance import Resistance
 from utils.argparser import ParsedArguments
 from utils.constants import SKILL_NAMES, STAT_ABBREVIATIONS, STAT_NAMES
 from utils.enums import AdvantageType
-from utils.functions import camel_to_title, exactly_one, verbose_stat
+from utils.functions import camel_to_title, verbose_stat
 
 _OwnerT = TypeVar("_OwnerT")
 _DT = TypeVar("_DT")
@@ -200,6 +200,7 @@ class InitPassiveEffect:
         deserializer=lambda data: set(data),
         serializer=lambda data: list(data),
     )
+    dc_bonus: int = _PassiveEffect(stringifier=_abstract_str_attr("Save DC Bonus"))
 
     def __init__(self, **kwargs):
         for attr in kwargs:
@@ -258,6 +259,7 @@ class InitPassiveEffect:
             check_bonus=args.join("cb", "+"),
             check_adv=resolve_check_advs(args.get("cadv")),
             check_dis=resolve_check_advs(args.get("cdis")),
+            dc_bonus=args.join("dc", "+"),
         )
 
     # ==== stringification ====

--- a/cogs5e/initiative/effects/passive.py
+++ b/cogs5e/initiative/effects/passive.py
@@ -259,7 +259,7 @@ class InitPassiveEffect:
             check_bonus=args.join("cb", "+"),
             check_adv=resolve_check_advs(args.get("cadv")),
             check_dis=resolve_check_advs(args.get("cdis")),
-            dc_bonus=args.join("dc", "+"),
+            dc_bonus=sum(args.get("dc", type_=int)),
         )
 
     # ==== stringification ====

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -394,6 +394,7 @@ class _PassiveEffectsWrapper:
             check_bonus=self.resolve_annotatedstring(autoctx, "check_bonus"),
             check_adv=self.resolve_check_advs(autoctx, "check_adv"),
             check_dis=self.resolve_check_advs(autoctx, "check_dis"),
+            dc_bonus=self.resolve_intexpression(autoctx, "dc_bonus"),
         )
 
     def resolve_annotatedstring(self, autoctx, attr: str) -> str | None:

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -66,6 +66,12 @@ class Save(Effect):
         elif autoctx.dc_override is not None:
             dc = autoctx.dc_override
 
+        # dc effects
+        bonus_effect_dc = autoctx.caster_active_effects(
+            mapper=lambda effect: effect.effects.dc_bonus, reducer=sum, default=0
+        )
+        dc += bonus_effect_dc
+
         if autoctx.args.last("dc") is not None:
             dc = maybe_mod(autoctx.args.last("dc"), dc)
 

--- a/dbot.py
+++ b/dbot.py
@@ -326,7 +326,7 @@ async def command_errors(ctx, error):
         elif isinstance(original, NotFound):
             return await ctx.send("Error: I tried to edit or delete a message that no longer exists.")
 
-        elif isinstance(original, (ClientResponseError, TypeError, ValueError, asyncio.TimeoutError, ClientOSError)):
+        elif isinstance(original, (ClientResponseError, asyncio.TimeoutError, ClientOSError)):
             return await ctx.send("Error in Discord API. Please try again.")
 
         elif isinstance(original, HTTPException):

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -385,6 +385,7 @@ PassiveEffects
         check_bonus: AnnotatedString;
         check_adv: AnnotatedString[];
         check_dis: AnnotatedString[];
+        dc_bonus: IntExpression;
     }
 
 Used to specify the passive effects granted by an initiative effect.
@@ -493,6 +494,10 @@ Used to specify the passive effects granted by an initiative effect.
         disadvantage on for ability checks for while this effect is active. If a base ability is given, the disadvantage
         will apply to all skills based on that ability (e.g. ``strength`` gives disadvantage on ``athletics`` checks).
         Use ``all`` as a stat name to specify all skills.
+
+    .. attribute:: dc_bonus
+
+        *optional* - A bonus added to the all of the combatant's save DCs while this effect is active.
 
 .. _attackinteraction:
 


### PR DESCRIPTION
### Summary
Adds the ability for ieffects to give a temporary bonus to save DCs (-dc; dc_bonus)
depends on https://github.com/avrae/automation-common/pull/5

also makes the error handler consider type/valueerrors not discord's fault (see commit comment)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
