### PR TITLE
Allow quote pairs to work everywhere argparse is used

### DIFF
--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -411,7 +411,7 @@ async def parse_snippets(args, ctx, statblock=None, character=None, base_args=No
             else:
                 # in case the user is using old-style on the fly templating
                 arg = await evaluator.transformed_str_async(arg, execution_scope=ExecutionScope.PERSONAL_SNIPPET)
-                new_args.append(argquote(arg))
+                new_args.append(arg)
     finally:
         await evaluator.run_commits()
         await send_warnings(ctx, evaluator.warnings)

--- a/cogs5e/dice/cog.py
+++ b/cogs5e/dice/cog.py
@@ -206,7 +206,7 @@ class Dice(commands.Cog):
         {VALID_CHECK_ARGS}
         """,
     )
-    async def monster_check(self, ctx, monster_name, check, *args):
+    async def monster_check(self, ctx, monster_name, check, *, args=""):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
         args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, check])
@@ -229,7 +229,7 @@ class Dice(commands.Cog):
         {VALID_SAVE_ARGS}
         """,
     )
-    async def monster_save(self, ctx, monster_name, save_stat, *args):
+    async def monster_save(self, ctx, monster_name, save_stat, *, args=""):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
         args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, save_stat])
@@ -254,7 +254,7 @@ class Dice(commands.Cog):
         {VALID_AUTOMATION_ARGS}
         """,
     )
-    async def monster_cast(self, ctx, monster_name, spell_name, *args):
+    async def monster_cast(self, ctx, monster_name, spell_name, *, args=""):
         await try_delete(ctx.message)
         monster: Monster = await select_monster_full(ctx, monster_name)
         args = await helpers.parse_snippets(args, ctx, statblock=monster, base_args=[monster_name, spell_name])

--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -284,7 +284,7 @@ class GameTrack(commands.Cog):
         await gameutils.send_hp_result(ctx, caster, delta)
 
     @game.group(name="deathsave", aliases=["ds"], invoke_without_command=True)
-    async def game_deathsave(self, ctx, *args):
+    async def game_deathsave(self, ctx, *, args=""):
         """Commands to manage character death saves.
         __Valid Arguments__
         See `!help save`."""
@@ -476,7 +476,7 @@ class GameTrack(commands.Cog):
         await ep.send_to(ctx)
 
     @spellbook.command(name="add")
-    async def spellbook_add(self, ctx, spell_name, *args):
+    async def spellbook_add(self, ctx, spell_name, *, args=""):
         """
         Adds a spell to the spellbook override.
 
@@ -622,7 +622,7 @@ class GameTrack(commands.Cog):
         await ctx.send(embed=result_embed)
 
     @customcounter.command(name="create")
-    async def customcounter_create(self, ctx, name, *args):
+    async def customcounter_create(self, ctx, name, *, args=""):
         """
         Creates a new custom counter.
         __Valid Arguments__
@@ -677,7 +677,7 @@ class GameTrack(commands.Cog):
             await ctx.send(f"Custom counter created.\n**{name}**\n{new_counter.full_str()}")
 
     @customcounter.command(name="edit")
-    async def customcounter_edit(self, ctx, name, *args):
+    async def customcounter_edit(self, ctx, name, *, args=""):
         """
         Edits an existing custom counter replacing passed arguments.
 

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -109,7 +109,7 @@ class InitTracker(commands.Cog):
         await ctx.send(f"Incorrect usage. Use {ctx.prefix}help init for help.")
 
     @init.command()
-    async def begin(self, ctx, *args):
+    async def begin(self, ctx, *, args=""):
         """
         Begins combat in the channel the command is invoked in.
         __Valid Arguments__
@@ -166,7 +166,7 @@ class InitTracker(commands.Cog):
         await ctx.send(out)
 
     @init.command()
-    async def add(self, ctx, modifier: int, name: str, *args):
+    async def add(self, ctx, modifier: int, name: str, *, args=""):
         """
         Adds a generic combatant to the initiative order.
 
@@ -235,7 +235,7 @@ class InitTracker(commands.Cog):
         await combat.final(ctx)
 
     @init.command()
-    async def madd(self, ctx, monster_name: str, *args):
+    async def madd(self, ctx, monster_name: str, *, args=""):
         """Adds a monster to combat.
         __Valid Arguments__
         `-name <name>` - Sets the combatant's name. Use "#" for auto-numbering, e.g. "Orc#"
@@ -526,7 +526,7 @@ class InitTracker(commands.Cog):
         await combat.final(ctx)
 
     @init.command(name="reroll", aliases=["shuffle"])
-    async def reroll(self, ctx, *args):
+    async def reroll(self, ctx, *, args=""):
         """
         Rerolls initiative for all combatants, and starts a new round of combat.
         __Valid Arguments__
@@ -562,7 +562,7 @@ class InitTracker(commands.Cog):
         await combat.final(ctx)
 
     @init.command(name="meta", aliases=["metaset"])
-    async def metasetting(self, ctx, *settings):
+    async def metasetting(self, ctx, *, settings=""):
         """
         Changes the settings of the active combat.
         __Valid Settings__
@@ -649,7 +649,7 @@ class InitTracker(commands.Cog):
         await combat.final(ctx)
 
     @init.command(aliases=["opts"])
-    async def opt(self, ctx, name: str, *args):
+    async def opt(self, ctx, name: str, *, args=""):
         """
         Edits the options of a combatant.
         __Valid Arguments__
