### PR TITLE
Add `list_display_override` to custom attacks

### DIFF
--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -210,22 +210,20 @@ class AttackList:
     @property
     def other_attacks(self):
         """Returns an AttackList of attacks that do not fall into the other action categories."""
-        return AttackList(
-            [
-                a
-                for a in self.attacks
-                if a.activation_type
-                not in (
-                    enums.ActivationType.ACTION,
-                    enums.ActivationType.BONUS_ACTION,
-                    enums.ActivationType.REACTION,
-                    enums.ActivationType.LEGENDARY,
-                    enums.ActivationType.MYTHIC,
-                    enums.ActivationType.LAIR,
-                    None,
-                )
-            ]
-        )
+        return AttackList([
+            a
+            for a in self.attacks
+            if a.activation_type
+            not in (
+                enums.ActivationType.ACTION,
+                enums.ActivationType.BONUS_ACTION,
+                enums.ActivationType.REACTION,
+                enums.ActivationType.LEGENDARY,
+                enums.ActivationType.MYTHIC,
+                enums.ActivationType.LAIR,
+                None,
+            )
+        ])
 
     # list compat
     def append(self, attack):

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -22,6 +22,7 @@ class Attack:
         thumb: str = None,
         extra_crit_damage: str = None,
         activation_type: enums.ActivationType = None,
+        list_display_override: str = None,
         **_,
     ):
         self.name = name
@@ -33,6 +34,7 @@ class Attack:
         self.thumb = thumb
         self.extra_crit_damage = extra_crit_damage
         self.activation_type = activation_type
+        self.list_display_override = list_display_override
 
     # ==== ser / deser ====
     @classmethod
@@ -57,6 +59,7 @@ class Attack:
             thumb=d.get("thumb"),
             extra_crit_damage=d.get("extra_crit_damage"),
             activation_type=activation_type,
+            list_display_override=d.get("list_display_override"),
         )
 
     @classmethod
@@ -80,7 +83,7 @@ class Attack:
         if self.proper:
             base["proper"] = True
 
-        for optattr in ("verb", "criton", "phrase", "thumb", "extra_crit_damage"):
+        for optattr in ("verb", "criton", "phrase", "thumb", "extra_crit_damage", "list_display_override"):
             if (val := getattr(self, optattr)) is not None:
                 base[optattr] = val
 
@@ -103,6 +106,7 @@ class Attack:
         thumb: Optional[str] = None,
         extra_crit_damage: Optional[str] = None,
         activation_type: Optional[enums.ActivationType] = None,
+        list_display_override: Optional[str] = None,
     ):
         """Creates a new attack for a character."""
         if bonus_calc is not None:
@@ -118,6 +122,7 @@ class Attack:
             thumb=thumb,
             extra_crit_damage=extra_crit_damage,
             activation_type=activation_type,
+            list_display_override=list_display_override,
         )
 
     @classmethod
@@ -133,10 +138,11 @@ class Attack:
             other.thumb,
             other.extra_crit_damage,
             other.activation_type,
+            other.list_display_override,
         )
 
     def build_str(self, caster):
-        return f"**{self.name}**: {self.automation.build_str(caster)}"
+        return f"**{self.name}**: {self.list_display_override or self.automation.build_str(caster)}"
 
     def __str__(self):
         return f"**{self.name}**: {str(self.automation)}"
@@ -204,20 +210,22 @@ class AttackList:
     @property
     def other_attacks(self):
         """Returns an AttackList of attacks that do not fall into the other action categories."""
-        return AttackList([
-            a
-            for a in self.attacks
-            if a.activation_type
-            not in (
-                enums.ActivationType.ACTION,
-                enums.ActivationType.BONUS_ACTION,
-                enums.ActivationType.REACTION,
-                enums.ActivationType.LEGENDARY,
-                enums.ActivationType.MYTHIC,
-                enums.ActivationType.LAIR,
-                None,
-            )
-        ])
+        return AttackList(
+            [
+                a
+                for a in self.attacks
+                if a.activation_type
+                not in (
+                    enums.ActivationType.ACTION,
+                    enums.ActivationType.BONUS_ACTION,
+                    enums.ActivationType.REACTION,
+                    enums.ActivationType.LEGENDARY,
+                    enums.ActivationType.MYTHIC,
+                    enums.ActivationType.LAIR,
+                    None,
+                )
+            ]
+        )
 
     # list compat
     def append(self, attack):


### PR DESCRIPTION
### Summary
Adds `list_display_override` to Attacks, matching how it works on Actions. Allows users to override the display of custom attacks, as well as allowing the override on attacks on officially automated monsters.

Reliant on https://github.com/avrae/automation-common/pull/11

### Changelog Entry
Adds `list_display_override` to Attacks, matching how it works on Actions. Allows users to override the display of custom attacks, as well as allowing the override on attacks on officially automated monsters.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
