### PR TITLE
Fix resetall and clean-up documentation referencing not passing in name and defaulting to a global character

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -578,7 +578,7 @@ class SheetManager(commands.Cog):
             channel_id = channel.id
             try:
                 channel_character: Character = await Character.from_bot_and_channel_id(ctx, ctx.author.id, channel_id)
-                unset_result = await channel_character.unset_active_channel_helper(ctx, channel_id, None)
+                unset_result = await channel_character.unset_active_channel_helper(ctx, channel_id)
                 if unset_result.did_unset_active_location:
                     list_of_unset_characters.append(f"{channel_character.name} for channel '{channel.name}'")
             except NoCharacter:

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -450,7 +450,7 @@ class SheetManager(commands.Cog):
         All commands in the server that use your active character will instead use the server character, even if the active character is changed elsewhere.
 
         __Required Arguments__
-        `name` - The name of the character you want to set as your server character. If not passed in it will default to switching to your current Global character.
+        `name` - The name of the character you want to set as your server character.
             e.g. `!character server "Character Name"`
         """  # noqa: E501
         new_character_to_set = None
@@ -511,7 +511,7 @@ class SheetManager(commands.Cog):
         All commands in the channel that use your active character will instead use the new channel character, even if the active character is changed elsewhere.
 
         __Required Arguments__
-        `name` - The name of the character you want to set as your channel character. If not passed in it will default to switching to your current Global character.
+        `name` - The name of the character you want to set as your channel character.
             e.g. `!character channel "Character Name"`
         """  # noqa: E501
 


### PR DESCRIPTION
### Summary
Fix resetall and clean-up documentation referencing not passing in name and defaulting to a global character

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
