### PR TITLE
Fixed a spelling issue in init dyn argument

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -567,7 +567,7 @@ class InitTracker(commands.Cog):
         """
         Changes the settings of the active combat.
         __Valid Settings__
-        `dyn` - Dynamic initiative; Rerolls all initiatves at the start of a round.
+        `dyn` - Dynamic initiative; Rerolls all initiatives at the start of a round.
         `turnnotif` - Notifies the controller of the next combatant in initiative.
         `deathdelete` - Toggles removing monsters below 0 HP.
         `-name <name>` - Sets a name for the combat instance.


### PR DESCRIPTION
### Summary
Noticed this when someone pulled up the help for init meta and decided to maintain my legacy of nonsense small changes

### Changelog Entry
Fixed a spelling issue in `!help init meta`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
