### PR TITLE
Add a name parameter to server and channel commands

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -966,11 +966,11 @@ class SheetManager(commands.Cog):
         )
         if (link := active_character.get_sheet_url()) is not None:
             desc = f"{desc}\n[Go to Character Sheet]({link})"
+        if message != "":
+            embed.add_field(name="Changes", value=message, inline=True)
         embed.description = desc
         characterInfoMessages = []
 
-        if message != "":
-            characterInfoMessages.append(f"{message}\n")
         if global_character is not None:
             characterInfoMessages.append(f"Global Character: {global_character.name}")
         if server_character is not None:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -433,7 +433,7 @@ class SheetManager(commands.Cog):
         if result.did_unset_active_location:
             embed = await self._active_character_embed(
                 ctx,
-                f"Active character changed to '{char.name}' for {result.character_location_context.value} context. Your previous active character has been unset.",
+                f"Active character changed to '{char.name}' for {result.character_location_context.value} context. Your previous active character '{result.previous_character_name}' has been unset.",
             )
             await ctx.send(embed=embed)
         else:
@@ -507,8 +507,10 @@ class SheetManager(commands.Cog):
         set_result = await new_character_to_set.set_server_active(ctx, server_character)
         msg = ""
         if set_result.did_unset_active_location:
-            msg = f"Unset previous server character '{server_character.name}'"
-        msg = f"{msg}Active server character set to '{new_character_to_set.name}'."
+            msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
+        msg = (
+            f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}",
+        )
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
@@ -575,10 +577,11 @@ class SheetManager(commands.Cog):
         set_result = await new_character_to_set.set_channel_active(ctx, channel_character)
         msg = ""
         if set_result.did_unset_active_location:
-            msg = f"Unset previous channel character '{channel_character.name}'"
-        embed = await self._active_character_embed(
-            ctx, f"{msg}Active channel character set to '{new_character_to_set.name}'."
+            msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
+        msg = (
+            f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}",
         )
+        embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
 
@@ -974,11 +977,11 @@ class SheetManager(commands.Cog):
 
         if message != "":
             characterInfoMessages.append(f"{message}\n")
-        if global_character is not None and active_character.upstream != global_character.upstream:
+        if global_character is not None:
             characterInfoMessages.append(f"Global Character: {global_character.name}")
-        if server_character is not None and active_character.upstream != server_character.upstream:
+        if server_character is not None:
             characterInfoMessages.append(f"Server Character: {server_character.name}")
-        if channel_character is not None and active_character.upstream != channel_character.upstream:
+        if channel_character is not None:
             characterInfoMessages.append(f"Channel Character: {channel_character.name}")
 
         # global and server active differ

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -938,7 +938,7 @@ class SheetManager(commands.Cog):
         return url
 
     @staticmethod
-    async def _active_character_embed(ctx, message = ""):
+    async def _active_character_embed(ctx, message=""):
         """Creates an embed to be displayed when the active character is checked"""
         global_character = None
         server_character = None

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -433,12 +433,12 @@ class SheetManager(commands.Cog):
         if result.did_unset_active_location:
             embed = await self._active_character_embed(
                 ctx,
-                f"{result.character_location_context.value} character changed to '{char.name}'. Your previous active character '{result.previous_character_name}' has been unset.",
+                f"{result.character_location_context.value} character changed to: {char.name}\nYour previous active character '{result.previous_character_name}' has been unset.",
             )
             await ctx.send(embed=embed)
         else:
             embed = await self._active_character_embed(
-                ctx, f"{result.character_location_context.value} character changed to '{char.name}'"
+                ctx, f"{result.character_location_context.value} character changed to: {char.name}"
             )
             await ctx.send(embed=embed)
 
@@ -507,8 +507,8 @@ class SheetManager(commands.Cog):
         set_result = await new_character_to_set.set_server_active(ctx, server_character)
         msg = ""
         if set_result.did_unset_active_location:
