### PR TITLE
HP deltas

### DIFF
--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -151,15 +151,17 @@ class Combatant(BaseCombatant, StatBlock):
         """Returns a string representation of the combatant's HP."""
         out = ""
         if not self.is_private or private:
+            hp_strs = []
             if self.max_hp is not None and self.hp is not None:
-                out = f"<{self.hp}/{self.max_hp} HP>"
+                hp_strs.append(f"{self.hp}/{self.max_hp} HP")
             elif self.hp is not None:
-                out = f"<{self.hp} HP>"
-            else:
-                out = ""
+                hp_strs.append(f"{self.hp} HP")
 
             if self.temp_hp and self.temp_hp > 0:
-                out += f" (+{self.temp_hp} temp)"
+                hp_strs.append(f"{self.temp_hp} temp")
+
+            out = f"<{', '.join(hp_strs) or 'None'}>"
+
         elif self.max_hp is not None and self.max_hp > 0:
             ratio = self.hp / self.max_hp
             if ratio >= 1:

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -341,7 +341,9 @@ class AutomationTarget:
 
             if isinstance(self.target, init.Combatant):
                 if self.target.is_private:
-                    autoctx.add_pm(self.target.controller_id, f"{self.target.name}'s HP: {self.target.hp_str(True)}{delta_str}")
+                    autoctx.add_pm(
+                        self.target.controller_id, f"{self.target.name}'s HP: {self.target.hp_str(True)}{delta_str}"
+                    )
                     # don't reveal HP/temp delta breakdown in the footer.
                     if delta_str:
                         delta_str = f" ({total_delta:+})"

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -320,15 +320,37 @@ class AutomationTarget:
     def damage(self, autoctx: AutomationContext, amount: int, allow_overheal: bool = True):
         # add damage footer when we attack a Combatant
         if not self.is_simple:
+            initial_hp = self.target.hp
+            initial_temp_hp = self.target.temp_hp
             result = self.target.modify_hp(-amount, overflow=allow_overheal)
-            autoctx.footer_queue(f"{self.target.name}: {result}")
+            result_str = f"{self.target.name}: {result}"
+
+            deltas = []
+            if self.target.temp_hp != initial_temp_hp:
+                deltas.append(f"{self.target.temp_hp - initial_temp_hp:+}")
+            if self.target.hp != initial_hp:
+                deltas.append(f"{self.target.hp - initial_hp:+}")
+            total_delta = self.target.temp_hp + self.target.hp - initial_temp_hp - initial_hp
+            if amount != total_delta:
+                deltas.append(f"{abs(amount - total_delta)} overflow")
+
+            if deltas:
+                delta_str = f" ({', '.join(deltas)})"
+            else:
+                delta_str = ""
 
             if isinstance(self.target, init.Combatant):
                 if self.target.is_private:
-                    autoctx.add_pm(self.target.controller_id, f"{self.target.name}'s HP: {self.target.hp_str(True)}")
+                    autoctx.add_pm(self.target.controller_id, f"{self.target.name}'s HP: {self.target.hp_str(True)}{delta_str}")
+                    # don't reveal HP/temp delta breakdown in the footer.
+                    if delta_str:
+                        delta_str = f" ({total_delta:+})"
 
                 if self.target.is_concentrating() and amount > 0:
                     autoctx.queue(f"**Concentration**: DC {int(max(amount / 2, 10))}")
+
+            autoctx.footer_queue(result_str + delta_str)
+
         # for a non-init target, we still want to display that a damage node was run in the footer.
         else:
             autoctx.footer_queue(f"{self.target or '<No Target>'}: Dealt {amount} damage!")

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -327,9 +327,9 @@ class AutomationTarget:
 
             deltas = []
             if self.target.temp_hp != initial_temp_hp:
-                deltas.append(f"{self.target.temp_hp - initial_temp_hp:+}")
+                deltas.append(f"{self.target.temp_hp - initial_temp_hp:+} temp")
             if self.target.hp != initial_hp:
-                deltas.append(f"{self.target.hp - initial_hp:+}")
+                deltas.append(f"{self.target.hp - initial_hp:+} HP")
             total_delta = self.target.temp_hp + self.target.hp - initial_temp_hp - initial_hp
             if -amount != total_delta:
                 deltas.append(f"{abs(amount + total_delta)} overflow")

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -331,8 +331,8 @@ class AutomationTarget:
             if self.target.hp != initial_hp:
                 deltas.append(f"{self.target.hp - initial_hp:+}")
             total_delta = self.target.temp_hp + self.target.hp - initial_temp_hp - initial_hp
