### PR TITLE
Uprev disnake to fix issue with display_name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ d20==1.1.2
 aiobotocore==2.1.0
 redis==4.6.0
 cachetools==4.2.2
-disnake~=2.7.0
+disnake~=2.9.0
 gspread==3.7.0
 httplib2==0.19.0
 launchdarkly-server-sdk==7.2.0


### PR DESCRIPTION
### Summary
Currently avrae cannot retrieve server display names since discord changed its display name setup. [2.9.0 disnake apparently fixes this in 2.9.0](https://docs.disnake.dev/en/stable/whats_new.html#v2-9-0), so this PR upgrades to that version. 

Current behaviour: 
`!test {{verify_signature(signature()).author.display_name}}` falls back to the same result as `!test {{verify_signature(signature()).author.name}}` (username).

This change should allow server usernames to be accessible via the `verify_signature` function once more.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
