### PR TITLE
Update custom one-off !init attack docs to be clearer about syntax

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1109,7 +1109,7 @@ class InitTracker(commands.Cog):
         Rolls an attack against another combatant.
         __**Valid Arguments**__
         {VALID_AUTOMATION_ARGS}
-        custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
+        custom - Modifier to indicate that the (arbitrarily-named) attack is custom, with custom to hit and damage values. Use `-b` and `-d` like this: `!init attack "pizza" custom -b 3 -d 1`
         """,
     )
     async def attack(self, ctx, atk_name=None, *, args=""):
@@ -1138,7 +1138,7 @@ class InitTracker(commands.Cog):
         Rolls an attack as another combatant.
         __**Valid Arguments**__
         {VALID_AUTOMATION_ARGS}
-        custom - Makes a custom attack with 0 to hit and base damage. Use `-b` and `-d` to add to hit and damage.
+        custom - Modifier to indicate that the (arbitrarily-named) attack is custom, with custom to hit and damage values. Use `-b` and `-d` like this: `!init attack "pizza" custom -b 3 -d 1`
         """,
     )
     async def aoo(self, ctx, combatant_name, atk_name=None, *, args=""):


### PR DESCRIPTION
Clarify the documentation on making one-off custom attacks to indicate that the attack needs to be named, the name can be anything, and "custom" is an argument. The previous wording was unclear about whether "custom" was a argument, or to be specified as the name of the attack; this hopefully improves that.

### Summary
Clarify !init attack documentation about custom one-off attacks

### Changelog Entry
Clarify !init attack documentation about custom one-off attacks

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