-            msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = f"{set_result.character_location_context.value} character changed to '{new_character_to_set.name}'.{msg}"
+            msg = f"\nYour previous active character '{set_result.previous_character_name}' has been unset."
+        msg = f"{set_result.character_location_context.value} character changed to: {new_character_to_set.name}{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
@@ -575,8 +575,8 @@ class SheetManager(commands.Cog):
         set_result = await new_character_to_set.set_channel_active(ctx, channel_character)
         msg = ""
         if set_result.did_unset_active_location:
-            msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = f"{set_result.character_location_context.value} character changed to '{new_character_to_set.name}.{msg}"
+            msg = f"\nYour previous active character '{set_result.previous_character_name}' has been unset."
+        msg = f"{set_result.character_location_context.value} character changed to: {new_character_to_set.name}{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -433,12 +433,12 @@ class SheetManager(commands.Cog):
         if result.did_unset_active_location:
             embed = await self._active_character_embed(
                 ctx,
-                f"Active character changed to '{char.name}' for {result.character_location_context.value} context. Your previous active character '{result.previous_character_name}' has been unset.",
+                f"{result.character_location_context.value} changed to '{char.name}'. Your previous active character '{result.previous_character_name}' has been unset.",
             )
             await ctx.send(embed=embed)
         else:
             embed = await self._active_character_embed(
-                ctx, f"Active character set to '{char.name}' for {result.character_location_context.value} context."
+                ctx, f"{result.character_location_context.value} changed to '{char.name}'"
             )
             await ctx.send(embed=embed)
 
@@ -508,7 +508,7 @@ class SheetManager(commands.Cog):
         msg = ""
         if set_result.did_unset_active_location:
             msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}"
+        msg = f"{set_result.character_location_context.value} changed to '{new_character_to_set.name}'.{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
@@ -576,7 +576,7 @@ class SheetManager(commands.Cog):
         msg = ""
         if set_result.did_unset_active_location:
             msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}"
+        msg = f"{set_result.character_location_context.value} changed to '{new_character_to_set.name}.{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -508,9 +508,7 @@ class SheetManager(commands.Cog):
         msg = ""
         if set_result.did_unset_active_location:
             msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = (
-            f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}",
-        )
+        msg = f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
@@ -578,9 +576,7 @@ class SheetManager(commands.Cog):
         msg = ""
         if set_result.did_unset_active_location:
             msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = (
-            f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}",
-        )
+        msg = f"Active character changed to '{new_character_to_set.name}' for {set_result.character_location_context.value} context.{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
@@ -985,7 +981,7 @@ class SheetManager(commands.Cog):
             characterInfoMessages.append(f"Channel Character: {channel_character.name}")
 
         # global and server active differ
-        embed.set_footer(text=("\n".join(characterInfoMessages)))
+        embed.set_footer(text="\n".join(characterInfoMessages))
         return embed
 
 

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -409,18 +409,19 @@ class SheetManager(commands.Cog):
 
     @commands.group(aliases=["char"], invoke_without_command=True)
     async def character(self, ctx, *, name: str = None):
-        """If no character name is passed in, it will display the current character and other contextual information. Otherwise it
-        switches the active character. This will switch the most specific context that is set with either the current global character
-        or the named character passed in.
+        """If no character name is passed in, it will display the current character and other contextual information.
+        Otherwise it switches the active character. This will switch the most specific context that is set with either
+        the current global character or the named character passed in.
 
-        For example, if you have a channel character set for the channel you are typing this command in, it will switch to have the character
-        that is passed in as the new channel character. If you don't have a channel character set but do have a server character set, it will
-        switch to have the server character be set to whatever is the character name passed in. If you have neither a channel or server character
-        set it will default to global context and switch your global character to the character name passed in.
+        For example, if you have a channel character set for the channel you are typing this command in, it will switch
+        to have the character that is passed in as the new channel character. If you don't have a channel character set
+        but do have a server character set, it will switch to have the server character be set to whatever is the
+        character name passed in. If you have neither a channel or server character set it will default to global
+        context and switch your global character to the character name passed in.
 
         __Optional Arguments__
