### PR TITLE
feat: include the range of a spell when it is cast

### DIFF
--- a/cogs5e/models/automation/effects/castspell.py
+++ b/cogs5e/models/automation/effects/castspell.py
@@ -101,6 +101,8 @@ class CastSpell(Effect):
                 autoctx.metavars["spell_level"] = autoctx.spell_level_override
             autoctx.spell = spell
 
+            autoctx.meta_queue(f"**Range**: {spell.range}")
+
             results = self.run_children(spell.automation.effects, autoctx)
 
             # and restore them


### PR DESCRIPTION
### Summary

Resolved #961

### Changelog Entry

Casting a spell now displays its range

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
