### PR TITLE
June 14th Hotfix

### DIFF
--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -66,17 +66,18 @@ class Save(Effect):
         elif autoctx.dc_override is not None:
             dc = autoctx.dc_override
 
+        if autoctx.args.last("dc") is not None:
+            dc = maybe_mod(autoctx.args.last("dc"), dc)
+
+        if dc is None:
+            raise NoSpellDC("No spell save DC found. Use the `-dc` argument to specify one!")
+
         # dc effects
         bonus_effect_dc = autoctx.caster_active_effects(
             mapper=lambda effect: effect.effects.dc_bonus, reducer=sum, default=0
         )
         dc += bonus_effect_dc
 
-        if autoctx.args.last("dc") is not None:
-            dc = maybe_mod(autoctx.args.last("dc"), dc)
-
-        if dc is None:
-            raise NoSpellDC("No spell save DC found. Use the `-dc` argument to specify one!")
         try:
             save_skill = next(
                 s


### PR DESCRIPTION
### Summary
- Move DC Bonus adding to after checking if they have a DC
  - If its a spell using the default DC, and the user is not a spellcaster, this was causing an error before it would check of the DC was None

Plan to go live with this PR is at 10pm MT, June 14th

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
