### PR TITLE
Adding an extra redis Set command to RedisIO

### DIFF
--- a/cogs5e/dice/inline.py
+++ b/cogs5e/dice/inline.py
@@ -159,7 +159,7 @@ class InlineRoller:
             await user.send(embed=embed)
         except disnake.HTTPException:
             return
-        await self.bot.rdb.set(f"cog.dice.inline_rolling.users.{user.id}.onboarded.message", str(time.time()))
+        await self.bot.rdb.bset(f"cog.dice.inline_rolling.users.{user.id}.onboarded.message", str(time.time()))
 
     async def inline_rolling_reaction_onboarding(self, user):
         if await self.bot.rdb.get(f"cog.dice.inline_rolling.users.{user.id}.onboarded.reaction"):
@@ -192,7 +192,7 @@ class InlineRoller:
             await user.send(embed=embed)
         except disnake.HTTPException:
             return
-        await self.bot.rdb.set(f"cog.dice.inline_rolling.users.{user.id}.onboarded.reaction", str(time.time()))
+        await self.bot.rdb.bset(f"cog.dice.inline_rolling.users.{user.id}.onboarded.reaction", str(time.time()))
 
 
 # ==== character-aware rolls ====

--- a/utils/redisIO.py
+++ b/utils/redisIO.py
@@ -33,6 +33,9 @@ class RedisIO:
             return await self._db.set(key, value, ex=ex, xx=True)
         return await self._db.set(key, value, ex=ex)
 
+    async def bset(self, key, value):
+        return await self._db.set(key, value)
+
     async def incr(self, key):
         return await self._db.incr(key)
 


### PR DESCRIPTION
### Summary
Resolving items without expiration not being created in redis, This was caused by redis-py update performed awhile ago.   By doing a basic set if we don't need the other values, we will now properly save status' such as inline reaction messages for the onboarding process ( first time messages )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
