### PR TITLE
Added "(Reply with yes/no)" to `!init note remove` message

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1066,7 +1066,7 @@ class InitTracker(commands.Cog):
             if effect is None:
                 confirmation = await confirm(
                     ctx,
-                    f"Are you sure you want to remove all effects ({len(effects)}) from {combatant.name}?",
+                    f"Are you sure you want to remove all effects ({len(effects)}) from {combatant.name}? (Reply with yes/no)",
                     delete_msgs=True,
                 )
                 if confirmation:
@@ -1077,7 +1077,7 @@ class InitTracker(commands.Cog):
             else:
                 to_remove = await combatant.select_effect(effect)
                 confirmation = to_remove.name.lower() == effect.lower() or await confirm(
-                    ctx, f"Are you sure you want to remove {to_remove.name} from {combatant.name}?", delete_msgs=True
+                    ctx, f"Are you sure you want to remove {to_remove.name} from {combatant.name}? (Reply with yes/no)", delete_msgs=True
                 )
                 if confirmation:
                     children_removed = ""


### PR DESCRIPTION


### Summary
The new `!init note remove` command requires a confirmation, but the user is not currently prompted how to respond, as they are with `!init end`
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
