### PR TITLE
Rule and Spell Lookup Changes

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -21,7 +21,7 @@ from cogs5e.models.errors import ConsumableException, InvalidArgument, NoSelecti
 from cogs5e.utils import actionutils, checkutils, gameutils, targetutils
 from cogs5e.utils.gameutils import resolve_strict_coins
 from cogs5e.utils.help_constants import *
-from gamedata.lookuputils import get_spell_choices, select_spell_full
+from gamedata.lookuputils import get_lookup_version, get_spell_choices, select_spell_full
 from utils.constants import COUNTER_BUBBLES
 from utils.argparser import argparse
 from utils.functions import confirm, maybe_mod, search, search_and_select, try_delete
@@ -486,7 +486,8 @@ class GameTrack(commands.Cog):
         -b <sab> - When cast, this spell always uses this spell attack bonus.
         -mod <mod> - When cast, this spell always uses this as the value of its casting stat (usually for healing spells).
         """  # noqa: E501
-        spell = await select_spell_full(ctx, spell_name)
+        version = await get_lookup_version(ctx)
+        spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.rulesVersion in [version, ""])
         character: Character = await ctx.get_character()
         args = argparse(args)
 
@@ -820,20 +821,23 @@ class GameTrack(commands.Cog):
         await try_delete(ctx.message)
 
         char: Character = await ctx.get_character()
+        version = await get_lookup_version(ctx)
 
         args = await helpers.parse_snippets(args, ctx, character=char, base_args=[spell_name])
         args = argparse(args)
 
         if not args.last("i", type_=bool):
             try:
-                spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.name in char.spellbook)
+                spell = await select_spell_full(
+                    ctx, spell_name, list_filter=lambda s: s.name in char.spellbook and s.rulesVersion in [version, ""]
+                )
             except NoSelectionElements:
                 return await ctx.send(
                     "No matching spells found. Make sure this spell is in your "
                     f"`{ctx.prefix}spellbook`, or cast with the `-i` argument to ignore restrictions!"
                 )
         else:
-            spell = await select_spell_full(ctx, spell_name)
+            spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.rulesVersion in [version, ""])
 
         caster, targets, combat = await targetutils.maybe_combat(ctx, char, args)
         result = await actionutils.cast_spell(spell, ctx, caster, targets, args, combat=combat)

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -16,7 +16,7 @@ from cogs5e.models.sheet.attack import Attack
 from cogs5e.utils import actionutils, checkutils, gameutils, targetutils
 from cogs5e.utils.help_constants import *
 from cogsmisc.stats import Stats
-from gamedata.lookuputils import select_monster_full, select_spell_full
+from gamedata.lookuputils import get_lookup_version, select_monster_full, select_spell_full
 from utils import checks, constants
 from utils.argparser import argparse
 from utils.functions import (
@@ -1399,16 +1399,22 @@ class InitTracker(commands.Cog):
             args = await helpers.parse_snippets(args, ctx, statblock=combatant, base_args=[combatant.name, spell_name])
         args = argparse(args)
 
+        version = await get_lookup_version(ctx)
+
         if not args.last("i", type_=bool):
             try:
-                spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.name in combatant.spellbook)
+                spell = await select_spell_full(
+                    ctx,
+                    spell_name,
+                    list_filter=lambda s: s.name in combatant.spellbook and s.rulesVersion in [version, ""],
+                )
             except NoSelectionElements:
                 return await ctx.send(
                     f"No matching spells found in {combatant.name}'s spellbook. Cast again "
                     "with the `-i` argument to ignore restrictions!"
                 )
         else:
-            spell = await select_spell_full(ctx, spell_name)
+            spell = await select_spell_full(ctx, spell_name, list_filter=lambda s: s.rulesVersion in [version, ""])
 
         targets = await targetutils.definitely_combat(ctx, combat, args, allow_groups=True)
         result = await actionutils.cast_spell(spell, ctx, combatant, targets, args, combat=combat)

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -93,7 +93,7 @@ class Lookup(commands.Cog):
     async def rule(self, ctx, *, name: str = None):
         """Looks up a rule."""
         if name:
-            version = name.split()[-1] if name.split()[-1] in VALID_VERSIONS else get_lookup_version(ctx)
+            version = name.split()[-1] if name.split()[-1] in VALID_VERSIONS else await get_lookup_version(ctx)
             name = name.replace(version, "").strip() if name.split()[-1] in VALID_VERSIONS else name
         else:
             version = await get_lookup_version(ctx)
@@ -958,8 +958,16 @@ class Lookup(commands.Cog):
     @commands.command()
     async def spell(self, ctx, *, name: str):
         """Looks up a spell."""
+        if name:
+            version = name.split()[-1] if name.split()[-1] in VALID_VERSIONS else await get_lookup_version(ctx)
+            name = name.replace(version, "").strip() if name.split()[-1] in VALID_VERSIONS else name
+        else:
+            version = await get_lookup_version(ctx)
+
         choices = await lookuputils.get_spell_choices(ctx)
-        spell = await lookuputils.search_entities(ctx, {"spell": choices}, name)
+        spell = await lookuputils.search_entities(
+            ctx, {"spell": choices}, name, list_filter=lambda s: s.rulesVersion in [version, ""]
+        )
 
         return await self._spell(ctx, spell)
 

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -136,7 +136,7 @@ class Lookup(commands.Cog):
     async def slash_rule_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         choices = []
         if "version" not in inter.filled_options:
-            version = await get_lookup_version(ctx)
+            version = await get_lookup_version(inter)
         else:
             version = inter.filled_options["version"]
 

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -93,10 +93,10 @@ class Lookup(commands.Cog):
     async def rule(self, ctx, *, name: str = None):
         """Looks up a rule."""
         if name:
-            version = name.split()[-1] if name.split()[-1] in VALID_VERSIONS else "2024"
+            version = name.split()[-1] if name.split()[-1] in VALID_VERSIONS else get_lookup_version(ctx)
             name = name.replace(version, "").strip() if name.split()[-1] in VALID_VERSIONS else name
         else:
-            version = "2024"
+            version = await get_lookup_version(ctx)
 
         if name is None:
             return await self._show_reference_options(ctx)
@@ -123,7 +123,7 @@ class Lookup(commands.Cog):
         ),
     ):
         if version not in VALID_VERSIONS:
-            version = "2024"
+            version = get_lookup_version(inter)
 
         if isinstance(name, list):
             if not name:
@@ -136,7 +136,7 @@ class Lookup(commands.Cog):
     async def slash_rule_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
         choices = []
         if "version" not in inter.filled_options:
-            version = "2024"
+            version = await get_lookup_version(ctx)
         else:
             version = inter.filled_options["version"]
 

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -124,7 +124,7 @@ async def get_lookup_version(ctx) -> str:
     if serv_settings:
         version = serv_settings.version
 
-    if serv_settings and serv_settings.allow_character_override:
+    if serv_settings and serv_settings.allow_character_override or not ctx.guild:
         try:
             if hasattr(ctx, "get_character"):
                 character: Character = await ctx.get_character()

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -293,18 +293,14 @@ def lookup_converter(entity_type: str) -> Callable:
             raise ValueError("That spell doesn't exist")
         return result
 
-    def rule_converter(_: disnake.ApplicationCommandInteraction, arg: str):
+    def rule_converter(inter: disnake.ApplicationCommandInteraction, arg: str):
         choices = []
-        for actiontype in (a for a in compendium.rule_references if a.get("version") == "2024" or "version" not in a):
-            choices.extend(actiontype["items"])
-        result: gamedata.monster = search(choices, arg, lambda e: e["fullName"])[0]
-        if result is None:
-            raise ValueError("That rule doesn't exist")
-        return result
+        if "version" not in inter.filled_options:
+            version = "2024"
+        else:
+            version = inter.filled_options["version"]
 
-    def rule2014_converter(_: disnake.ApplicationCommandInteraction, arg: str):
-        choices = []
-        for actiontype in (a for a in compendium.rule_references if a.get("version") == "2014" or "version" not in a):
+        for actiontype in (a for a in compendium.rule_references if a.get("version") == version or "version" not in a):
             choices.extend(actiontype["items"])
         result: gamedata.monster = search(choices, arg, lambda e: e["fullName"])[0]
         if result is None:
@@ -376,8 +372,6 @@ def lookup_converter(entity_type: str) -> Callable:
             return subclass_converter
         case "classfeat":
             return classfeat_converter
-        case "rule2014":
-            return rule2014_converter
         case _:
             raise ValueError("That converter does not exist")
 
@@ -506,37 +500,11 @@ async def get_spell_choices(ctx, homebrew=True):
     :param ctx: The context.
     :param homebrew: Whether to include homebrew entities.
     """
