### PR TITLE
Avr 516 add rules reference code in avrae to handle versions

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -93,7 +93,7 @@ class Lookup(commands.Cog):
 
         if name:
             version = name.split()[-1] if name.split()[-1] in valid_versions else "2024"
-            name = name.replace(version, "") if name.split()[-1] in valid_versions else name
+            name = name.replace(version, "").strip() if name.split()[-1] in valid_versions else name
         else:
             version = "2024"
 

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -89,7 +89,7 @@ class Lookup(commands.Cog):
     @commands.command(aliases=["reference"])
     async def rule(self, ctx, *, name: str = None):
         """Looks up a rule."""
-        valid_versions = [ "2024", "2014"] #TODO: move to a global variable
+        valid_versions = ["2024", "2014"]  # TODO: move to a global variable
 
         if name:
             version = name.split()[-1] if name.split()[-1] in valid_versions else "2024"

--- a/cogsmisc/adminUtils.py
+++ b/cogsmisc/adminUtils.py
@@ -363,7 +363,6 @@ class AdminUtils(commands.Cog):
         except Exception as e:
             await ctx.send(f"Error registering slash commands: {e}")
 
-
     # ---- workshop ----
     @admin.group(name="workshop", invoke_without_command=True)
     @checks.is_owner()

--- a/cogsmisc/adminUtils.py
+++ b/cogsmisc/adminUtils.py
@@ -353,6 +353,17 @@ class AdminUtils(commands.Cog):
         resp = await self.pscall("kill_cluster", kwargs={"cluster_id": cluster_id}, expected_replies=1)
         await self._send_replies(ctx, resp)
 
+    @admin.command(hidden=True, name="register_commands")
+    @checks.is_owner()
+    async def registerslash(self, ctx):
+        """Registers all slash commands."""
+        try:
+            await self.bot._sync_application_commands()
+            await ctx.send("Registered slash commands succesfully.")
+        except Exception as e:
+            await ctx.send(f"Error registering slash commands: {e}")
+
+
     # ---- workshop ----
     @admin.group(name="workshop", invoke_without_command=True)
     @checks.is_owner()


### PR DESCRIPTION
### Summary
Updated !rules/!reference command to accept version as an argument.

Example: !rules Two-Weapon Fighting 2014
Where **Two-Weapon Fighting** is the name to search and **2014** is the version

Version defaults to 2024 if no version is passed.

### Changelog Entry
Add versioning to the rule compendium lookups.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
