### PR TITLE
Add spell_level as an automation variable

### DIFF
--- a/cogs5e/models/automation/effects/castspell.py
+++ b/cogs5e/models/automation/effects/castspell.py
@@ -61,9 +61,6 @@ class CastSpell(Effect):
             autoctx.meta_queue(f"**Error**: Unable to cast {spell.name} at level {cast_level} (invalid level).")
             return CastSpellResult(success=False, spell_id=self.id)
 
-        # AFR-988
-        autoctx.metavars["lastSpellLevel"] = cast_level
-
         if autoctx.is_spell:
             autoctx.meta_queue(f"**Error**: Unable to cast another spell inside a spell.")
             return CastSpellResult(success=False, spell_id=self.id)
@@ -75,6 +72,9 @@ class CastSpell(Effect):
             old_dc_override = autoctx.dc_override
             old_spell_override = autoctx.evaluator.builtins.get("spell")
             old_level_override = autoctx.spell_level_override
+            autoctx.metavars["spell_level"] = (
+                old_spell_level := autoctx.spell_level_override if autoctx.spell_level_override else cast_level
+            )
 
             # parenting
             explicit_parent = None
@@ -98,7 +98,9 @@ class CastSpell(Effect):
                 spell_override = autoctx.evaluator.builtins["spell"] = autoctx.parse_intexpression(self.casting_mod)
             if self.level is not None:
                 autoctx.spell_level_override = self.level
+                autoctx.metavars["spell_level"] = autoctx.spell_level_override
             autoctx.spell = spell
+
             results = self.run_children(spell.automation.effects, autoctx)
 
             # and restore them
@@ -107,6 +109,7 @@ class CastSpell(Effect):
             autoctx.evaluator.builtins["spell"] = old_spell_override
             autoctx.spell_level_override = old_level_override
             autoctx.spell = None
+            autoctx.metavars["spell_level"] = old_spell_level
 
             # display higher level info
             if cast_level != spell.level and spell.higherlevels:

--- a/cogs5e/models/automation/effects/castspell.py
+++ b/cogs5e/models/automation/effects/castspell.py
@@ -60,6 +60,10 @@ class CastSpell(Effect):
         if not spell.level <= cast_level <= 9:
             autoctx.meta_queue(f"**Error**: Unable to cast {spell.name} at level {cast_level} (invalid level).")
             return CastSpellResult(success=False, spell_id=self.id)
+
+        # AFR-988
+        autoctx.metavars["lastSpellLevel"] = cast_level
+
         if autoctx.is_spell:
             autoctx.meta_queue(f"**Error**: Unable to cast another spell inside a spell.")
             return CastSpellResult(success=False, spell_id=self.id)

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -73,6 +73,7 @@ class AutomationContext:
 
         self.metavars["spell_attack_bonus"] = self.ab_override or self.caster.spellbook.sab
         self.metavars["spell_dc"] = self.dc_override or self.caster.spellbook.dc
+        self.metavars["spell_level"] = self.spell_level_override
 
         # InitiativeEffect utils
         self.ieffect = ieffect

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -10,7 +10,7 @@ from cogs5e.models import embeds
 from cogs5e.models.errors import InvalidArgument, InvalidSpellLevel, RequiresLicense
 from cogs5e.models.sheet.action import Action, Actions
 from cogs5e.models.sheet.attack import Attack, AttackList
-from gamedata import lookuputils
+from gamedata import lookuputils, monster
 from utils import constants
 from utils.enums import CritDamageType
 from utils.functions import a_or_an, confirm, maybe_http_url, natural_join, search_and_select, smart_trim, verbose_stat
@@ -302,6 +302,7 @@ async def cast_spell(
             ab_override=ab_override,
             dc_override=dc_override,
             spell_override=spell_override,
+            spell_level_override=cast_level,
         )
     else:
         # no automation, display spell description
@@ -321,7 +322,10 @@ async def cast_spell(
         embed.add_field(name="At Higher Levels", value=smart_trim(spell.higherlevels), inline=False)
 
     if cast_level > 0 and not ignore:
-        embed.add_field(name="Spell Slots", value=caster.spellbook.remaining_casts_of(spell, cast_level))
+        remaining_casts = caster.spellbook.remaining_casts_of(spell, cast_level)
+        if not (isinstance(caster.spellbook, monster.MonsterSpellbook) and spell.name in caster.spellbook.at_will):
+            remaining_casts += " (-1)"
+        embed.add_field(name="Spell Slots", value=remaining_casts)
 
     if conc_conflict:
         conflicts = ", ".join(e.name for e in conc_conflict)

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -1000,7 +1000,7 @@ This is usually used in features that cast spells using alternate resources (i.e
 
 **Variables**
 
-- ``spell_level`` (:class:`int`) The level used to cast the spell.
+No variables are exposed.
 
 Ability Check
 -------------

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -40,6 +40,7 @@ All Automation runs provide the following variables:
   targeted by this automation (i.e. the ``-t`` argument).
 - ``spell_attack_bonus`` (:class:`int` or None) - The attack bonus for the spell, or the caster's default attack bonus.
 - ``spell_dc`` (:class:`int` or None) - The DC for the spell, or the caster's default DC.
+- ``spell_level`` (:class:`int` or None) - The level used to cast the spell, or None
 - ``choice`` (:class:`str`) - The input provided by the ``-choice`` argument, always lowercase. If the arg was not used, it will be an empty string.
 
 Additionally, runs triggered by an initiative effect (such as automation provided in a :ref:`ButtonInteraction`) provide
@@ -999,7 +1000,7 @@ This is usually used in features that cast spells using alternate resources (i.e
 
 **Variables**
 
-No variables are exposed.
+- ``spell_level`` (:class:`int`) The level used to cast the spell.
 
 Ability Check
 -------------

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -447,7 +447,9 @@ class CustomStringView(StringView):
                 continue
 
             # opening quote
-            if not is_quoted and current in ALL_QUOTES and current != "'" and current != "’":  # special case: apostrophes in mid-string
+            if (
+                not is_quoted and current in ALL_QUOTES and current != "'" and current != "’"
+            ):  # special case: apostrophes in mid-string
                 close_quote = QUOTE_PAIRS.get(current)
                 is_quoted = True
                 _escaped_quotes = (current, close_quote)


### PR DESCRIPTION
### Summary
Adds `spell_level` as an automation metavar.

Resolves #1998 

### Changelog Entry
Adds `spell_level` as an automation meta-var when casting a spell.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
