### PR TITLE
Jokeen/2023w24

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -616,7 +616,9 @@ class InitTracker(commands.Cog):
             out = combat.get_summary()
         await destination.send(out)
 
-    @init.command()
+    @init.group(
+        invoke_without_command=True,
+    )
     async def note(self, ctx, name: str, *, note: str = ""):
         """Attaches a note to a combatant."""
         combat = await ctx.get_combat()
@@ -625,12 +627,23 @@ class InitTracker(commands.Cog):
         if combatant is None:
             return await ctx.send("Combatant not found.")
 
-        combatant.notes = note
         if note == "":
-            await ctx.send("Removed note.")
+            await ctx.send(f"```md\n{combatant}\n# {combatant.notes}\n```")
         else:
-            await ctx.send("Added note.")
+            combatant.notes = note
+            await ctx.send(f"Added note to {combatant.name}.")
         await combat.final(ctx)
+
+    @note.command(name="remove", aliases=["delete"])
+    async def note_remove(self, ctx, name: str):
+        """Removes a note from a combatant."""
+        combat = await ctx.get_combat()
+
+        combatant = await combat.select_combatant(ctx, name)
+        if combatant is None:
+            return await ctx.send("Combatant not found.")
+
+        await ctx.send(f"Removed note from {combatant.name}.")
 
     @init.command(aliases=["opts"])
     async def opt(self, ctx, name: str, *args):

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -258,6 +258,8 @@ class IEffect(Effect):
         if self.target_self:
             combatant = autoctx.caster
             effect_target = f" on {combatant.name}"
+            if not isinstance(combatant, init.Combatant):
+                combatant = None
         else:
             combatant = autoctx.target.combatant
             effect_target = ""

--- a/cogs5e/models/automation/effects/usecounter.py
+++ b/cogs5e/models/automation/effects/usecounter.py
@@ -9,7 +9,15 @@ from ..utils import stringify_intexpr
 
 
 class UseCounter(Effect):
-    def __init__(self, counter, amount: str, allowOverflow: bool = False, errorBehaviour: str = "warn", **kwargs):
+    def __init__(
+        self,
+        counter,
+        amount: str,
+        allowOverflow: bool = False,
+        errorBehaviour: str = "warn",
+        fixedValue: bool = None,
+        **kwargs,
+    ):
         """
         :type counter: str or SpellSlotReference or AbilityReference
         """
@@ -18,6 +26,7 @@ class UseCounter(Effect):
         self.amount = amount
         self.allow_overflow = allowOverflow
         self.error_behaviour = errorBehaviour
+        self.fixedValue = fixedValue
 
     @classmethod
     def from_data(cls, data):
@@ -36,6 +45,8 @@ class UseCounter(Effect):
                 "errorBehaviour": self.error_behaviour,
             }
         )
+        if self.fixedValue is not None:
+            out["fixedValue"] = self.fixedValue
         return out
 
     def run(self, autoctx):
@@ -53,6 +64,8 @@ class UseCounter(Effect):
         # -l, nopact handled in use_spell_slot
 
         try:
+            if self.fixedValue:
+                amt = None
             amount = amt or autoctx.parse_intexpression(self.amount)
         except Exception:
             raise AutomationException(f"{self.amount!r} cannot be interpreted as an amount (in Use Counter)")

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -237,7 +237,7 @@ class TempCharacter:
         col = letter2num(_pos.group(1))
         row = int(_pos.group(2)) - 1
         if row > len(source) or col > len(source[row]):
-            raise IndexError("Cell out of bounds.")
+            raise IndexError(f"Cell `{pos}` is out of bounds.")
         value = source[row][col]
         log.debug(f"Cell {pos}: {value}")
         return value
@@ -606,6 +606,8 @@ class GoogleSheet(SheetLoaderABC):
             adv = None
             if self.version >= (2, 0) and advcell:
                 advtype = character.unformatted_value(advcell)
+                if isinstance(advtype, str):
+                    advtype = advtype.lower()
                 if advtype in {"a", "adv", "advantage"}:
                     adv = True
                 elif advtype in {"d", "dis", "disadvantage"}:
@@ -615,6 +617,8 @@ class GoogleSheet(SheetLoaderABC):
                 prof = 0.5
             if profcell:
                 proftype = character.unformatted_value(profcell)
+                if isinstance(proftype, str):
+                    proftype = proftype.lower()
                 if proftype == "e":
                     prof = 2
                 elif proftype and proftype != "0":

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -683,7 +683,7 @@ Rolls some dice and saves the result in a variable. Displays the roll and its na
 
     .. attribute:: fixedValue
 
