### PR TITLE
Update check.py to allow for self-related arguments for "check vs caster" automation

### DIFF
--- a/cogs5e/models/automation/effects/check.py
+++ b/cogs5e/models/automation/effects/check.py
@@ -96,8 +96,6 @@ class Check(Effect):
 
         # ==== user args for user's checks in contested check automation ====
         contest_ability_list = autoctx.args.get("selfability") or self.contest_ability_list
-        self_auto_pass = autoctx.args.last("selfcpass", type_=bool, ephem=True)
-        self_auto_fail = autoctx.args.last("selfcfail", type_=bool, ephem=True)
         self_check_bonus = autoctx.args.get("selfcb", ephem=True)
         self_adv = reconcile_adv(
             adv=autoctx.args.last("selfcadv", type_=bool, ephem=True) or self.adv == enums.AdvantageType.ADV,

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -10,9 +10,9 @@ __Valid Arguments__
 *adv/dis* - Give advantage/disadvantage to the check roll(s).
 *-b <bonus>* - Adds a bonus to the roll.
 -dc <dc> - Sets a DC and counts successes/failures.
--mc <minimum roll> - Sets the minimum roll on the dice (e.g. Reliable Talent, Glibness)
+*-mc <minimum roll>* - Sets the minimum roll on the dice (e.g. Reliable Talent, Glibness).
 -rr <iterations> - How many checks to roll.
-str/dex/con/int/wis/cha - Rolls using a different skill base (e.g. Strength (Intimidation))
+str/dex/con/int/wis/cha - Rolls using a different skill base (e.g. Strength (Intimidation)).
 
 -phrase <phrase> - Adds flavor text.
 -title <title> - Changes the title of the check. Replaces [name] with caster's name and [cname] with the check's name.
@@ -30,7 +30,7 @@ __Valid Arguments__
 *adv/dis* - Give advantage/disadvantage to the save roll(s).
 *-b <bonus>* - Adds a bonus to the roll.
 -dc <dc> - Sets a DC and counts successes/failures.
--mc <minimum roll> - Sets the minimum roll on the dice (e.g. Starry Form: Dragon, Trance of Order)
+*-mc <minimum roll>* - Sets the minimum roll on the dice (e.g. Starry Form: Dragon, Trance of Order)
 -rr <iterations> - How many saves to roll (does not apply to Death Saves).
 
 -phrase <phrase> - Adds flavor text.
@@ -103,6 +103,7 @@ nopact - Uses a normal spell slot instead of a Pact Magic slot, if applicable.
 **Checks**
 -ability <ability> - Overrides the check roll's ability (e.g. `-ability arcana`, `-ability sleightOfHand`).
 *-cb <bonus>* - Adds a bonus to ability checks.
+*-mc <minimum roll>* - Sets the minimum roll on the dice (e.g. Reliable Talent, Glibness).
 -cdc <dc> - Overrides the DC of the ability check.
 -cdc <+X/-X> - Modifies the DC by a certain amount.
 *cadv/cdis* - Gives the target advantage/disadvantage on the ability check.
@@ -112,9 +113,9 @@ __Contest Against Caster Checks__
 > The following are arguments when the automation causes the target to roll a contested check against you (a Grapple contest, for example).
 > Use these arguments to modify your roll(s), and use the regular **Check** arguments above to modify the target's rolls.
 -selfability <ability> - Overrides the check roll's ability for you.
-*-selfcb <bonus>* - Adds a bonus to your check.
-*selfcadv/selfcdis* - Gives you advantage/disadvantage on your ability check.
--selfmc <minimum roll value> - Sets the minimum value the dice can return for your check (before bonuses).
+*-selfcb <bonus>* - Adds a bonus to your ability checks.
+*selfcadv/selfcdis* - Gives you advantage/disadvantage on your ability checks.
+*-selfmc <minimum roll value>* - Sets the minimum roll on the dice (e.g. Reliable Talent, Glibness).
 
 **Other**
 -choice <choice> - Provides input to the attack. Not all attacks will utilize this argument.


### PR DESCRIPTION
Adding "self" arguments for caster in contested vs. caster checks

### Summary
Here goes a short summary about what the PR is about.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
