### PR TITLE
Add an option to avrae to hide a forced roll

### DIFF
--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -155,7 +155,7 @@ class Attack(Effect):
             if ac:
                 to_hit_message = f"**To Hit (AC {ac})**:"
             if force_roll and not hide_force_roll:
-                to_hit_message = f"{to_hit_message} Forced Roll BLAH!"
+                to_hit_message = f"{to_hit_message} Forced Roll!"
 
             if b:
                 to_hit_roll = d20.roll(f"{formatted_d20}+{attack_bonus}+{b}")

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -53,7 +53,7 @@ class Attack(Effect):
         criton = args.last("criton", 20, int)
         ac = args.last("ac", None, int)
         force_roll = args.last("attackroll", None, int, ephem=True)
-        hide_force_roll = args.last("hideforceroll", None, bool, ephem=True) and 1
+        hide_force_roll = args.last("hideforcedroll", default=False, type_=bool, ephem=True)
         min_attack_roll = args.last("attackmin", 0, int)
 
         # ==== caster options ====
@@ -140,7 +140,7 @@ class Attack(Effect):
             if min_attack_roll:
                 reroll_str = f"{reroll_str}mi{min_attack_roll}"
 
-            if force_roll and not hide_force_roll:
+            if force_roll:
                 formatted_d20 = f"{force_roll}"
             elif adv == AdvantageType.ADV:
                 formatted_d20 = f"2d20{reroll_str}kh1"
@@ -155,7 +155,7 @@ class Attack(Effect):
             if ac:
                 to_hit_message = f"**To Hit (AC {ac})**:"
             if force_roll and not hide_force_roll:
-                to_hit_message = f"{to_hit_message} Forced Roll!"
+                to_hit_message = f"{to_hit_message} Forced Roll BLAH!"
 
             if b:
                 to_hit_roll = d20.roll(f"{formatted_d20}+{attack_bonus}+{b}")

--- a/cogs5e/models/automation/effects/attack.py
+++ b/cogs5e/models/automation/effects/attack.py
@@ -53,6 +53,7 @@ class Attack(Effect):
         criton = args.last("criton", 20, int)
         ac = args.last("ac", None, int)
         force_roll = args.last("attackroll", None, int, ephem=True)
+        hide_force_roll = args.last("hideforceroll", None, bool, ephem=True) and 1
         min_attack_roll = args.last("attackmin", 0, int)
 
         # ==== caster options ====
@@ -139,7 +140,7 @@ class Attack(Effect):
             if min_attack_roll:
                 reroll_str = f"{reroll_str}mi{min_attack_roll}"
 
-            if force_roll:
+            if force_roll and not hide_force_roll:
                 formatted_d20 = f"{force_roll}"
             elif adv == AdvantageType.ADV:
                 formatted_d20 = f"2d20{reroll_str}kh1"
@@ -153,7 +154,7 @@ class Attack(Effect):
             to_hit_message = "**To Hit**:"
             if ac:
                 to_hit_message = f"**To Hit (AC {ac})**:"
-            if force_roll:
+            if force_roll and not hide_force_roll:
                 to_hit_message = f"{to_hit_message} Forced Roll!"
 
             if b:


### PR DESCRIPTION
### Summary
Adding an option to hide whether a forced roll happened or not. TODO: Looking for help for how to keep a GM informed that this happened. I want GM's to have the option to hide if a forced roll happened from users but don't let players do the same thing. 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
