### PR TITLE
Fix for AVR-1027

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -128,7 +128,7 @@ class Lookup(commands.Cog):
                 await inter.send("Rule not found.", ephemeral=True)
                 return
             name = name[0]
-        return await self._rule(inter, name)
+        return await self._rule(inter, name, "2024")
 
     @slash_rule.autocomplete("name")
     async def slash_rule_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):


### PR DESCRIPTION
See comment on AVR-1027 - inter is not an object supporting the ctx functions so the call to self._rule can only work if the version is specified.

### Summary
Very simple fix for AVR-1027

### Changelog Entry
Fix AVR-1027 - restore /lookup rule functionality

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
