### PR TITLE
Swap deprecated Image.ANTIALIAS for Image.Resampling.LANCZOS

### DIFF
--- a/utils/img.py
+++ b/utils/img.py
@@ -41,13 +41,11 @@ async def generate_token(img_url, is_subscriber=False, token_args=None):
 
         # crop/resize the token image
         width, height = img.size
-        is_taller = height >= width
-        if is_taller:
+        if height >= width:
             box = (0, 0, width, width)
         else:
             box = (width / 2 - height / 2, 0, width / 2 + height / 2, height)
-        img = img.crop(box)
-        img = img.resize(TOKEN_SIZE, Image.ANTIALIAS)
+        img = img.resize(TOKEN_SIZE, Image.Resampling.LANCZOS, box)
 
         # paste mask
         mask_img = Image.open("res/alphatemplate.tif")


### PR DESCRIPTION
### Summary
Image.ANTIALIAS is deprecated and removed in pillow 10 causing token utils to no longer be valid. The replacement for Image.ANTIALIAS is the IntEnum Resampling.LANCZOS, which Image.ANTIALIAS was an alias to previously. Also makes crop and resize into a single step by leveraging the box arg for img.resize

See [Pillow 9.1.0 update notes](https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html) for info about the deprecation.
### Changelog Entry
Swap deprecated Image.ANTIALIAS for Image.Resampling.LANCZOS

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