-        *optional* - If ``true``, won't add any bonuses to damage from `-d` arguments or damage bonus effects.
+        *optional* - If ``true``, won't add any bonuses to damage from ``-d`` arguments or damage bonus effects.
 
 
 **Variables**
@@ -849,7 +849,7 @@ Uses a number of charges of the given counter, and displays the remaining amount
 
     .. attribute:: fixedValue
 
-        *optional* - If ``true``, won't add any bonuses to damage from `amt` arguments.
+        *optional* - If ``true``, won't take into account ``-amt`` arguments.
 
 **Variables**
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -57,6 +57,7 @@ Target
         target: "all" | "each" | int | "self" | "parent" | "children";
         effects: Effect[];
         sortBy?: "hp_asc" | "hp_desc";
+        self_target?: boolean;
     }
 
 A Target effect should only show up as a top-level effect.
@@ -85,6 +86,10 @@ It designates what creatures to affect.
 
         - ``hp_asc``: Sorts the targets in order of remaining hit points ascending (lowest HP first, None last).
         - ``hp_desc``: Sorts the targets in order of remaining hit points descending (highest HP first, None last).
+
+    .. attribute:: self_target
+
+        *optional* - If ``true``, the effect will be added to the caster of the automation as opposed to the target.
 
 **Variables**
 
@@ -643,6 +648,7 @@ Roll
         cantripScale?: boolean;
         hidden?: boolean;
         displayName?: string;
+        fixedValue?: boolean;
     }
 
 Rolls some dice and saves the result in a variable. Displays the roll and its name in a Meta field, unless
@@ -674,6 +680,11 @@ Rolls some dice and saves the result in a variable. Displays the roll and its na
     .. attribute:: displayName
 
         The name to display in the Meta field. If left blank, it will use the saved name.
+
+    .. attribute:: fixedValue
+
+        *optional* - If ``true``, won't add any bonuses to damage from `-d` arguments or damage bonus effects.
+
 
 **Variables**
 
@@ -798,6 +809,7 @@ Use Counter
         amount: IntExpression;
         allowOverflow?: boolean;
         errorBehaviour?: "warn" | "raise" | "ignore";
+        fixedValue?: boolean;
     }
 
 Uses a number of charges of the given counter, and displays the remaining amount and delta.
@@ -834,6 +846,10 @@ Uses a number of charges of the given counter, and displays the remaining amount
         - The target does not have counters (e.g. they are a monster)
         - The counter does not exist
         - ``allowOverflow`` is false and the new value is out of bounds
+
+    .. attribute:: fixedValue
+
+        *optional* - If ``true``, won't add any bonuses to damage from `amt` arguments.
 
 **Variables**
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -210,6 +210,7 @@ Damage
         overheal?: boolean;
         higher?: {int: string};
         cantripScale?: boolean;
+        fixedValue?: boolean;
     }
 
 Deals damage to or heals a targeted creature. It must be inside a Target effect.
@@ -237,6 +238,10 @@ Deals damage to or heals a targeted creature. It must be inside a Target effect.
     .. attribute:: cantripScale
 
         *optional* - Whether this roll should scale like a cantrip.
+
+    .. attribute:: fixedValue
+
+        *optional* - If ``true``, won't add any bonuses to damage from ``-d`` arguments or damage bonus effects.
 
 **Variables**
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -295,6 +295,7 @@ IEffect
         stacking?: boolean;
         save_as?: string;
         parent?: string;
+        target_self?: boolean;
     }
 
 Adds an InitTracker Effect to a targeted creature, if the automation target is in combat.
@@ -362,6 +363,11 @@ It must be inside a Target effect.
 
         If ``stacking`` is true and a valid stack parent exists, the stack parent will take priority over the given
         parent.
+
+    .. attribute:: target_self
+
+        *optional, default false* - If true, the effect will be applied to the caster of the spell, rather than the
+        target.
 
 **Variables**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v4.1.6
+git+https://github.com/avrae/automation-common@v4.1.7
 d20==1.1.2
 
 # top-level deps


### PR DESCRIPTION
### Summary
- Adds `!init note remove <name>` to remove notes
  - `!init note <name>` with no note afterward now just displays the note
- Added `fixedValue` argument for Roll and UseCounter effect nodes
  - This causes it to ignore `-d` arguments (and effects) and `-amt` arguments
- Added `target_self` argument to IEffect effect nodes
  - This will add the effect to the caster/user of the automation, regardless of what target branch it is under
- Gsheet importer now properly handles if a user puts E or Adv/Dis for their skills, before only handled lowercase
- Displays the erroring cell on gsheet import

https://github.com/avrae/automation-common/pull/6
https://github.com/avrae/avrae.io/pull/674

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