-            if amount != total_delta:
-                deltas.append(f"{abs(amount - total_delta)} overflow")
+            if -amount != total_delta:
+                deltas.append(f"{abs(amount + total_delta)} overflow")
 
             if deltas:
                 delta_str = f" ({', '.join(deltas)})"

--- a/tests/e2e/initiative_mixed_test.py
+++ b/tests/e2e/initiative_mixed_test.py
@@ -125,7 +125,7 @@ async def attack_I(avrae, dhttp, name="KO1", attack_command="!attack", delete_fi
         await dhttp.receive_delete()
     embed = disnake.Embed(title=rf".* attacks with a {DAGGER_PATTER}!")
     embed.add_field(name=name, value=ATTACK_PATTERN, inline=False)
-    embed.set_footer(text=rf"{name}: <-?\d+/\d+ HP> \([-+]\d+ HP\)")
+    embed.set_footer(text=rf"{name}: <-?\d+/\d+ HP>( \([-+]\d+ HP\))+")
     await dhttp.receive_edit()
     await dhttp.receive_message(embed=embed)
     await dhttp.drain()
@@ -152,7 +152,7 @@ async def cast_I(avrae, dhttp, names=("KO2", "KO3"), cast_command="!cast"):
     embed.add_field(name="Meta", value=rf"{DAMAGE_PATTERN}\n\*\*DC\*\*: \d+", inline=False)
     for target in names:
         embed.add_field(name=target, value=SAVE_PATTERN, inline=False)
-    footer = "\n".join(rf"{name}: <-?\d+/\d+ HP> \([-+]\d+ HP\)" for name in names)
+    footer = "\n".join(rf"{name}: <-?\d+/\d+ HP>( \([-+]\d+ HP\))?" for name in names)
     embed.set_footer(text=footer)
     await dhttp.receive_message(embed=embed)
     await dhttp.drain()

--- a/tests/e2e/initiative_mixed_test.py
+++ b/tests/e2e/initiative_mixed_test.py
@@ -125,7 +125,7 @@ async def attack_I(avrae, dhttp, name="KO1", attack_command="!attack", delete_fi
         await dhttp.receive_delete()
     embed = disnake.Embed(title=rf".* attacks with a {DAGGER_PATTER}!")
     embed.add_field(name=name, value=ATTACK_PATTERN, inline=False)
-    embed.set_footer(text=rf"{name}: <-?\d+/\d+ HP> (-?\d+ HP)")
+    embed.set_footer(text=rf"{name}: <-?\d+/\d+ HP> \([-+]\d+ HP\)")
     await dhttp.receive_edit()
     await dhttp.receive_message(embed=embed)
     await dhttp.drain()
@@ -152,7 +152,7 @@ async def cast_I(avrae, dhttp, names=("KO2", "KO3"), cast_command="!cast"):
     embed.add_field(name="Meta", value=rf"{DAMAGE_PATTERN}\n\*\*DC\*\*: \d+", inline=False)
     for target in names:
         embed.add_field(name=target, value=SAVE_PATTERN, inline=False)
-    footer = "\n".join(rf"{name}: <-?\d+/\d+ HP> (-?\d+ HP)" for name in names)
+    footer = "\n".join(rf"{name}: <-?\d+/\d+ HP> \([-+]\d+ HP\)" for name in names)
     embed.set_footer(text=footer)
     await dhttp.receive_message(embed=embed)
     await dhttp.drain()


### PR DESCRIPTION
### Summary
Resolves #1821 - sorta. HP deltas are shown but damage instances are **not** grouped together, as per [benubu](https://github.com/benubu)'s comment on that FR.

NOTE: This changes the return value of `Combatant.hp_str()`, which may affect aliases.
Instead of `<10/10> (+10 temp)` for a non-hidden combatant, it will display as `<10/10, 10 temp>`.
This change was necessary to make sure the new HP is distinct from the delta HP.

### Changelog Entry
When a combatant is damaged via automation, HP deltas will now be shown in the footer alongside the new HP values.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
