### PR TITLE
Do not catch Evaluation Error for CC reset by

### DIFF
--- a/cogs5e/models/sheet/player.py
+++ b/cogs5e/models/sheet/player.py
@@ -3,7 +3,6 @@ import collections
 import d20
 
 from cogs5e.models.errors import CounterOutOfBounds, InvalidArgument, NoReset
-from aliasing.errors import EvaluationError
 from utils import constants
 from utils.functions import bubble_format
 from .attack import AttackList
@@ -192,10 +191,7 @@ class CustomCounter:
                 raise InvalidArgument(f"Reset to value {reset_to_value} is greater than max value {max_value}.")
 
         if reset_by is not None:
-            try:
-                evaluated_str = character.evaluate_annostr(str(reset_by))
-            except EvaluationError:
-                raise InvalidArgument(f"`{reset_by}` (`resetby`) has invalid annotations")
+            evaluated_str = character.evaluate_annostr(str(reset_by))
 
             try:
                 d20.parse(evaluated_str)


### PR DESCRIPTION
### Summary
Since the evaluation step already converts the error type, we don't need to catch it here.
### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
