### PR TITLE
Improve monster embeds

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -612,19 +612,19 @@ class Lookup(commands.Cog):
         if visible:
             embed_queue[-1].description = monster.get_meta()
             if monster.traits:
-                trait = "\n\n".join(f"**{a.name}:** {a.desc}" for a in monster.traits)
+                trait = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.traits)
                 if trait:
                     safe_append("Special Abilities", trait)
             if monster.actions:
-                action = "\n\n".join(f"**{a.name}:** {a.desc}" for a in monster.actions)
+                action = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.actions)
                 if action:
                     safe_append("Actions", action)
             if monster.bonus_actions:
-                bonus_action = "\n\n".join(f"**{a.name}:** {a.desc}" for a in monster.bonus_actions)
+                bonus_action = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.bonus_actions)
                 if bonus_action:
                     safe_append("Bonus Actions", bonus_action)
             if monster.reactions:
-                reaction = "\n\n".join(f"**{a.name}:** {a.desc}" for a in monster.reactions)
+                reaction = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.reactions)
                 if reaction:
                     safe_append("Reactions", reaction)
             if monster.legactions:
@@ -637,13 +637,13 @@ class Lookup(commands.Cog):
                 ]
                 for a in monster.legactions:
                     if a.name:
-                        legendary.append(f"**{a.name}:** {a.desc}")
+                        legendary.append(f"***{a.name}.*** {a.desc}")
                     else:
                         legendary.append(a.desc)
                 if legendary:
                     safe_append("Legendary Actions", "\n\n".join(legendary))
             if monster.mythic_actions:
-                mythic_action = "\n\n".join(f"**{a.name}:** {a.desc}" for a in monster.mythic_actions)
+                mythic_action = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.mythic_actions)
                 if mythic_action:
                     safe_append("Mythic Actions", mythic_action)
 
@@ -681,10 +681,10 @@ class Lookup(commands.Cog):
             languages = len(monster.languages)
 
             embed_queue[-1].description = (
-                f"{size} {_type}.\n"
-                f"**AC:** {ac}.\n**HP:** {hp}.\n**Speed:** {monster.speed}\n"
+                f"*{size} {_type}*\n"
+                f"**AC** {ac}\n**HP** {hp}\n**Speed** {monster.speed}\n"
                 f"{monster.get_hidden_stat_array()}\n"
-                f"**Languages:** {languages}\n"
+                f"**Languages** {languages}\n"
             )
 
             if monster.traits:

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -342,7 +342,7 @@ class Monster(StatBlock, Sourced):
             desc += "**Languages** --\n"
 
         if not self.hide_cr:
-            desc += f"**Challenge** {self.cr} ({self.xp} XP)"
+            desc += f"**Challenge** {self.cr} ({self.xp:,} XP)"
         return desc
 
     def get_title_name(self):

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -315,34 +315,34 @@ class Monster(StatBlock, Sourced):
         """
         size = self.size
         type_ = self.creature_type
-        alignment = self.alignment
+        alignment = ", " + self.alignment if self.alignment else ""
         ac = str(self.ac) + (f" ({self.armortype})" if self.armortype else "")
         hp = f"{self.hp} ({self.hitdice})"
         speed = self.speed
 
-        desc = f"{size} {type_}. {alignment}.\n**AC:** {ac}.\n**HP:** {hp}.\n**Speed:** {speed}\n"
+        desc = f"*{size} {type_}{alignment}*\n**AC** {ac}\n**HP** {hp}\n**Speed** {speed}\n"
         desc += f"{self.get_stat_array()}\n"
 
         if str(self.saves):
-            desc += f"**Saving Throws:** {self.saves}\n"
+            desc += f"**Saving Throws** {self.saves}\n"
         if str(self.skills):
-            desc += f"**Skills:** {self.skills}\n"
-        desc += f"**Senses:** {self.get_senses_str()}.\n"
+            desc += f"**Skills** {self.skills}\n"
+        desc += f"**Senses** {self.get_senses_str()}\n"
         if self._displayed_resistances.vuln:
-            desc += f"**Vulnerabilities:** {', '.join(str(r) for r in self._displayed_resistances.vuln)}\n"
+            desc += f"**Vulnerabilities** {', '.join(str(r) for r in self._displayed_resistances.vuln)}\n"
         if self._displayed_resistances.resist:
-            desc += f"**Resistances:** {', '.join(str(r) for r in self._displayed_resistances.resist)}\n"
+            desc += f"**Resistances** {', '.join(str(r) for r in self._displayed_resistances.resist)}\n"
         if self._displayed_resistances.immune:
-            desc += f"**Damage Immunities:** {', '.join(str(r) for r in self._displayed_resistances.immune)}\n"
+            desc += f"**Damage Immunities** {', '.join(str(r) for r in self._displayed_resistances.immune)}\n"
         if self.condition_immune:
-            desc += f"**Condition Immunities:** {', '.join(map(str, self.condition_immune))}\n"
+            desc += f"**Condition Immunities** {', '.join(map(str, self.condition_immune))}\n"
         if self.languages:
-            desc += f"**Languages:** {', '.join(self.languages)}\n"
+            desc += f"**Languages** {', '.join(self.languages)}\n"
         else:
-            desc += "**Languages:** --\n"
+            desc += "**Languages** --\n"
 
         if not self.hide_cr:
-            desc += f"**CR:** {self.cr} ({self.xp} XP)"
+            desc += f"**Challenge** {self.cr} ({self.xp} XP)"
         return desc
 
     def get_title_name(self):


### PR DESCRIPTION
### Summary
Make monster embeds closer to source material.
- Alignment can be omitted
- Size/Type/Alignment line is italicized
- Trait/Action names are italicized and have a full stop instead of a colon
- Removed punctuation not present in books
- Changed "CR" to "Challenge" as it is in books
- XP is comma-separated

Note: I haven't done anything with how ability scores are displayed because Discord doesn't support markdown tables and the current solution seems good enough while that remains true.

### Changelog Entry
Make monster embeds closer to source material.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
