### PR TITLE
AVR-294 added datadog tracer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ COPY --chown=avrae:avrae . .
 # Download AWS pubkey to connect to documentDB
 RUN wget https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 
-ENTRYPOINT python dbot.py $DBOT_ARGS
+ENTRYPOINT /home/avrae/.local/bin/ddtrace-run python dbot.py $DBOT_ARGS

--- a/dbot.py
+++ b/dbot.py
@@ -32,6 +32,18 @@ from utils.feature_flags import AsyncLaunchDarklyClient
 from utils.help import help_command
 from utils.redisIO import RedisIO
 
+from ddtrace import tracer
+from ddtrace.sampler import DatadogSampler, SamplingRule
+
+tracer.configure(
+    sampler=DatadogSampler(
+        rules=[
+            # Sample all 'avrae-bot' traces at 90.00%:
+            SamplingRule(sample_rate=0.9000, service="avrae-bot")
+        ]
+    )
+)
+
 # This method will load the variables from .env into the environment for running in local
 # from dotenv import load_dotenv
 # load_dotenv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ botocore==1.23.24
 google-auth==2.13.0
 
 # Handling for Datadog
-ddtrace>=0.59.1
+ddtrace~=2.8.2


### PR DESCRIPTION
### Summary
Added datadog support for traces on avrae bot according to [AVR-294](https://wizardsofthecoast.atlassian.net/browse/AVR-294). ECS task definition update is pending from avrae-terraform repo or direct aws console update, since the ddagent container is not defined in the task definition and its resources must be upgraded to prevent it from breaking.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
