### PR TITLE
fix: preserve ephem arguments in combat checks/saves

### DIFF
--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -375,7 +375,7 @@ def _monster_factory_bestiary_builder(data, bestiary_name):
     attacks.extend(atks)
     _, atks = parse_bestiary_builder_traits(data, "regional")
     attacks.extend(atks)
-    
+
     name_duplications = {}
     for atk in attacks:
         if atk.name in name_duplications:

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Any
 
 from d20 import roll
 
@@ -60,8 +61,11 @@ def run_check(skill_key, caster, args, embed):
 
     # ieffect handling
     if isinstance(caster, init.Combatant):
+        combat_context: dict[str, Any] = {}
+
         # -cb
-        args["b"] = args.get("b") + caster.active_effects(mapper=lambda effect: effect.effects.check_bonus, default=[])
+        combat_context["b"] = caster.active_effects(mapper=lambda effect: effect.effects.check_bonus, default=[])
+
         # -cadv/cdis
         cadv_effects = caster.active_effects(
             mapper=lambda effect: effect.effects.check_adv, reducer=lambda checks: set().union(*checks), default=set()
@@ -70,9 +74,12 @@ def run_check(skill_key, caster, args, embed):
             mapper=lambda effect: effect.effects.check_dis, reducer=lambda checks: set().union(*checks), default=set()
         )
         if skill_key in cadv_effects or base_ability_key in cadv_effects:
-            args["adv"] = True
+            combat_context["adv"] = True
         if skill_key in cdis_effects or base_ability_key in cdis_effects:
-            args["dis"] = True
+            combat_context["dis"] = True
+
+        args.add_context("combat", combat_context)
+        args.set_context("combat")
 
     result = _run_common(skill, args, embed, mod_override=mod)
     return CheckResult(rolls=result.rolls, skill=skill, skill_name=skill_name, skill_roll_result=result)
@@ -114,8 +121,9 @@ def run_save(save_key, caster, args, embed):
 
     # ieffect handling
     if isinstance(caster, init.Combatant):
+        combat_context: dict[str, Any] = {}
         # -sb
-        args["b"] = args.get("b") + caster.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+        combat_context["b"] = caster.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
         # -sadv/sdis
         sadv_effects = caster.active_effects(
             mapper=lambda effect: effect.effects.save_adv, reducer=lambda saves: set().union(*saves), default=set()
@@ -124,9 +132,12 @@ def run_save(save_key, caster, args, embed):
             mapper=lambda effect: effect.effects.save_dis, reducer=lambda saves: set().union(*saves), default=set()
         )
         if stat in sadv_effects:
-            args["adv"] = True  # Because adv() only checks last() just forcibly add them
+            combat_context["adv"] = True  # Because adv() only checks last() just forcibly add them
         if stat in sdis_effects:
-            args["dis"] = True
+            combat_context["dis"] = True
+
+        args.add_context("combat", combat_context)
+        args.set_context("combat")
 
     result = _run_common(save, args, embed, rr_format="Save {}")
     return SaveResult(rolls=result.rolls, skill=save, skill_name=stat_name, skill_roll_result=result)


### PR DESCRIPTION
### Summary
Preserve ephemeral arguments in combat checks/saves by storing the arguments as a context, instead of overwriting the argument list directly.

Fixes AVR-978

### Changelog Entry
Preserve ephemeral args in combat checks/saves (Fixed AVR-978)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
