### PR TITLE
Add damage information to non-init attacks

### DIFF
--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -317,6 +317,7 @@ class AutomationTarget:
 
     # ==== helpers ====
     def damage(self, autoctx: AutomationContext, amount: int, allow_overheal: bool = True):
+        # add damage footer when we attack a Combatant
         if not self.is_simple:
             result = self.target.modify_hp(-amount, overflow=allow_overheal)
             autoctx.footer_queue(f"{self.target.name}: {result}")
@@ -327,6 +328,9 @@ class AutomationTarget:
 
                 if self.target.is_concentrating() and amount > 0:
                     autoctx.queue(f"**Concentration**: DC {int(max(amount / 2, 10))}")
+        # for a non-init target, we still want to display that a damage node was run in the footer.
+        else:
+            autoctx.footer_queue(f"{self.target or '<No Target>'}: Dealt {amount} damage!")
 
     # ==== target base class helpers ====
     @cached_property

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -110,7 +110,7 @@ async def run_action(
     else:
         embed.title = f"{name} uses {action.name}!"
 
-    if action.automation is not None:
+    if action.automation:
         result = await run_automation(ctx, embed, args, caster, action.automation, targets, combat)
     else:
         # else, show action description and note that it can't be automated


### PR DESCRIPTION
### Summary
Implements existing behavior in actions to include actions taken outside of initiative. This PR adds the "Damage taken" footer. The style of the message is modeled after the existing message when a creature with no HP (ex: added via `!i add`) is damaged.

Corrects an issue that prevented actions without automation from displaying a footer showing there was no automation.

### Changelog Entry

- Corrects an issue that prevented actions without automation from displaying a footer showing there was no automation.
- Actions that have Damage nodes will now show a footer of the damage dealt when out of combat

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
