### PR TITLE
Fix exception handling for gsheets

### DIFF
--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -15,7 +15,6 @@ from urllib.parse import urlparse
 import google.oauth2.service_account
 import gspread
 from d20 import RollSyntaxError
-from google.auth.transport.requests import Request
 from google.oauth2.service_account import Credentials
 from gspread import SpreadsheetNotFound
 from gspread.exceptions import APIError, WorksheetNotFound

--- a/cogs5e/sheets/gsheet.py
+++ b/cogs5e/sheets/gsheet.py
@@ -354,10 +354,10 @@ class GoogleSheet(SheetLoaderABC):
         owner_id = str(ctx.author.id)
         try:
             await self.get_character()
-        except (KeyError, SpreadsheetNotFound, APIError):
+        except (KeyError, SpreadsheetNotFound, APIError, PermissionError):
             raise ExternalImportError(
                 "Invalid character sheet. Make sure you've shared it with me at "
-                f"`{GoogleSheet.g_client.auth.signer_email}`, or made the sheet viewable to 'Anyone with the link'!"
+                f"`{GoogleSheet.g_client.http_client.auth.service_account_email}`, or made the sheet viewable to 'Anyone with the link'!"
             )
         except Exception:
             raise


### PR DESCRIPTION
### Summary
gspread now raises a PermissionError if the client does not have access to the requested sheet, so we must handle it as well.

Need to access auth within http_client to get the email.

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
