### PR TITLE
Add AFR-1055

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -103,7 +103,7 @@ class InitTracker(commands.Cog):
                 log.exception("Failed to handle init effect button click interaction:")
 
     # ==== commands ====
-    @commands.group(aliases=["i"], invoke_without_command=True)
+    @commands.group(aliases=["i", "I"], invoke_without_command=True)
     async def init(self, ctx):
         """Commands to help track initiative."""
         await ctx.send(f"Incorrect usage. Use {ctx.prefix}help init for help.")


### PR DESCRIPTION
Frankly it is absurd that this wasn't a thing years ago but someone's gotta do it

### Summary
Adds AFR-1055 | An additional alias for `!init`: `!I`. Mobile devices often correct the lowercase `i` to `I` when attempting to use `!i`; this ensures that users won't have to go out of their way to `!alias I i`, or spend the extra three fingerstrokes for `!init`.

### Changelog Entry
Mobile users rejoice! A new built-in alias for `!init`, **`!I`**, allows one to access `!init` commands with just one fingerstroke on phones that were correcting the lowercase `i` to an uppercase `I`.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
