### PR TITLE
Fixes the argument passing for `!save death [args]`

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -211,10 +211,8 @@ class SheetManager(commands.Cog):
         if conflicts:
             if await confirm(
                 ctx,
-                (
-                    f"This will overwrite {len(conflicts)} attacks with the same name "
-                    f"({', '.join(c.name for c in conflicts)}). Continue? (Reply with yes/no)"
-                ),
+                f"This will overwrite {len(conflicts)} attacks with the same name "
+                f"({', '.join(c.name for c in conflicts)}). Continue? (Reply with yes/no)",
             ):
                 for conflict in conflicts:
                     character.overrides.attacks.remove(conflict)
@@ -250,13 +248,15 @@ class SheetManager(commands.Cog):
     async def save(self, ctx, skill, *, args=""):
         if skill == "death":
             base_cmd = "game deathsave"
-            if args and (sub_cmd := args[0].lower()) in ("fail", "success", "reset"):
+            if args and (sub_cmd := args.split()[0].lower()) in ("fail", "success", "reset"):
                 base_cmd += f" {sub_cmd}"
-                args = []
+                args = ""
             ds_cmd = self.bot.get_command(base_cmd)
             if ds_cmd is None:
                 return await ctx.send("Error: GameTrack cog not loaded.")
-            return await ctx.invoke(ds_cmd, args=args)
+            if args:
+                return await ctx.invoke(ds_cmd, args=args)
+            return await ctx.invoke(ds_cmd)
 
         char: Character = await ctx.get_character()
 
@@ -458,7 +458,8 @@ class SheetManager(commands.Cog):
 
         if name is None:
             await ctx.send(
-                "Please pass in the name of a character to switch to for the server command. e.g. `!char server Merlin`",
+                "Please pass in the name of a character to switch to for the server command. e.g. `!char server"
+                " Merlin`",
                 delete_after=DELETE_AFTER_SECONDS,
             )
             return
@@ -519,7 +520,8 @@ class SheetManager(commands.Cog):
         new_character_to_set = None
         if name is None:
             await ctx.send(
-                "Please pass in the name of a character to switch to for the channel command. e.g. `!char channel Merlin`",
+                "Please pass in the name of a character to switch to for the channel command. e.g. `!char channel"
+                " Merlin`",
                 delete_after=DELETE_AFTER_SECONDS,
             )
             return
@@ -798,11 +800,9 @@ class SheetManager(commands.Cog):
         if conflict:
             return await confirm(
                 ctx,
-                (
-                    "Warning: This will overwrite a character with the same ID. Do you wish to continue "
-                    "(Reply with yes/no)?\n"
-                    f"If you only wanted to update your character, run `{ctx.prefix}update` instead."
-                ),
+                "Warning: This will overwrite a character with the same ID. Do you wish to continue "
+                "(Reply with yes/no)?\n"
+                f"If you only wanted to update your character, run `{ctx.prefix}update` instead.",
             )
         return True
 


### PR DESCRIPTION
### Summary
Updates `!save` to properly handle the `!save death [fail|success|reset]` subcommand passing again

Was originally implemented in https://github.com/avrae/avrae/pull/1918, but https://github.com/avrae/avrae/pull/1989 ended up breaking this unintentionally

### Changelog Entry
`!save death [fail|success|reset]` will properly fail, succeed, or reset your death saves again, without rolling.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
