### PR TITLE
Improvements to snippet parsing

### DIFF
--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -368,9 +368,7 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
     if not isinstance(args, list):
         args = list(args)
 
-    original_args = args[:]
-    if base_args is not None:
-        original_args = base_args + original_args
+    original_args = str((base_args or []) + args)
 
     new_list = []
 
@@ -395,7 +393,7 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
                 await workshop_entitlements_check(ctx, the_snippet)
 
             if the_snippet:
-                the_snippet.code = the_snippet.code.replace("&ARGS&", str(original_args))
+                the_snippet.code = the_snippet.code.replace("&ARGS&", original_args)
                 # enter the evaluator
                 execution_scope = ExecutionScope.SERVER_SNIPPET if server_invoker else ExecutionScope.PERSONAL_SNIPPET
                 new_args += argsplit(

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -351,7 +351,7 @@ async def update_gvar(ctx, gid, value):
 
 
 # snippets
-async def parse_snippets(args, ctx, statblock=None, character=None, base_args=None) -> str:
+async def parse_snippets(args, ctx, statblock=None, character=None, base_args=None) -> [str]:
     """
     Parses user and server snippets, including any inline scripting.
 
@@ -360,7 +360,7 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
     :param statblock: The statblock to populate locals from.
     :param character: If passed, provides the base character to use character-scoped functions against.
     :param base_args: The args to pass through to the snippet code via &ARGS&
-    :return: The string, with snippets replaced.
+    :return: The list of args, with snippets replaced.
     """
     # make args a list of str
     if isinstance(args, str):
@@ -371,6 +371,8 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
     original_args = args[:]
     if base_args is not None:
         original_args = base_args + original_args
+
+    new_list = []
 
     # set up the evaluator
     evaluator = await evaluators.ScriptingEvaluator.new(ctx)
@@ -396,8 +398,10 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
                 the_snippet.code = the_snippet.code.replace("&ARGS&", str(original_args))
                 # enter the evaluator
                 execution_scope = ExecutionScope.SERVER_SNIPPET if server_invoker else ExecutionScope.PERSONAL_SNIPPET
-                args[index] = await evaluator.transformed_str_async(
-                    the_snippet.code, execution_scope=execution_scope, invoking_object=the_snippet
+                new_args += argsplit(
+                    await evaluator.transformed_str_async(
+                        the_snippet.code, execution_scope=execution_scope, invoking_object=the_snippet
+                    )
                 )
                 # analytics
                 await the_snippet.log_invocation(ctx, server_invoker)
@@ -409,11 +413,11 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
             else:
                 # in case the user is using old-style on the fly templating
                 arg = await evaluator.transformed_str_async(arg, execution_scope=ExecutionScope.PERSONAL_SNIPPET)
-                args[index] = argquote(arg)
+                new_args.append(argquote(arg))
     finally:
         await evaluator.run_commits()
         await send_warnings(ctx, evaluator.warnings)
-    return " ".join(args)
+    return new_args
 
 
 # transformers

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -370,7 +370,7 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
 
     original_args = str((base_args or []) + args)
 
-    new_list = []
+    new_args = []
 
     # set up the evaluator
     evaluator = await evaluators.ScriptingEvaluator.new(ctx)

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -1,6 +1,7 @@
 import collections
 import itertools
 import re
+import string
 from typing import Iterator
 
 from disnake.ext.commands import BadArgument, ExpectedClosingQuoteError
@@ -380,7 +381,7 @@ class ParsedArguments:
 
 # ==== other helpers ====
 def argquote(arg: str):
-    if " " in arg:
+    if any(char in arg for char in string.whitespace):
         arg = arg.replace('"', '\\"')  # re.sub(r'(?<!\\)"', r'\"', arg)
         arg = f'"{arg}"'
     return arg


### PR DESCRIPTION
### Summary
- We parse raw arguments into a string, only to immediately split them back into a list once we get to argument parsing. Instead we should just return the list.
- argquote needs to match str.isspace, as otherwise we will split on characters that we are not quoting.
- Convert original_args to a string only once, since it won't change between accesses.

### Changelog Entry
Improvements to snippet parsing

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
