### PR TITLE
Handle exclude and include tags for DCv2 resistances

### DIFF
--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -345,16 +345,14 @@ class DicecloudV2Parser(SheetLoaderABC):
 
             # 7 was too small so 10 instead
             display_type = "bubble" if uses < 10 else None
-            consumables.append(
-                {
-                    "name": name,
-                    "value": int(attr.get("value", uses)),
-                    "minv": "0",
-                    "maxv": str(uses),
-                    "reset": RESET_MAP.get(attr.get("reset")),
-                    "display_type": display_type,
-                }
-            )
+            consumables.append({
+                "name": name,
+                "value": int(attr.get("value", uses)),
+                "minv": "0",
+                "maxv": str(uses),
+                "reset": RESET_MAP.get(attr.get("reset")),
+                "display_type": display_type,
+            })
 
     def get_levels(self) -> Levels:
         """Returns a dict with the character's level and class levels."""
@@ -433,16 +431,14 @@ class DicecloudV2Parser(SheetLoaderABC):
                 if attack.get("uses"):
                     uses = attack["uses"]["value"]
                     display_type = "bubble" if uses < 10 else None
-                    consumables.append(
-                        {
-                            "name": aname,
-                            "value": attack.get("usesLeft", uses),
-                            "minv": "0",
-                            "maxv": str(uses),
-                            "reset": RESET_MAP.get(attack.get("reset")),
-                            "display_type": display_type,
-                        }
-                    )
+                    consumables.append({
+                        "name": aname,
+                        "value": attack.get("usesLeft", uses),
+                        "minv": "0",
+                        "maxv": str(uses),
+                        "reset": RESET_MAP.get(attack.get("reset")),
+                        "display_type": display_type,
+                    })
 
                 consumables += self._consumables_from_resources(attack["resources"])
 
@@ -609,16 +605,14 @@ class DicecloudV2Parser(SheetLoaderABC):
                 uses = spell["uses"]["value"]
                 display_type = "bubble" if uses < 10 else None
                 action_name = f"{sl_name}: {spell['name']}" if sl_name else spell["name"]
-                spell_consumables.append(
-                    {
-                        "name": action_name,
-                        "value": spell.get("usesLeft", 0),
-                        "minv": "0",
-                        "maxv": str(uses),
-                        "reset": RESET_MAP.get(spell.get("reset")),
-                        "display_type": display_type,
-                    }
-                )
+                spell_consumables.append({
+                    "name": action_name,
+                    "value": spell.get("usesLeft", 0),
+                    "minv": "0",
+                    "maxv": str(uses),
+                    "reset": RESET_MAP.get(spell.get("reset")),
+                    "display_type": display_type,
+                })
 
             spell_consumables += self._consumables_from_resources(spell["resources"])
             consumables += spell_consumables
@@ -757,16 +751,14 @@ class DicecloudV2Parser(SheetLoaderABC):
                 self._seen_consumables.add(full_attr["_id"])
                 uses = full_attr["total"]
                 display_type = "bubble" if uses < 10 else None
-                consumables.append(
-                    {
-                        "name": full_attr["name"],
-                        "value": full_attr.get("value", uses),
-                        "minv": "0",
-                        "maxv": str(uses),
-                        "reset": RESET_MAP.get(full_attr.get("reset")),
-                        "display_type": display_type,
-                    }
-                )
+                consumables.append({
+                    "name": full_attr["name"],
+                    "value": full_attr.get("value", uses),
+                    "minv": "0",
+                    "maxv": str(uses),
+                    "reset": RESET_MAP.get(full_attr.get("reset")),
+                    "display_type": display_type,
+                })
         return consumables
 
 

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -716,9 +716,7 @@ class DicecloudV2Parser(SheetLoaderABC):
         verb, proper = (
             ("casts", True)
             if atk_prop["type"] == "spell"
-            else ("uses", False)
-            if atk_prop["actionType"] != "attack"
-            else (None, False)
+            else ("uses", False) if atk_prop["actionType"] != "attack" else (None, False)
         )
         log.debug(f"Parsing {atk_prop['type']}")
         activation = ACTIVATION_MAP.get(atk_prop["actionType"], ActivationType.SPECIAL)

--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -345,14 +345,16 @@ class DicecloudV2Parser(SheetLoaderABC):
 
             # 7 was too small so 10 instead
             display_type = "bubble" if uses < 10 else None
