### PR TITLE
Allow `list_display_override` to be an annotated string

### DIFF
--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -210,22 +210,20 @@ class AttackList:
     @property
     def other_attacks(self):
         """Returns an AttackList of attacks that do not fall into the other action categories."""
-        return AttackList(
-            [
-                a
-                for a in self.attacks
-                if a.activation_type
-                not in (
-                    enums.ActivationType.ACTION,
-                    enums.ActivationType.BONUS_ACTION,
-                    enums.ActivationType.REACTION,
-                    enums.ActivationType.LEGENDARY,
-                    enums.ActivationType.MYTHIC,
-                    enums.ActivationType.LAIR,
-                    None,
-                )
-            ]
-        )
+        return AttackList([
+            a
+            for a in self.attacks
+            if a.activation_type
+            not in (
+                enums.ActivationType.ACTION,
+                enums.ActivationType.BONUS_ACTION,
+                enums.ActivationType.REACTION,
+                enums.ActivationType.LEGENDARY,
+                enums.ActivationType.MYTHIC,
+                enums.ActivationType.LAIR,
+                None,
+            )
+        ])
 
     # list compat
     def append(self, attack):

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -142,7 +142,7 @@ class Attack:
         )
 
     def build_str(self, caster):
-        return f"**{self.name}**: {self.list_display_override or self.automation.build_str(caster)}"
+        return f"**{self.name}**: {caster.evaluate_annostr(self.list_display_override) if self.list_display_override else self.automation.build_str(caster)}"
 
     def __str__(self):
         return f"**{self.name}**: {str(self.automation)}"
@@ -210,20 +210,22 @@ class AttackList:
     @property
     def other_attacks(self):
         """Returns an AttackList of attacks that do not fall into the other action categories."""
-        return AttackList([
-            a
-            for a in self.attacks
-            if a.activation_type
-            not in (
-                enums.ActivationType.ACTION,
-                enums.ActivationType.BONUS_ACTION,
-                enums.ActivationType.REACTION,
-                enums.ActivationType.LEGENDARY,
-                enums.ActivationType.MYTHIC,
-                enums.ActivationType.LAIR,
-                None,
-            )
-        ])
+        return AttackList(
+            [
+                a
+                for a in self.attacks
+                if a.activation_type
+                not in (
+                    enums.ActivationType.ACTION,
+                    enums.ActivationType.BONUS_ACTION,
+                    enums.ActivationType.REACTION,
+                    enums.ActivationType.LEGENDARY,
+                    enums.ActivationType.MYTHIC,
+                    enums.ActivationType.LAIR,
+                    None,
+                )
+            ]
+        )
 
     # list compat
     def append(self, attack):

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -1477,7 +1477,7 @@ Custom Attack Structure
         thumb?: string;
         extra_crit_damage?: string;
         activation_type?: number;
-        list_display_override?: AnnotatedString
+        list_display_override?: AnnotatedString;
     }
 
 In order to use Automation, it needs to be contained within a custom attack or spell. We recommend building these on
@@ -1533,7 +1533,7 @@ Hand-written custom attacks may be written in JSON or YAML and imported using th
 
     ...attribute:: list_display_override
         
-        *optional* - The display text to display in the action list (such as ``!a list`` )
+        *optional* - The display text to display in the action list (such as ``!a list`` ).
 
         .. code-block:: text
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -1477,6 +1477,7 @@ Custom Attack Structure
         thumb?: string;
         extra_crit_damage?: string;
         activation_type?: number;
+        list_display_override?: AnnotatedString
     }
 
 In order to use Automation, it needs to be contained within a custom attack or spell. We recommend building these on
@@ -1529,6 +1530,10 @@ Hand-written custom attacks may be written in JSON or YAML and imported using th
     .. attribute:: activation_type
 
         *optional* - What action type to display this attack as in an action list (such as ``!a list``).
+
+    ...attribute:: list_display_override
+        
+        *optional* - The display text to display in the action list (such as ``!a list`` )
 
         .. code-block:: text
 


### PR DESCRIPTION
### Summary
Allow `list_display_override` to be an annotated string

Should be paired with avrae/automation-common#12

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
