### PR TITLE
Fix "Playing the Game" tutorial for death saves

### DIFF
--- a/cogsmisc/tutorials/playingthegame.py
+++ b/cogsmisc/tutorials/playingthegame.py
@@ -290,7 +290,7 @@ class PlayingTheGame(Tutorial):
             await ctx.send(embed=embed)
 
         async def listener(self, ctx, state_map):
-            if (ctx.command is ctx.bot.get_command("save death")) or ctx.command is ctx.bot.get_command("g ds"):
+            if ctx.command is ctx.bot.get_command("save death") or ctx.command is ctx.bot.get_command("g ds"):
                 await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):

--- a/cogsmisc/tutorials/playingthegame.py
+++ b/cogsmisc/tutorials/playingthegame.py
@@ -284,15 +284,13 @@ class PlayingTheGame(Tutorial):
             embed.description = f"""
             Death Saves are a special type of saving throw. Avrae tracks your death saves automatically when you have to make them; to roll one, use `{ctx.prefix}save death`. Try making one now!
             ```
-            {ctx.prefix}save death
+            {ctx.prefix}game deathsave
             ```
             """
             await ctx.send(embed=embed)
 
         async def listener(self, ctx, state_map):
-            if (
-                ctx.command is ctx.bot.get_command("save") and "death" in ctx.message.content
-            ) or ctx.command is ctx.bot.get_command("g ds"):
+            if (ctx.command is ctx.bot.get_command("save death")) or ctx.command is ctx.bot.get_command("g ds"):
                 await self.transition(ctx, state_map)
 
         async def transition(self, ctx, state_map):


### PR DESCRIPTION
### Summary
When `!save death` was changed to use a subcommand, the tutorial "Playing the Game" stopped detecting the command properly (It was looking for the `!save` command with `death` in its args.

Additionally, the tutorially _probably_ should have been pointing at `!game deathsave` in the first place.

### Changelog Entry
Fixed the Death Save portion of the "Playing the Game" tutorial.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
