### PR TITLE
Add extra messages when set_active is called to make it clear what is being switched.

### DIFF
--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -385,11 +385,14 @@ class Character(StatBlock):
 
         if ctx.channel is not None and channel_character is not None and channel_character.is_active_channel(ctx):
             # for all characters owned by this owner who are active on this guild, make them inactive on this guild
+            await ctx.send(f"Current context being switched is channel.")
             return await self.set_channel_active(ctx)
         elif ctx.guild is not None and server_character is not None and server_character.is_active_server(ctx):
             # for all characters owned by this owner who are active on this guild, make them inactive on this guild
+            await ctx.send(f"Current context being switched is server.")
             return await self.set_server_active(ctx)
         else:
+            await ctx.send(f"Current context being switched is global.")
             # for all characters owned by this owner who are globally active, make them inactive
             await ctx.bot.mdb.characters.update_many({"owner": owner_id, "active": True}, {"$set": {"active": False}})
             # make this character active


### PR DESCRIPTION
### Summary
This will make it clearer what context is being switched

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
