### PR TITLE
Warn users trying to import bestiaries with `!import` rather than `!bestiary import`

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -900,6 +900,12 @@ class SheetManager(commands.Cog):
             try:
                 url = extract_gsheet_id_from_url(url)
             except ExternalImportError:
+                if re.match(
+                    r"https?://(?:www\.)?bestiarybuilder.com/bestiary-viewer/([0-9a-f]+)", url) 
+                or re.match(
+                    r"https?://(?:www\.)?critterdb.com(?::443|:80)?.*#/(published)?bestiary/view/([0-9a-f]+)", url
+                ):
+                    return await ctx.send("Bestiaries must be imported with the `!bestiary import` command.")
                 return await ctx.send("Sheet type did not match accepted formats.")
             loading = await ctx.send("Loading character data from Google...")
             prefix = "google"

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -6,6 +6,7 @@ Created on Jan 19, 2017
 
 import asyncio
 import logging
+import re
 import time
 import traceback
 from typing import List
@@ -901,11 +902,11 @@ class SheetManager(commands.Cog):
                 url = extract_gsheet_id_from_url(url)
             except ExternalImportError:
                 if re.match(
-                    r"https?://(?:www\.)?bestiarybuilder.com/bestiary-viewer/([0-9a-f]+)", url) 
-                or re.match(
+                    r"https?://(?:www\.)?bestiarybuilder.com/bestiary-viewer/([0-9a-f]+)", url
+                ) or re.match(
                     r"https?://(?:www\.)?critterdb.com(?::443|:80)?.*#/(published)?bestiary/view/([0-9a-f]+)", url
                 ):
-                    return await ctx.send("Bestiaries must be imported with the `!bestiary import` command.")
+                    return await ctx.send("Bestiaries must be imported with the `!bestiary import` command instead.")
                 return await ctx.send("Sheet type did not match accepted formats.")
             loading = await ctx.send("Loading character data from Google...")
             prefix = "google"


### PR DESCRIPTION
### Summary
Inform users trying to import bestiaries with `!import` rather than `!bestiary import`. This is a common mistake people make.

### Changelog Entry
Warn users trying to `!import` bestiaries to use `!bestiary import` instead.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
