### PR TITLE
Add GridFS functionality via LaunchDarkly Flag

### DIFF
--- a/gamedata/compendium.py
+++ b/gamedata/compendium.py
@@ -134,7 +134,9 @@ class Compendium:
 
         ldclient.set_config(ldclient.Config(sdk_key=config.LAUNCHDARKLY_SDK_KEY))
 
-        if ldclient.get().variation("data.monsters.gridfs", {"key": "anonymous-user-start-bot", "anonymous": True}, False):
+        if ldclient.get().variation(
+                "data.monsters.gridfs", {"key": "anonymous-user-start-bot", "anonymous": True}, False
+        ):
             fs = motor.motor_asyncio.AsyncIOMotorGridFSBucket(mdb)
             data = await fs.open_download_stream_by_name(filename="monsters")
             gridout = await data.read()
@@ -272,7 +274,7 @@ class Compendium:
             self._actions_by_eid[(action.type_id, action.id)].append(action)
 
     def _deserialize_and_register_lookups(
-            self, cls: Type[T], data_source: List[dict], skip_out_filter: Callable[[T], bool] = None, **kwargs
+        self, cls: Type[T], data_source: List[dict], skip_out_filter: Callable[[T], bool] = None, **kwargs
     ) -> List[T]:
         out = []
         for entity_data in data_source:

--- a/gamedata/compendium.py
+++ b/gamedata/compendium.py
@@ -135,7 +135,7 @@ class Compendium:
         ldclient.set_config(ldclient.Config(sdk_key=config.LAUNCHDARKLY_SDK_KEY))
 
         if ldclient.get().variation(
-                "data.monsters.gridfs", {"key": "anonymous-user-start-bot", "anonymous": True}, False
+            "data.monsters.gridfs", {"key": "anonymous-user-start-bot", "anonymous": True}, False
         ):
             fs = motor.motor_asyncio.AsyncIOMotorGridFSBucket(mdb)
             data = await fs.open_download_stream_by_name(filename="monsters")

--- a/gamedata/compendium.py
+++ b/gamedata/compendium.py
@@ -6,6 +6,8 @@ import logging
 import os
 from typing import Callable, List, Type, TypeVar
 
+import motor.motor_asyncio
+
 import gamedata.spell
 from gamedata.action import Action
 from gamedata.background import Background
@@ -18,6 +20,7 @@ from gamedata.monster import Monster
 from gamedata.race import Race, RaceFeature, SubRace
 from gamedata.shared import Sourced
 from utils import config
+import ldclient
 
 log = logging.getLogger(__name__)
 T = TypeVar("T")
@@ -128,7 +131,16 @@ class Compendium:
 
         self.raw_classes = lookup.get("classes", [])
         self.raw_feats = lookup.get("feats", [])
-        self.raw_monsters = lookup.get("monsters", [])
+
+        ldclient.set_config(ldclient.Config(sdk_key=config.LAUNCHDARKLY_SDK_KEY))
+
+        if ldclient.get().variation("data.monsters.gridfs", {"key": "anonymous-user-start-bot", "anonymous": True}, False):
+            fs = motor.motor_asyncio.AsyncIOMotorGridFSBucket(mdb)
+            data = await fs.open_download_stream_by_name(filename="monsters")
+            gridout = await data.read()
+            self.raw_monsters = json.loads(gridout)
+        else:
+            self.raw_monsters = lookup.get("monsters", [])
         self.raw_backgrounds = lookup.get("backgrounds", [])
         self.raw_adventuring_gear = lookup.get("adventuring-gear", [])
         self.raw_armor = lookup.get("armor", [])
@@ -260,7 +272,7 @@ class Compendium:
             self._actions_by_eid[(action.type_id, action.id)].append(action)
 
     def _deserialize_and_register_lookups(
-        self, cls: Type[T], data_source: List[dict], skip_out_filter: Callable[[T], bool] = None, **kwargs
+            self, cls: Type[T], data_source: List[dict], skip_out_filter: Callable[[T], bool] = None, **kwargs
     ) -> List[T]:
         out = []
         for entity_data in data_source:

--- a/utils/redisIO.py
+++ b/utils/redisIO.py
@@ -67,7 +67,7 @@ class RedisIO:
             default = {}
         out = await self._db.hgetall(key)
 
-        data = {key.decode('utf-8'): value for key, value in out.items()}
+        data = {key.decode("utf-8"): value for key, value in out.items()}
 
         if data is None:
             return default


### PR DESCRIPTION
### Summary
To address the MongoDB (DocumentDB) document size limitation for Monster Data, we considered various solutions, including migrating static files to S3, transitioning to a traditional relational database, or maintaining MongoDB using the GridFS client supplied by Mongo.

In alignment with our commitment to maintaining continuity for our community members operating their own Avrae instances, we've opted to retain data within MongoDB. This will be achieved through GridFS, with the flexibility of LaunchDarkly feature flags. These flags ensure that our users can choose whether to adopt GridFS for their needs, preserving flexibility and choice within the Avrae experience.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
