### PR TITLE
docs: get_combatant() doesn't return groups

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -53,13 +53,13 @@ class SimpleCombat:
         """
         Gets a combatant by its name or ID.
 
-        :param str name: The name or id of the combatant or group to get.
+        :param str name: The name or id of the combatant to get.
         :param strict: Whether combatant name must be a full case insensitive match.
             If this is ``None`` (default), attempts a strict match with fallback to partial match.
             If this is ``False``, it returns the first partial match.
             If this is ``True``, it will only return a strict match.
-        :return: The combatant or group or None.
-        :rtype: :class:`~aliasing.api.combat.SimpleCombatant` or `~aliasing.api.combat.SimpleGroup`
+        :return: The combatant or None.
+        :rtype: :class:`~aliasing.api.combat.SimpleCombatant`
         """
         name = str(name)
         combatant = self._combat.get_combatant(name, strict)


### PR DESCRIPTION
### Summary
Fixes the documentation, which incorrectly states that `get_combatant()` can return a group. 

This is a follow-up to an issue brought up on Discord in November, where updating the docs like this was deemed to be the simplest change. Rev also suggested replacing L68 with `return None`.

The alternative would be to change the code in [cogs5e/initiative/combat.py](https://github.com/avrae/avrae/blob/nightly/cogs5e/initiative/combat.py) so L317 and L319 there iterate over `self.get_combatants(groups=True)`, but this might break things.

### Changelog Entry
N/A

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [X] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
