### PR TITLE
feat: ieffects tick on other combatant's turn

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -418,6 +418,7 @@ class SimpleCombatant(AliasStatBlock):
         passive_effects: dict = None,
         attacks: list[dict] = None,
         buttons: list[dict] = None,
+        tick_on_combatant_id: str = None,
     ):
         """
         Adds an effect to the combatant. Returns the added effect.
@@ -442,6 +443,7 @@ class SimpleCombatant(AliasStatBlock):
         :param passive_effects: The passive effects this effect should grant. See :ref:`ieffectargs`.
         :param attacks: The attacks granted by this effect. See :ref:`ieffectargs`.
         :param buttons: The buttons granted by this effect. See :ref:`ieffectargs`.
+        :param tick_on_combatant_id: The ID of the combatant whose turn the effect duration ticks on (defaults to the combatant who the effect is on).
         :rtype: :class:`~aliasing.api.combat.SimpleEffect`
         """  # noqa: E501
         # validate types
@@ -459,6 +461,8 @@ class SimpleCombatant(AliasStatBlock):
             raise ValueError("The parent of a SimpleEffect must be a SimpleEffect.")
         if desc is not None:
             desc = str(desc)
+        if tick_on_combatant_id is not None:
+            tick_on_combatant_id = str(tick_on_combatant_id)
 
         # parse v4.1 models (passive, attacks, buttons)
         parsed_passive = parsed_attacks = parsed_buttons = None
@@ -500,6 +504,7 @@ class SimpleCombatant(AliasStatBlock):
             passive_effects=parsed_passive,
             attacks=parsed_attacks,
             buttons=parsed_buttons,
+            tick_on_combatant_id=tick_on_combatant_id,
         )
         if parent:
             effect_obj.set_parent(parent._effect)

--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -428,9 +428,6 @@ class Combat:
 
         messages = []
 
-        if self.current_combatant:
-            self.current_combatant.on_turn_end()
-
         changed_round = False
         if self.index is None:  # new round, no dynamic reroll
             self._current_index = 0
@@ -445,15 +442,16 @@ class Combat:
             self._current_index += 1
 
         self._turn = self.current_combatant.init
-        self.current_combatant.on_turn()
+        for combatant in self._combatants:
+            combatant.on_turn()
         return changed_round, messages
 
     def rewind_turn(self):
         if len(self._combatants) == 0:
             raise NoCombatants
 
-        if self.current_combatant:
-            self.current_combatant.on_turn_end(num_turns=-1)
+        for combatant in self._combatants:
+            combatant.on_turn(num_turns=-1)
 
         if self.index is None:  # start of combat
             self._current_index = len(self._combatants) - 1
@@ -469,8 +467,8 @@ class Combat:
         if len(self._combatants) == 0:
             raise NoCombatants
 
-        if self.current_combatant:
-            self.current_combatant.on_turn_end(num_turns=0)
+        for combatant in self._combatants:
+            combatant.on_turn(num_turns=0)
 
         if is_combatant:
             if init_num.group:
@@ -491,7 +489,6 @@ class Combat:
         self.round_num += num_rounds
         for com in self.get_combatants():
             com.on_turn(num_rounds)
-            com.on_turn_end(num_rounds)
         if self.options.dynamic:
             messages.append(f"New initiatives:\n{self.reroll_dynamic()}")
 

--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -411,17 +411,12 @@ class Combatant(BaseCombatant, StatBlock):
     # hooks
     def on_turn(self, num_turns: int = 1):
         """
-        A method called at the start of each of the combatant's turns.
+        A method called at the start of each combatant's turns.
         :param num_turns: The number of turns that just passed.
         :return: None
         """
         for e in self.get_effects().copy():
             e.on_turn(num_turns)
-
-    def on_turn_end(self, num_turns: int = 1):
-        """A method called at the end of each of the combatant's turns."""
-        for e in self.get_effects().copy():
-            e.on_turn_end(num_turns)
 
     def on_remove(self):
         """

--- a/cogs5e/initiative/group.py
+++ b/cogs5e/initiative/group.py
@@ -145,7 +145,6 @@ class CombatantGroup(Combatant):
         for c in self.get_combatants():
             c.on_turn(num_turns)
 
-
     def on_remove(self):
         for c in self.get_combatants():
             c.on_remove()

--- a/cogs5e/initiative/group.py
+++ b/cogs5e/initiative/group.py
@@ -145,9 +145,6 @@ class CombatantGroup(Combatant):
         for c in self.get_combatants():
             c.on_turn(num_turns)
 
-    def on_turn_end(self, num_turns=1):
-        for c in self.get_combatants():
-            c.on_turn_end(num_turns)
 
     def on_remove(self):
         for c in self.get_combatants():

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -296,6 +296,7 @@ IEffect
         save_as?: string;
         parent?: string;
         target_self?: boolean;
+        tick_on_caster?: boolean;
     }
 
 Adds an InitTracker Effect to a targeted creature, if the automation target is in combat.
@@ -316,6 +317,16 @@ It must be inside a Target effect.
 
         *optional, default infinite* - The duration of the effect, in rounds of combat. If this is negative, creates an
         effect with infinite duration.
+
+        .. note::
+
+            **Wait, how do durations actually work?**
+
+            Durations use a "tick" system, and ``duration`` is actually a measure of how many "ticks" an effect sticks
+            around for. By default, each effect "ticks" once at the beginning of its combatant's turn.
+
+            By using ``end`` and ``tick_on_caster``, you can control how the duration ticks in order to create effects
+            that last until the end of your next turn, end of the caster's next turn, etc.
 
     .. attribute:: effects
 
@@ -366,8 +377,16 @@ It must be inside a Target effect.
 
     .. attribute:: target_self
 
-        *optional, default false* - If true, the effect will be applied to the caster of the spell, rather than the
+        *optional, default false* - If true, the effect will be applied to the caster of the action, rather than the
         target.
+
+    .. attribute:: tick_on_caster
+
+        *optional, default false* - If true, the effect's duration will be dependent on the caster of the action, rather
+        than the target. For example, a ``tick_on_caster`` effect with a duration of 1 will last until the start of the
+        *caster's* next turn, rather than the *target's*.
+
+        If the caster is not in combat, this has no effect.
 
 **Variables**
 


### PR DESCRIPTION
### Summary
Allows initiative effects to tick on other combatants' turns, not just the combatant who the effect is on.

This makes durations of the form "until the caster's next turn" much easier to implement without having to deal with parent effects.

- IEffect: added `tick_on_caster`
- aliasing: added `tick_on_combatant_id` to `SimpleCombatant.add_effect()`

Depends on https://github.com/avrae/automation-common/pull/7.

### Breaking Changes
Rather than 2 discrete hooks `Combatant.on_turn()` and `Combatant.on_turn_end()` checking only the effects of that combatant, the combat now runs the `on_turn()` hook for all combatants on every turn. `on_turn_end()` was removed, since effects that ticked on end of turn can now check if a combatant after it just began.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
