### PR TITLE
Quickfix for Alias/Snippet Pagination

### DIFF
--- a/cogs5e/gamelog/cog.py
+++ b/cogs5e/gamelog/cog.py
@@ -42,8 +42,8 @@ class GameLog(commands.Cog):
         """
         Links a D&D Beyond campaign to this channel, displaying rolls made on players' character sheets in real time.
 
-        You must be the DM of the campaign to link it to a channel. 
-        
+        You must be the DM of the campaign to link it to a channel.
+
         This link should be the url visible on your web browser when you are viewing your campaign and *not* the join link.
 
         Not seeing a player's rolls? Link their D&D Beyond and Discord accounts [here](https://www.dndbeyond.com/account), and check with the `!ddb` command!

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -358,9 +358,11 @@ class CollectableManagementGroup(commands.Group):
         changes = "\n".join([f"`{old}` ({collection}) -> `{new}`" for old, new, collection in rename_tris])
         response = await confirm(
             ctx,
-            f"This will rename {len(rename_tris)} {self.obj_name_pl}. "
-            "Do you want to continue? (Reply with yes/no)\n"
-            f"{changes}",
+            (
+                f"This will rename {len(rename_tris)} {self.obj_name_pl}. "
+                "Do you want to continue? (Reply with yes/no)\n"
+                f"{changes}"
+            ),
         )
         if not response:
             return await ctx.send("Ok, aborting.")
@@ -427,9 +429,11 @@ class CollectableManagementGroup(commands.Group):
             collection = personal_obj.collection
             response = await confirm(
                 ctx,
-                f"This action will subscribe the server to the `{collection.name}` workshop collection, found at "
-                f"<{collection.url}>. This will add {collection.alias_count} aliases and "
-                f"{collection.snippet_count} snippets to the server. Do you want to continue? (Reply with yes/no)",
+                (
+                    f"This action will subscribe the server to the `{collection.name}` workshop collection, found at "
+                    f"<{collection.url}>. This will add {collection.alias_count} aliases and "
+                    f"{collection.snippet_count} snippets to the server. Do you want to continue? (Reply with yes/no)"
+                ),
             )
             if not response:
                 return await ctx.send("Ok, aborting.")
@@ -456,8 +460,10 @@ class CollectableManagementGroup(commands.Group):
         # check if it overwrites anything
         if existing_server_obj is not None and not await confirm(
             ctx,
-            f"There is already an existing server {self.obj_name} named `{name}`. Do you want to overwrite it? "
-            "(Reply with yes/no)",
+            (
+                f"There is already an existing server {self.obj_name} named `{name}`. Do you want to overwrite it? "
+                "(Reply with yes/no)"
+            ),
         ):
             return await ctx.send("Ok, aborting.")
 
@@ -584,15 +590,19 @@ class Customization(commands.Cog):
         if prefix.startswith("/"):
             if not await confirm(
                 ctx,
-                "Setting a prefix that begins with / may cause issues. "
-                "Are you sure you want to continue? (Reply with yes/no)",
+                (
+                    "Setting a prefix that begins with / may cause issues. "
+                    "Are you sure you want to continue? (Reply with yes/no)"
+                ),
             ):
                 return await ctx.send("Ok, cancelling.")
         else:
             if not await confirm(
                 ctx,
-                f"Are you sure you want to set my prefix to `{prefix}`? This will affect "
-                "everyone on this server! (Reply with yes/no)",
+                (
+                    f"Are you sure you want to set my prefix to `{prefix}`? This will affect "
+                    "everyone on this server! (Reply with yes/no)"
+                ),
             ):
                 return await ctx.send("Ok, cancelling.")
 
@@ -649,9 +659,11 @@ class Customization(commands.Cog):
         """Deletes ALL user aliases."""
         if not await confirm(
             ctx,
-            "This will delete **ALL** of your personal user aliases (it will not affect workshop subscriptions). "
-            "Are you *absolutely sure* you want to continue?\n"
-            "Type `Yes, I am sure` to confirm.",
+            (
+                "This will delete **ALL** of your personal user aliases (it will not affect workshop subscriptions). "
+                "Are you *absolutely sure* you want to continue?\n"
+                "Type `Yes, I am sure` to confirm."
+            ),
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -702,9 +714,11 @@ class Customization(commands.Cog):
         """Deletes ALL user snippets."""
         if not await confirm(
             ctx,
-            "This will delete **ALL** of your personal user snippets (it will not affect workshop subscriptions). "
-            "Are you *absolutely sure* you want to continue?\n"
-            "Type `Yes, I am sure` to confirm.",
+            (
+                "This will delete **ALL** of your personal user snippets (it will not affect workshop subscriptions). "
+                "Are you *absolutely sure* you want to continue?\n"
+                "Type `Yes, I am sure` to confirm."
+            ),
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -820,9 +834,11 @@ class Customization(commands.Cog):
         char: Character = await ctx.get_character()
         if not await confirm(
             ctx,
-            f"This will delete **ALL** of your character variables for {char.name}. "
-            "Are you *absolutely sure* you want to continue?\n"
-            "Type `Yes, I am sure` to confirm.",
+            (
+                f"This will delete **ALL** of your character variables for {char.name}. "
+                "Are you *absolutely sure* you want to continue?\n"
+                "Type `Yes, I am sure` to confirm."
+            ),
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -885,9 +901,11 @@ class Customization(commands.Cog):
         """Deletes ALL user variables."""
         if not await confirm(
             ctx,
-            "This will delete **ALL** of your user variables (uvars). "
-            "Are you *absolutely sure* you want to continue?\n"
-            "Type `Yes, I am sure` to confirm.",
+            (
+                "This will delete **ALL** of your user variables (uvars). "
+                "Are you *absolutely sure* you want to continue?\n"
+                "Type `Yes, I am sure` to confirm."
+            ),
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -222,9 +222,6 @@ class CollectableManagementGroup(commands.Group):
             if bindings := subscription_doc[self.binding_key]:
                 collections.append((the_collection.name, ", ".join(sorted(ab["name"] for ab in bindings))))
 
-        # Mock 40 collections
-        collections.extend([("Collection", "Alias") for _ in range(25)])
-
         # build the resulting embed
         if collections:
             amt_per_page = 20

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -222,15 +222,19 @@ class CollectableManagementGroup(commands.Group):
             if bindings := subscription_doc[self.binding_key]:
                 collections.append((the_collection.name, ", ".join(sorted(ab["name"] for ab in bindings))))
 
+        # Mock 40 collections
+        collections.extend([("Collection", "Alias") for _ in range(25)])
+
         # build the resulting embed
         if collections:
+            amt_per_page = 20
             total = len(collections)
-            maxpage = ceil(total / 25)
+            maxpage = ceil(total / amt_per_page)
             page = max(1, min(page, maxpage))
-            pages = [collections[i : i + 25] for i in range(0, total, 25)]
+            pages = [collections[i : i + amt_per_page] for i in range(0, total, amt_per_page)]
             for name, bindings_str in pages[page - 1]:
                 ep.add_field(name, bindings_str)
-            if total > 25:
+            if total > amt_per_page:
                 ep.set_footer(value=f"Page [{page}/{maxpage}] | {ctx.prefix}{self.command_group_name} list <page>")
         else:
             ep.add_description(
@@ -357,11 +361,9 @@ class CollectableManagementGroup(commands.Group):
         changes = "\n".join([f"`{old}` ({collection}) -> `{new}`" for old, new, collection in rename_tris])
         response = await confirm(
             ctx,
-            (
-                f"This will rename {len(rename_tris)} {self.obj_name_pl}. "
-                "Do you want to continue? (Reply with yes/no)\n"
-                f"{changes}"
-            ),
+            f"This will rename {len(rename_tris)} {self.obj_name_pl}. "
+            "Do you want to continue? (Reply with yes/no)\n"
+            f"{changes}",
         )
         if not response:
             return await ctx.send("Ok, aborting.")
@@ -428,11 +430,9 @@ class CollectableManagementGroup(commands.Group):
             collection = personal_obj.collection
             response = await confirm(
                 ctx,
-                (
-                    f"This action will subscribe the server to the `{collection.name}` workshop collection, found at "
-                    f"<{collection.url}>. This will add {collection.alias_count} aliases and "
-                    f"{collection.snippet_count} snippets to the server. Do you want to continue? (Reply with yes/no)"
-                ),
+                f"This action will subscribe the server to the `{collection.name}` workshop collection, found at "
+                f"<{collection.url}>. This will add {collection.alias_count} aliases and "
+                f"{collection.snippet_count} snippets to the server. Do you want to continue? (Reply with yes/no)",
             )
             if not response:
                 return await ctx.send("Ok, aborting.")
@@ -459,10 +459,8 @@ class CollectableManagementGroup(commands.Group):
         # check if it overwrites anything
         if existing_server_obj is not None and not await confirm(
             ctx,
-            (
-                f"There is already an existing server {self.obj_name} named `{name}`. Do you want to overwrite it? "
-                "(Reply with yes/no)"
-            ),
+            f"There is already an existing server {self.obj_name} named `{name}`. Do you want to overwrite it? "
+            "(Reply with yes/no)",
         ):
             return await ctx.send("Ok, aborting.")
 
@@ -589,19 +587,15 @@ class Customization(commands.Cog):
         if prefix.startswith("/"):
             if not await confirm(
                 ctx,
-                (
-                    "Setting a prefix that begins with / may cause issues. "
-                    "Are you sure you want to continue? (Reply with yes/no)"
-                ),
+                "Setting a prefix that begins with / may cause issues. "
+                "Are you sure you want to continue? (Reply with yes/no)",
             ):
                 return await ctx.send("Ok, cancelling.")
         else:
             if not await confirm(
                 ctx,
-                (
-                    f"Are you sure you want to set my prefix to `{prefix}`? This will affect "
-                    "everyone on this server! (Reply with yes/no)"
-                ),
+                f"Are you sure you want to set my prefix to `{prefix}`? This will affect "
+                "everyone on this server! (Reply with yes/no)",
             ):
                 return await ctx.send("Ok, cancelling.")
 
@@ -658,11 +652,9 @@ class Customization(commands.Cog):
         """Deletes ALL user aliases."""
         if not await confirm(
             ctx,
-            (
-                "This will delete **ALL** of your personal user aliases (it will not affect workshop subscriptions). "
-                "Are you *absolutely sure* you want to continue?\n"
-                "Type `Yes, I am sure` to confirm."
-            ),
+            "This will delete **ALL** of your personal user aliases (it will not affect workshop subscriptions). "
+            "Are you *absolutely sure* you want to continue?\n"
+            "Type `Yes, I am sure` to confirm.",
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -713,11 +705,9 @@ class Customization(commands.Cog):
         """Deletes ALL user snippets."""
         if not await confirm(
             ctx,
-            (
-                "This will delete **ALL** of your personal user snippets (it will not affect workshop subscriptions). "
-                "Are you *absolutely sure* you want to continue?\n"
-                "Type `Yes, I am sure` to confirm."
-            ),
+            "This will delete **ALL** of your personal user snippets (it will not affect workshop subscriptions). "
+            "Are you *absolutely sure* you want to continue?\n"
+            "Type `Yes, I am sure` to confirm.",
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -833,11 +823,9 @@ class Customization(commands.Cog):
         char: Character = await ctx.get_character()
         if not await confirm(
             ctx,
-            (
-                f"This will delete **ALL** of your character variables for {char.name}. "
-                "Are you *absolutely sure* you want to continue?\n"
-                "Type `Yes, I am sure` to confirm."
-            ),
+            f"This will delete **ALL** of your character variables for {char.name}. "
+            "Are you *absolutely sure* you want to continue?\n"
+            "Type `Yes, I am sure` to confirm.",
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")
@@ -900,11 +888,9 @@ class Customization(commands.Cog):
         """Deletes ALL user variables."""
         if not await confirm(
             ctx,
-            (
-                "This will delete **ALL** of your user variables (uvars). "
-                "Are you *absolutely sure* you want to continue?\n"
-                "Type `Yes, I am sure` to confirm."
-            ),
+            "This will delete **ALL** of your user variables (uvars). "
+            "Are you *absolutely sure* you want to continue?\n"
+            "Type `Yes, I am sure` to confirm.",
             response_check=lambda r: r == "Yes, I am sure",
         ):
             return await ctx.send("Unconfirmed. Aborting.")


### PR DESCRIPTION
### Summary
Discord made a change so that embeds sent with more than 25 fields will no longer trim the excess fields, but instead error. 

While we do have pagination set up on most things, at least for alias/snippet lists its set to paginate based on the number of collections displayed, as opposed to the number of fields. This is mostly fine, unless one collection has enough entries in it to go over the max field length, in which case we auto append a second field with a blank title, containing the rest (ad nauseum until all the data is covered).

This means if a user or server has 25+ collections, and at least one of those collections goes over the max field value size, an extra field gets added, and it sends the single page of 25 collections with 26+ fields. This was technically a bug for us before now, because instead of erroring, it just wouldn't display the last collection(s) for that page. This is a bit of an edge case, however, and due to it just not showing, significantly harder for someone to notice a collection missing amongst 25+ collections.

The extra changes in the file is just my black formatter going crazy for some reason, nothing broke though.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
