### PR TITLE
Implementing logic to respect allow_character_override

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -875,12 +875,22 @@ class SheetManager(commands.Cog):
 
 
         """  # noqa: E501
+        serv_settings = await ctx.get_server_settings()
         if version is None:
-            serv_settings = await ctx.get_server_settings()
             if serv_settings:
                 version = serv_settings.version
             else:
                 version = "2024"
+        else:
+            # version was passed in, check allow_character_override
+            if version != serv_settings.version and not serv_settings.allow_character_override:
+                version = serv_settings.version
+                await ctx.send(
+                    f"Character-specific version override is disabled. This character was imported as {version}, If you think this is incorrect, please contact a Server Admin."
+                )
+            else:
+                version = version
+
         url = await self._check_url(ctx, url)  # check for < >
         # Sheets in order: DDB, Dicecloud, Gsheet
         if beyond_match := DDB_URL_RE.match(url):

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -487,11 +487,15 @@ async def get_spell_choices(ctx, homebrew=True):
     else:
         version = "2024"
 
-    try:
-        character: Character = await ctx.get_character()
-        version = character.options.version if character.options.version else version
-    except NoCharacter:
-        pass
+    # If allow_character_override is enabled, check for a character and use its version. Else, use the server version.
+    if serv_settings.allow_character_override:
+        try:
+            character: Character = await ctx.get_character()
+            version = character.options.version if character.options.version else version
+        except NoCharacter:
+            pass
+    else:
+        version = version
 
     if not homebrew:
         if version == "2024":

--- a/ui/charsettings.py
+++ b/ui/charsettings.py
@@ -11,6 +11,7 @@ from cogs5e.models import embeds
 from cogs5e.models.character import Character
 from utils.enums import CoinsAutoConvert
 from utils.settings import CharacterSettings
+from utils.settings import ServerSettings
 from .menu import MenuBase
 
 _AvraeT = TypeVar("_AvraeT", bound=disnake.Client)

--- a/ui/servsettings.py
+++ b/ui/servsettings.py
@@ -340,7 +340,7 @@ class _LookupSettingsUI(ServerSettingsMenuBase):
             name="Allow Character Override",
             value=(
                 f"**{self.settings.allow_character_override}**\n"
-                "*If this is enabled, ... Add an appropriate description.*"
+                "*If this is enabled, users are able to use their own character version vs being locked to the server version.*"
             ),
             inline=False,
         )


### PR DESCRIPTION
### Summary
This update adds a check to respect the flag "allow_character_override" when importing a character and performing spells lookups.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