-    version = await get_lookup_version(ctx)
+
+    compendium_list = compendium.spells
 
     if not homebrew:
-        if version == "2024":
-            the_spells = [spell for spell in compendium.spells if spell.rulesVersion in ["2024", ""]]
-
-            spell_dict = {}
-            for spell in the_spells:
-                if spell.name not in spell_dict or spell.rulesVersion == "2024":
-                    spell_dict[spell.name] = spell
-
-            return list(spell_dict.values())
-        else:
-            the_spells = [spell for spell in compendium.spells if spell.rulesVersion != "2024"]
-
-            return the_spells
-
-    # compendium_list = compendium.spells
-    if version == "2024":
-        the_spells = [spell for spell in compendium.spells if spell.rulesVersion in ["2024", ""]]
-
-        spell_dict = {}
-        for spell in the_spells:
-            if spell.name not in spell_dict or spell.rulesVersion == "2024":
-                spell_dict[spell.name] = spell
-
-        compendium_list = list(spell_dict.values())
-    else:
-        the_spells = [spell for spell in compendium.spells if spell.rulesVersion != "2024"]
-
-        compendium_list = the_spells
+        return compendium_list
 
     # personal active tome
     try:

--- a/gamedata/shared.py
+++ b/gamedata/shared.py
@@ -138,6 +138,7 @@ class CachedSourced(Sourced):
             url=kwargs.get("url"),
             is_free=kwargs.get("is_free"),
             is_legacy=kwargs.get("is_legacy"),
+            rulesVersion=kwargs.get("rulesVersion"),
         )
 
     @classmethod
@@ -152,6 +153,7 @@ class CachedSourced(Sourced):
             entity_id=d["entity_id"],
             is_free=d["is_free"],
             is_legacy=d["is_legacy"],
+            rulesVersion=d["rulesVersion"],
         )
 
     def to_dict(self):
@@ -165,4 +167,5 @@ class CachedSourced(Sourced):
             "entity_id": self.entity_id,
             "is_free": self.is_free,
             "is_legacy": self.is_legacy,
+            "rulesVersion": self.rulesVersion,
         }


### PR DESCRIPTION
### Summary
- Update `/spell` to be more version agnostic 
- Update `!spell` to respect server version and user input if specified
- Setup lambda functions in `!cast`, `!mcast`, `!rcast`, etc to respect lookup version
- Modify `/rule` lookup to have a version parameter and the converter function to swap back and forth. 

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