-            consumables.append({
-                "name": name,
-                "value": int(attr.get("value", uses)),
-                "minv": "0",
-                "maxv": str(uses),
-                "reset": RESET_MAP.get(attr.get("reset")),
-                "display_type": display_type,
-            })
+            consumables.append(
+                {
+                    "name": name,
+                    "value": int(attr.get("value", uses)),
+                    "minv": "0",
+                    "maxv": str(uses),
+                    "reset": RESET_MAP.get(attr.get("reset")),
+                    "display_type": display_type,
+                }
+            )
 
     def get_levels(self) -> Levels:
         """Returns a dict with the character's level and class levels."""
@@ -431,14 +433,16 @@ class DicecloudV2Parser(SheetLoaderABC):
                 if attack.get("uses"):
                     uses = attack["uses"]["value"]
                     display_type = "bubble" if uses < 10 else None
-                    consumables.append({
-                        "name": aname,
-                        "value": attack.get("usesLeft", uses),
-                        "minv": "0",
-                        "maxv": str(uses),
-                        "reset": RESET_MAP.get(attack.get("reset")),
-                        "display_type": display_type,
-                    })
+                    consumables.append(
+                        {
+                            "name": aname,
+                            "value": attack.get("usesLeft", uses),
+                            "minv": "0",
+                            "maxv": str(uses),
+                            "reset": RESET_MAP.get(attack.get("reset")),
+                            "display_type": display_type,
+                        }
+                    )
 
                 consumables += self._consumables_from_resources(attack["resources"])
 
@@ -511,6 +515,10 @@ class DicecloudV2Parser(SheetLoaderABC):
                 # each resistance property can give multiple resistances
                 for dmg_type in dmg_mult["damageTypes"]:
                     if dmg_type in DAMAGE_TYPES:
+                        for exclude in dmg_mult.get("excludeTags", []):
+                            dmg_type = f"non{exclude} {dmg_type}"
+                        for include in dmg_mult.get("includeTags", []):
+                            dmg_type = f"{include} {dmg_type}"
                         # if we're immune, nothing else matters
                         if dmg_type in out["immune"]:
                             continue
@@ -601,14 +609,16 @@ class DicecloudV2Parser(SheetLoaderABC):
                 uses = spell["uses"]["value"]
                 display_type = "bubble" if uses < 10 else None
                 action_name = f"{sl_name}: {spell['name']}" if sl_name else spell["name"]
-                spell_consumables.append({
-                    "name": action_name,
-                    "value": spell.get("usesLeft", 0),
-                    "minv": "0",
-                    "maxv": str(uses),
-                    "reset": RESET_MAP.get(spell.get("reset")),
-                    "display_type": display_type,
-                })
+                spell_consumables.append(
+                    {
+                        "name": action_name,
+                        "value": spell.get("usesLeft", 0),
+                        "minv": "0",
+                        "maxv": str(uses),
+                        "reset": RESET_MAP.get(spell.get("reset")),
+                        "display_type": display_type,
+                    }
+                )
 
             spell_consumables += self._consumables_from_resources(spell["resources"])
             consumables += spell_consumables
@@ -706,7 +716,9 @@ class DicecloudV2Parser(SheetLoaderABC):
         verb, proper = (
             ("casts", True)
             if atk_prop["type"] == "spell"
-            else ("uses", False) if atk_prop["actionType"] != "attack" else (None, False)
+            else ("uses", False)
+            if atk_prop["actionType"] != "attack"
+            else (None, False)
         )
         log.debug(f"Parsing {atk_prop['type']}")
         activation = ACTIVATION_MAP.get(atk_prop["actionType"], ActivationType.SPECIAL)
@@ -747,14 +759,16 @@ class DicecloudV2Parser(SheetLoaderABC):
                 self._seen_consumables.add(full_attr["_id"])
                 uses = full_attr["total"]
                 display_type = "bubble" if uses < 10 else None
-                consumables.append({
-                    "name": full_attr["name"],
-                    "value": full_attr.get("value", uses),
-                    "minv": "0",
-                    "maxv": str(uses),
-                    "reset": RESET_MAP.get(full_attr.get("reset")),
-                    "display_type": display_type,
-                })
+                consumables.append(
+                    {
+                        "name": full_attr["name"],
+                        "value": full_attr.get("value", uses),
+                        "minv": "0",
+                        "maxv": str(uses),
+                        "reset": RESET_MAP.get(full_attr.get("reset")),
+                        "display_type": display_type,
+                    }
+                )
         return consumables
 
 


### PR DESCRIPTION
### Summary
Handles exclude (nonmagical pizza) and include (magical pizza) tags for damage resistances/immunities/vulnerabilities

![image](https://github.com/avrae/avrae/assets/5848891/f43ec7b5-d781-4d49-a864-42088b708806)
This should properly import as `nonmagical bludgeoning`


### Changelog Entry
Added support for Include and Exclude tags on damage resistances/immunities/vulnerabilities for Dicecloud V2 characters

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