@@ -957,7 +957,7 @@ class InitTracker(commands.Cog):
         await gameutils.send_hp_result(ctx, combatant, delta)
 
     @init.command()
-    async def effect(self, ctx, target_name: str, effect_name: str, *args):
+    async def effect(self, ctx, target_name: str, effect_name: str, *, args=""):
         """
         Attaches a status effect to a combatant.
         [args] is a set of args that affects a combatant in combat.

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -768,7 +768,7 @@ class Lookup(commands.Cog):
         await destination.send(embed=embed)
 
     @commands.command()
-    async def token(self, ctx, name=None, *args):
+    async def token(self, ctx, name=None, *, args=""):
         """
         Shows a monster or your character's token.
         __Valid Arguments__
@@ -780,8 +780,8 @@ class Lookup(commands.Cog):
             if token_cmd is None:
                 return await ctx.send("Error: SheetManager cog not loaded.")
             if name:
-                args = (name, *args)
-            return await ctx.invoke(token_cmd, *args)
+                args = name + " " + args
+            return await ctx.invoke(token_cmd, args=args)
 
         # select monster
         token_args = argparse(args)
@@ -1059,7 +1059,7 @@ class Lookup(commands.Cog):
     @commands.command(hidden=True)
     @commands.guild_only()
     @checks.admin_or_permissions(manage_guild=True)
-    async def lookup_settings(self, ctx, *args):
+    async def lookup_settings(self, ctx, *, args=""):
         """This command has been replaced by `!servsettings`. If you're used to it, it still works like before!"""
         guild_settings = await ctx.get_server_settings()
         if not args:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -114,7 +114,7 @@ class SheetManager(commands.Cog):
 
     # ---- attack management commands ----
     @action.command(name="add", aliases=["create"])
-    async def attack_add(self, ctx, name, *args):
+    async def attack_add(self, ctx, name, *, args=""):
         """
         Adds an attack to the active character.
         __Valid Arguments__
@@ -246,7 +246,7 @@ class SheetManager(commands.Cog):
         {VALID_SAVE_ARGS}
         """,
     )
-    async def save(self, ctx, skill, *args):
+    async def save(self, ctx, skill, *, args=""):
         if skill == "death":
             base_cmd = "game deathsave"
             if args and (sub_cmd := args[0].lower()) in ("fail", "success", "reset"):
@@ -255,7 +255,7 @@ class SheetManager(commands.Cog):
             ds_cmd = self.bot.get_command(base_cmd)
             if ds_cmd is None:
                 return await ctx.send("Error: GameTrack cog not loaded.")
-            return await ctx.invoke(ds_cmd, *args)
+            return await ctx.invoke(ds_cmd, args=args)
 
         char: Character = await ctx.get_character()
 
@@ -283,7 +283,7 @@ class SheetManager(commands.Cog):
         {VALID_CHECK_ARGS}
         """,
     )
-    async def check(self, ctx, check, *args):
+    async def check(self, ctx, check, *, args=""):
         char: Character = await ctx.get_character()
         skill_key = await search_and_select(ctx, SKILL_NAMES, check, camel_to_title)
         args = await self.new_arg_stuff(args, ctx, char, base_args=[check])
@@ -373,7 +373,7 @@ class SheetManager(commands.Cog):
         await ctx.send("Portrait override removed!")
 
     @commands.command(hidden=True)  # hidden, as just called by token command
-    async def playertoken(self, ctx, *args):
+    async def playertoken(self, ctx, *, args=""):
         """
         Generates and sends a token for use on VTTs.
         __Valid Arguments__
@@ -518,7 +518,7 @@ class SheetManager(commands.Cog):
 
     @commands.command()
     @commands.max_concurrency(1, BucketType.user)
-    async def update(self, ctx, *args):
+    async def update(self, ctx, *, args=""):
         """
         Updates the current character sheet, preserving all settings.
         __Valid Arguments__
@@ -663,7 +663,7 @@ class SheetManager(commands.Cog):
 
     @commands.command(name="import")
     @commands.max_concurrency(1, BucketType.user)
-    async def import_sheet(self, ctx, url: str, *args):
+    async def import_sheet(self, ctx, url: str, *, args=""):
         """
         Loads a character sheet from one of the accepted sites:
             [D&D Beyond](https://www.dndbeyond.com/)
@@ -738,11 +738,11 @@ class SheetManager(commands.Cog):
 
     @commands.command(hidden=True, aliases=["gsheet", "dicecloud"])
     @commands.max_concurrency(1, BucketType.user)
-    async def beyond(self, ctx, url: str, *args):
+    async def beyond(self, ctx, url: str, *, args=""):
         """
         This is an old command and has been replaced. Use `!import` instead!
         """
-        await self.import_sheet(ctx, url, *args)
+        await self.import_sheet(ctx, url, args=args)
 
     @staticmethod
     async def _load_sheet(ctx, parser, args, loading):


### PR DESCRIPTION
### Summary
Some commands being set up to receive a list of args from Disnake causes some issues with argparse, since Disnake only uses `"` for quoted strings, and as such the quote pairs that argsplitter and by extension argparse will not be used. Switching all of these commands to take a raw arg string from Disnake, and parse entirely using argparse resolves this issue.

### Changelog Entry
Allow quote pairs to work everywhere argparse is used.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
