### PR TITLE
Add typographic apostrophe ’ into the same exception as '

### DIFF
--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -447,7 +447,7 @@ class CustomStringView(StringView):
                 continue
 
             # opening quote
-            if not is_quoted and current in ALL_QUOTES and current != "'":  # special case: apostrophes in mid-string
+            if not is_quoted and current in ALL_QUOTES and current != "'" and current != "’":  # special case: apostrophes in mid-string
                 close_quote = QUOTE_PAIRS.get(current)
                 is_quoted = True
                 _escaped_quotes = (current, close_quote)


### PR DESCRIPTION
### Summary
Resolves #1904 (AVR-952 Argument parsing fails with typographic apostrophe)

### Changelog Entry
Add typographic apostrophe ’ (aka smart quote) into the exception list when considering mid-string apostrophes.

### Checklist
- [x] Typographic apostrophe (smart quote) now behaves similarly as normal apostrophe
#### PR Type
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] ~~I have updated the documentation to reflect the changes.~~ No relevant documentation to be updated
