### PR TITLE
Replace default prefix in help commands with context prefix

### DIFF
--- a/utils/help.py
+++ b/utils/help.py
@@ -72,7 +72,7 @@ class AvraeHelp(HelpCommand):
 
             # Replace default prefix with the contexts prefix
             # new variable to avoid changing the original
-            command_text = re.sub(r"!(\w+)", rf"{self.context.clean_prefix}\1", command.help)
+            command_text = re.sub(r"!([aA-zZ0-9]+)", rf"{self.context.clean_prefix}\1", command.help)
             try:
                 self.embed_paginator.extend_field(command_text)
             except ValueError:

--- a/utils/help.py
+++ b/utils/help.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 
 import disnake
 from disnake.ext.commands import Group, HelpCommand
@@ -68,10 +69,14 @@ class AvraeHelp(HelpCommand):
         if command.help:
             # Strip left spaces (but not tabs) from help docs, as Discord inconsistently does this based on device
             command.help = "\n".join([line.lstrip(" ") for line in command.help.splitlines()])
+
+            # Replace default prefix with the contexts prefix
+            # new variable to avoid changing the original
+            command_text = re.sub(r"!(\w+)", rf"{self.context.clean_prefix}\1", command.help)
             try:
-                self.embed_paginator.extend_field(command.help)
+                self.embed_paginator.extend_field(command_text)
             except ValueError:
-                for line in command.help.splitlines():
+                for line in command_text.splitlines():
                     self.embed_paginator.extend_field(line)
 
     def add_help_footer(self):


### PR DESCRIPTION
### Summary
Uses a basic regex to replace the `!` in `!help` output to use whatever the current context's prefix.

There might be cases where this doesn't work as intended, I didn't check every single command.

### Changelog Entry
`!help` on servers with an adjusted command prefix will now show you commands using that prefix.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
