### PR TITLE
Make `adv` in check and save nodes an IntExpression

### DIFF
--- a/cogs5e/models/automation/effects/check.py
+++ b/cogs5e/models/automation/effects/check.py
@@ -264,21 +264,23 @@ class Check(Effect):
     def build_str(self, caster, evaluator):
         super().build_str(caster, evaluator)
         skill_name = natural_join([camel_to_title(a) for a in self.ability_list], "or")
-        if self.dc is not None:
-            dc = stringify_intexpr(evaluator, self.dc)
-            out = f"DC {dc} {skill_name} Check"
-        elif self.contest_ability is not None:
-            contest_skill_name = natural_join([camel_to_title(a) for a in self.contest_ability_list], "or")
-            out = f"{skill_name} Check vs. caster's {contest_skill_name} Check"
-        else:
-            return f"{skill_name} Check"
 
+        adv = ""
         if self.adv:
             match stringify_intexpr(evaluator, self.adv):
                 case AdvantageType.ADV:
-                    out += ", with advantage"
+                    adv = ", with advantage"
                 case AdvantageType.DIS:
-                    out += ", with disdvantage"
+                    adv = ", with disdvantage"
+
+        if self.dc is not None:
+            dc = stringify_intexpr(evaluator, self.dc)
+            out = f"DC {dc} {skill_name} Check" + adv
+        elif self.contest_ability is not None:
+            contest_skill_name = natural_join([camel_to_title(a) for a in self.contest_ability_list], "or")
+            out = f"{skill_name} Check vs. caster's {contest_skill_name} Check" + adv
+        else:
+            return f"{skill_name} Check" + adv
 
         if self.fail:
             fail_out = self.build_child_str(self.fail, caster, evaluator)

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -10,7 +10,7 @@ from ..utils import stringify_intexpr
 
 
 class Save(Effect):
-    def __init__(self, stat: str, fail: list, success: list, dc: str = None, adv: enums.AdvantageType = None, **kwargs):
+    def __init__(self, stat: str, fail: list, success: list, dc: str = None, adv: str = None, **kwargs):
         super().__init__("save", **kwargs)
         self.stat = stat
         self.fail = fail
@@ -34,7 +34,7 @@ class Save(Effect):
         if self.dc is not None:
             out["dc"] = self.dc
         if self.adv is not None:
-            out["adv"] = self.adv.value
+            out["adv"] = self.adv
         return out
 
     def run(self, autoctx):
@@ -107,9 +107,18 @@ class Save(Effect):
         sdis = stat in sdis_effects
 
         # ==== adv ====
+
+        # explicit advantage
+        explicit_adv = None
+        if self.adv:
+            try:
+                explicit_adv = autoctx.parse_intexpression(self.adv)
+            except Exception:
+                raise AutomationException(f"{self.adv!r} cannot be interpreted as an advantage type.")
+
         adv = reconcile_adv(
-            adv=autoctx.args.last("sadv", type_=bool, ephem=True) or sadv or self.adv == enums.AdvantageType.ADV,
-            dis=autoctx.args.last("sdis", type_=bool, ephem=True) or sdis or self.adv == enums.AdvantageType.DIS,
+            adv=autoctx.args.last("sadv", type_=bool, ephem=True) or sadv or explicit_adv == enums.AdvantageType.ADV,
+            dis=autoctx.args.last("sdis", type_=bool, ephem=True) or sdis or explicit_adv == enums.AdvantageType.DIS,
         )
 
         # ==== execution ====

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -160,7 +160,7 @@ Save
         fail: Effect[];
         success: Effect[];
         dc?: IntExpression;
-        adv?: -1 | 0 | 1;
+        adv?: IntExpression;
     }
 
 A Save effect forces a targeted creature to make a saving throw.
@@ -186,8 +186,8 @@ It must be inside a Target effect.
 
     .. attribute:: adv
 
-        *optional, default 0* - Whether the saving throw should have advantage by default (``-1`` = disadvantage,
-        ``1`` = advantage, ``0`` = no advantage).
+        *optional, default 0* - An IntExpression that details whether the saving throw has inherent advantage or not.
+        ``0`` for flat, ``1`` for Advantage, ``-1`` for Disadvantage (Default is flat).
 
 **Variables**
 
@@ -1016,7 +1016,7 @@ Ability Check
         success?: Effect[];
         fail?: Effect[];
         contestTie?: "fail" | "success" | "neither";
-        adv?: -1 | 0 | 1;
+        adv?: IntExpression;
     }
 
 An Ability Check effect forces a targeted creature to make an ability check, optionally as a contest against the caster.
@@ -1089,8 +1089,8 @@ It must be inside a Target effect.
 
     .. attribute:: adv
 
-        *optional, default 0* - Whether the check should have advantage by default (``-1`` = disadvantage,
-        ``1`` = advantage, ``0`` = no advantage).
+        *optional, default 0* - An IntExpression that details whether the check has inherent advantage or not.
+        ``0`` for flat, ``1`` for Advantage, ``-1`` for Disadvantage (Default is flat).
 
 **Variables**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v4.1.8
+git+https://github.com/avrae/automation-common@v4.2.47
 d20==1.1.2
 
 # top-level deps


### PR DESCRIPTION
### Summary
Makes `adv` in check and save nodes an IntExpression instead of `-1 | 0 | 1` (AFR-1048)

This will require other repos to be updated:
- https://github.com/avrae/automation-common/pull/9
- https://github.com/avrae/avrae-service for the automation builder I think, but someone else will need to do that part.

### Changelog Entry
Makes `adv` in check and save nodes an IntExpression instead of `-1 | 0 | 1`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
