### PR TITLE
AFR-1043 - Enables strict=True option for get_effect for aliasing

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -394,10 +394,9 @@ class SimpleCombatant(AliasStatBlock):
 
     def get_effect(self, name: str, strict: bool = False):
         """
-        Gets a SimpleEffect, fuzzy searching (partial match) for a match.
-
+        Gets a SimpleEffect, fuzzy searching (partial match) for the first match.
         :param str name: The name of the effect to get.
-        :param bool strict: Whether combatant name must be a full case insensitive match.
+        :param bool strict: Whether effect name must be an exact match.
             If this is ``False``, it returns the first partial match.
             If this is ``True``, it will only return a strict match.
         :return: The effect.

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -392,16 +392,19 @@ class SimpleCombatant(AliasStatBlock):
             note = str(note)
         self._combatant.notes = note
 
-    def get_effect(self, name: str):
+    def get_effect(self, name: str, strict: bool = False):
         """
         Gets a SimpleEffect, fuzzy searching (partial match) for a match.
 
         :param str name: The name of the effect to get.
+        :param bool strict: Whether combatant name must be a full case insensitive match.
+            If this is ``False``, it returns the first partial match.
+            If this is ``True``, it will only return a strict match.
         :return: The effect.
         :rtype: :class:`~aliasing.api.combat.SimpleEffect`
         """
         name = str(name)
-        effect = self._combatant.get_effect(name, False)
+        effect = self._combatant.get_effect(name, strict)
         if effect:
             return SimpleEffect(effect)
         return None

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -394,7 +394,7 @@ class SimpleCombatant(AliasStatBlock):
 
     def get_effect(self, name: str, strict: bool = False):
         """
-        Gets a SimpleEffect, fuzzy searching (partial match) for the first match.
+        Gets a SimpleEffect, fuzzy searching (partial match) for the first match or an exact match.
         :param str name: The name of the effect to get.
         :param bool strict: Whether effect name must be an exact match.
             If this is ``False``, it returns the first partial match.
@@ -515,14 +515,17 @@ class SimpleCombatant(AliasStatBlock):
 
         return SimpleEffect(effect_obj)
 
-    def remove_effect(self, name: str):
+    def remove_effect(self, name: str, strict: bool = False):
         """
-        Removes an effect from the combatant, fuzzy searching on name. If not found, does nothing.
+        Removes an effect from the combatant, fuzzy searching on name or an exact match. If not found, does nothing.
 
         :param str name: The name of the effect to remove.
+        :param bool strict: Whether effect name must be an exact match.
+            If this is ``False``, it returns the first partial match.
+            If this is ``True``, it will only return a strict match.
         """
         name = str(name)
-        effect = self._combatant.get_effect(name, strict=False)
+        effect = self._combatant.get_effect(name, strict)
         if effect:
             effect.remove()
             self._update_effects()


### PR DESCRIPTION
### Summary
Enables strict=True option for get_effect for aliasing.

### Checklist
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