-        `<name>` - The name of the character you want to switch to. If not passed in it will show active character information.
-            e.g. `{ctx.prefix}character "Character Name"`
+        `<name>` - The name of the character you want to switch to. If not passed in it will show active character
+            information. e.g. `{ctx.prefix}character "Character Name"`
         """
         if name is None:
             embed = await self._active_character_embed(ctx)
@@ -433,7 +434,8 @@ class SheetManager(commands.Cog):
         if result.did_unset_active_location:
             embed = await self._active_character_embed(
                 ctx,
-                f"{result.character_location_context.value} character changed to: {char.name}\nYour previous active character '{result.previous_character_name}' has been unset.",
+                f"{result.character_location_context.value} character changed to: {char.name}\nYour previous active"
+                f"character '{result.previous_character_name}' has been unset.",
             )
             await ctx.send(embed=embed)
         else:
@@ -476,7 +478,7 @@ class SheetManager(commands.Cog):
                 )
             except NoCharacter:
                 await ctx.send(
-                    f"No global character is active. You must have a global character set to set a server character."
+                    "No global character is active. You must have a global character set to set a server character."
                 )
                 return
         else:
@@ -537,18 +539,11 @@ class SheetManager(commands.Cog):
                 )
             except NoCharacter:
                 await ctx.send(
-                    f"No global character is active. You must have a global character set to set a server character."
+                    "No global character is active. You must have a global character set to set a server character."
                 )
                 return
         else:
             new_character_to_set = await self.get_character_by_name(ctx, name)
-
-        try:
-            server_character: Character = await Character.from_ctx(
-                ctx, use_global=False, use_guild=True, use_channel=False
-            )
-        except:
-            pass
 
         try:
             channel_character: Character = await Character.from_ctx(
@@ -615,7 +610,7 @@ class SheetManager(commands.Cog):
             full_list_message = ", ".join(list_of_unset_characters)
             await ctx.send(f"Unset the following character mappings: {full_list_message}")
         else:
-            await ctx.send(f"No characters were set on any channels or servers")
+            await ctx.send("No characters were set on any channels or servers")
         await try_delete(ctx.message)
 
     @character.command(name="list")

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -427,12 +427,9 @@ class SheetManager(commands.Cog):
         result = await char.set_active(ctx)
         await try_delete(ctx.message)
         if result.did_unset_active_location:
-            await ctx.send(
-                f"Active character changed to {char.name}. Your previous active character has been unset.",
-                delete_after=30,
-            )
+            await self._active_character_embed(ctx, f"Active character changed to {char.name}. Your previous active character has been unset.")
         else:
-            await ctx.send(f"Active character set to {char.name}.", delete_after=15)
+            await self._active_character_embed(ctx, f"Active character set to {char.name}.")
 
     @character.command(name="server")
     @commands.guild_only()
@@ -470,14 +467,15 @@ class SheetManager(commands.Cog):
             # Toggle server character to not be set
             unset_server_result = await server_character.unset_server_active(ctx)
             if unset_server_result.did_unset_active_location:
-                await ctx.send(f"Unset previous server character {server_character.name}.")
+                await self._active_character_embed(ctx, f"Unset previous server character {server_character.name}.")
                 return
 
         set_result = await global_character.set_server_active(ctx)
         msg = ""
         if set_result.did_unset_active_location:
             msg = f"Unset previous server character '{server_character.name}'"
-        await ctx.send(f"{msg}Active server character set to {global_character.name}.")
+        msg = f"{msg}Active server character set to {global_character.name}."
+        await self._active_character_embed(ctx, msg)
         await try_delete(ctx.message)
 
     @character.command(name="channel")
@@ -518,14 +516,14 @@ class SheetManager(commands.Cog):
         ):
             unset_channel_result = await channel_character.unset_channel_active(ctx)
             if unset_channel_result.did_unset_active_location:
-                await ctx.send(f"Unset previous channel character '{channel_character.name}'.")
+                await self._active_character_embed(ctx, f"Unset previous channel character '{channel_character.name}'.")
                 return
 
         set_result = await global_character.set_channel_active(ctx)
         msg = ""
         if set_result.did_unset_active_location:
             msg = f"Unset previous channel character '{channel_character.name}'"
-        await ctx.send(f"{msg}Active channel character set to {global_character.name}.")
+        await self._active_character_embed(ctx, f"{msg}Active channel character set to '{global_character.name}'.")
         await try_delete(ctx.message)
 
     @character.command(name="resetall")
@@ -881,7 +879,7 @@ class SheetManager(commands.Cog):
         return url
 
     @staticmethod
-    async def _active_character_embed(ctx):
+    async def _active_character_embed(ctx, message = ""):
         """Creates an embed to be displayed when the active character is checked"""
         global_character = None
         server_character = None
@@ -917,6 +915,9 @@ class SheetManager(commands.Cog):
             desc = f"{desc}\n[Go to Character Sheet]({link})"
         embed.description = desc
         characterInfoMessages = []
+
+        if message != "":
+            characterInfoMessages.append(f"{message}\n")
         if global_character is not None and active_character.upstream != global_character.upstream:
             characterInfoMessages.append(f"Global Character: {global_character.name}")
         if server_character is not None and active_character.upstream != server_character.upstream:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -433,12 +433,12 @@ class SheetManager(commands.Cog):
         if result.did_unset_active_location:
             embed = await self._active_character_embed(
                 ctx,
-                f"{result.character_location_context.value} changed to '{char.name}'. Your previous active character '{result.previous_character_name}' has been unset.",
+                f"{result.character_location_context.value} character changed to '{char.name}'. Your previous active character '{result.previous_character_name}' has been unset.",
             )
             await ctx.send(embed=embed)
         else:
             embed = await self._active_character_embed(
-                ctx, f"{result.character_location_context.value} changed to '{char.name}'"
+                ctx, f"{result.character_location_context.value} character changed to '{char.name}'"
             )
             await ctx.send(embed=embed)
 
@@ -508,7 +508,7 @@ class SheetManager(commands.Cog):
         msg = ""
         if set_result.did_unset_active_location:
             msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = f"{set_result.character_location_context.value} changed to '{new_character_to_set.name}'.{msg}"
+        msg = f"{set_result.character_location_context.value} character changed to '{new_character_to_set.name}'.{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)
@@ -576,7 +576,7 @@ class SheetManager(commands.Cog):
         msg = ""
         if set_result.did_unset_active_location:
             msg = f" Your previous active character '{set_result.previous_character_name}' has been unset."
-        msg = f"{set_result.character_location_context.value} changed to '{new_character_to_set.name}.{msg}"
+        msg = f"{set_result.character_location_context.value} character changed to '{new_character_to_set.name}.{msg}"
         embed = await self._active_character_embed(ctx, msg)
         await ctx.send(embed=embed)
         await try_delete(ctx.message)

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -607,8 +607,11 @@ class SheetManager(commands.Cog):
             if unset_server_result.did_unset_active_location:
                 list_of_unset_characters.append(f"{server_character.name} for server '{ctx.guild.name}'")
         if len(list_of_unset_characters) > 0:
-            full_list_message = ", ".join(list_of_unset_characters)
-            await ctx.send(f"Unset the following character mappings: {full_list_message}")
+            full_list_message = "\n".join(list_of_unset_characters)
+            embed = await self._active_character_embed(
+                ctx, f"Unset the following character mappings:\n\n{full_list_message}"
+            )
+            await ctx.send(embed=embed)
         else:
             await ctx.send("No characters were set on any channels or servers")
         await try_delete(ctx.message)


### PR DESCRIPTION
### Summary
Switch to using embeds for any character switching/setting and add a -name parameter to server and channel commands.

### Changelog Entry
Using embeds for char channel, char server and char commands
Add a -name parameter for server and channel commands. 

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
