### PR TITLE
skipround respecting deathdelete

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -511,9 +511,10 @@ class InitTracker(commands.Cog):
         combat = await ctx.get_combat()
 
         to_remove = []
-        for co in combat.get_combatants():
-            if isinstance(co, MonsterCombatant) and co.hp <= 0 and co is not combat.current_combatant:
-                to_remove.append(co)
+        if combat.options.deathdelete:
+            for co in combat.get_combatants():
+                if isinstance(co, MonsterCombatant) and co.hp <= 0 and co is not combat.current_combatant:
+                    to_remove.append(co)
 
         messages = combat.skip_rounds(numrounds)
 


### PR DESCRIPTION

### Summary
Currently `!init skipround` does not adhere to the deathdelete toggle.  This change will verify deathdelete is True prior to removing 0 hp combatants with `!init skipround`

### Changelog Entry

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
