### PR TITLE
Fix homebrew lookup in slash commands

### DIFF
--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -239,7 +239,7 @@ async def add_training_data(mdb, lookup_type, query, result_name, metadata=None,
 
 
 def slash_match_key(entity):
-    return f"{entity.name} {entity.source} {'homebrew' if entity.homebrew else ''}"
+    return f"{entity.name} ({'🍺 - ' if entity.homebrew else ''}{entity.source})"
 
 
 def lookup_converter(entity_type: str) -> Callable:


### PR DESCRIPTION
### Summary
With the changes to fuzzy search, the match key generated for slash commands wasn't as close as it needs to be, causing some homebrew stuff to end up being de-prioritized when selected via slash command lookup.

Honestly surprised it was working as well as it was before this, haha.

### Changelog Entry
Fixed homebrew content (Monsters, spells, items) being able to be looked up properly with slash commands

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
