### PR TITLE
fix(gsheets): use http_client login method

### DIFF
--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -313,15 +313,8 @@ class GoogleSheet(SheetLoaderABC):
     @staticmethod
     async def _refresh_google_token():
         with GoogleSheet._client_lock():
-
-            def _():
-                GoogleSheet.g_client.auth.refresh(request=Request())
-                GoogleSheet.g_client.session.headers.update(
-                    {"Authorization": "Bearer %s" % GoogleSheet.g_client.auth.token}
-                )
-
             try:
-                await asyncio.get_event_loop().run_in_executor(None, _)
+                await asyncio.get_event_loop().run_in_executor(None, GoogleSheet.g_client.http_client.login)
             except:
                 GoogleSheet._client_initializing = False
                 raise


### PR DESCRIPTION
### Summary
At some point between gspread 3.7.0 and 6.0.0, gspread moved auth information into a new `HTTPClient` class which `gspread.Client` wraps.

However `HTTPClient` also provides a method which does the exact same thing that the existing token refresh method does.

I haven't been able to fully test if it works, however logically it should, since the body of the function is the same, it's just in a different place.

### Changelog Entry
Fix GSheet reauthentication issue.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
