### PR TITLE
Added -cantripdice and fixed bug with cantrip scaling actions

### DIFF
--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -28,7 +28,7 @@ def upcast_scaled_dice(effect, autoctx, dice_ast):
             level_dice = 3
         else:
             level_dice = 4
-        level_dice = autoctx.args.last("cantripdice",default=level_dice,type_=int)
+        level_dice = autoctx.args.last("cantripdice", default=level_dice, type_=int)
         def mapper(node):
             if isinstance(node, d20.ast.Dice):
                 node.num = level_dice

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -18,24 +18,23 @@ def maybe_alias_statblock(target):
 
 def upcast_scaled_dice(effect, autoctx, dice_ast):
     """Scales the dice of the cast to its appropriate amount (handling cantrip scaling and higher level addition)."""
-    if autoctx.is_spell:
-        if effect.cantripScale:
-            level = autoctx.caster.spellbook.caster_level
-            if level < 5:
-                level_dice = 1
-            elif level < 11:
-                level_dice = 2
-            elif level < 17:
-                level_dice = 3
-            else:
-                level_dice = 4
+    if effect.cantripScale:
+        level = autoctx.caster.spellbook.caster_level
+        if level < 5:
+            level_dice = 1
+        elif level < 11:
+            level_dice = 2
+        elif level < 17:
+            level_dice = 3
+        else:
+            level_dice = 4
+        level_dice = autoctx.args.last("cantripdice",default=level_dice,type_=int)
+        def mapper(node):
+            if isinstance(node, d20.ast.Dice):
+                node.num = level_dice
+            return node
 
-            def mapper(node):
-                if isinstance(node, d20.ast.Dice):
-                    node.num = level_dice
-                return node
-
-            dice_ast = d20.utils.tree_map(mapper, dice_ast)
+        dice_ast = d20.utils.tree_map(mapper, dice_ast)
 
     if effect.higher:
         higher = effect.higher.get(str(autoctx.get_cast_level()))

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -80,6 +80,7 @@ sadv/sdis - Gives the target advantage/disadvantage on the saving throw.
 *-c <damage>* - Adds additional damage for when the attack crits, not doubled.
 *-mi <value>* - Minimum value of each die on the damage roll.
 *savage* - Rolls two sets of the base damage dice, choosing the higher of the two.
+*-cantripdice <amount>* - Overrides how many dice to use for cantrip scaling.
 
 __Damage Types__
 *magical* - Makes the damage type of the attack magical.


### PR DESCRIPTION
### Summary
Removes the check for if an automation call is a spell to use cantrip level dice, allowing normal actions to use it as intended.

Adds -cantripdice to override the amount of dice used by automation that calls for cantrip scaling, and can be used to go above  the normal 4 limit, allowing additional support for epic level homebrew. (something i had inquired about potentially requesting at one point.)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
