### PR TITLE
Fix the ReadTheDocs builds

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -395,6 +395,7 @@ class SimpleCombatant(AliasStatBlock):
     def get_effect(self, name: str, strict: bool = False):
         """
         Gets a SimpleEffect, fuzzy searching (partial match) for the first match or an exact match.
+
         :param str name: The name of the effect to get.
         :param bool strict: Whether effect name must be an exact match.
             If this is ``False``, it returns the first partial match.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 -r ../requirements.txt
-Sphinx==4.2.0
+Sphinx==5.3.0
 sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
### Summary
Updates the Sphinx version to 5.3.0, as it started to fail [building 3 1/2 months ago](https://readthedocs.org/projects/avrae/builds/24248282/)

Also fixed the `get_effect()` docstring, as it was breaking without the extra line break?

You can see a version with these changes here: https://avrae-croebh.readthedocs.io/en/latest/

### Changelog Entry
Fix the ReadTheDocs build process

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
