### PR TITLE
fix: properly handle cadv/cdis/sadv/sdis in arg context

### DIFF
--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -74,9 +74,9 @@ def run_check(skill_key, caster, args, embed):
             mapper=lambda effect: effect.effects.check_dis, reducer=lambda checks: set().union(*checks), default=set()
         )
         if skill_key in cadv_effects or base_ability_key in cadv_effects:
-            combat_context["adv"] = True
+            combat_context["adv"] = ["True"]
         if skill_key in cdis_effects or base_ability_key in cdis_effects:
-            combat_context["dis"] = True
+            combat_context["dis"] = ["True"]
 
         args.add_context("combat", combat_context)
         args.set_context("combat")
@@ -132,9 +132,9 @@ def run_save(save_key, caster, args, embed):
             mapper=lambda effect: effect.effects.save_dis, reducer=lambda saves: set().union(*saves), default=set()
         )
         if stat in sadv_effects:
-            combat_context["adv"] = True  # Because adv() only checks last() just forcibly add them
+            combat_context["adv"] = ["True"]  # Because adv() only checks last() just forcibly add them
         if stat in sdis_effects:
-            combat_context["dis"] = True
+            combat_context["dis"] = ["True"]
 
         args.add_context("combat", combat_context)
         args.set_context("combat")


### PR DESCRIPTION
### Summary
Corrects an issue with #1971 by making the combat context set `["True"]` instead of `True`, as `add_context` expects a list of strings and won't accept a direct value like setting it directly did.

### Changelog Entry
Fix handling of cadv/cdis/sadv/sdis from ieffects

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
