### PR TITLE
Correct mistake in automation reference

### DIFF
--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -88,10 +88,6 @@ It designates what creatures to affect.
         - ``hp_asc``: Sorts the targets in order of remaining hit points ascending (lowest HP first, None last).
         - ``hp_desc``: Sorts the targets in order of remaining hit points descending (highest HP first, None last).
 
-    .. attribute:: self_target
-
-        *optional* - If ``true``, the effect will be added to the caster of the automation as opposed to the target.
-
 **Variables**
 
 - ``target`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The current target.


### PR DESCRIPTION
### Summary
This doesn't exist. https://github.com/avrae/automation-common/blob/7c0b4783d99eac27139c422d7c1ebd31b3337e3a/automation_common/validation/models.py#L106

### Changelog Entry
Fixes an error in the automation docs about the Target node
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
