### PR TITLE
hotfix: spell lookup on DMs

### DIFF
--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -488,7 +488,7 @@ async def get_spell_choices(ctx, homebrew=True):
         version = "2024"
 
     # If allow_character_override is enabled, check for a character and use its version. Else, use the server version.
-    if serv_settings.allow_character_override:
+    if serv_settings and serv_settings.allow_character_override:
         try:
             character: Character = await ctx.get_character()
             version = character.options.version if character.options.version else version


### PR DESCRIPTION
### Summary
Spell lookup were breaking when executed in DMs due to serv_settings being None. The issue occurred because serv_settings.allow_character_override was accessed without checking if serv_settings existed.

### Changelog Entry
Added a safeguard to ensure serv_settings is not None before checking allow_character_override, as serv_settings is unavailable in DMs.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
