### PR TITLE
fix: mapping datadog trace environment to live

### DIFF
--- a/utils/datadog.py
+++ b/utils/datadog.py
@@ -27,7 +27,7 @@ class JSONFormatter(logging.Formatter):
 
 
 def do_patches():
-    ddtrace.config.env = config.ENVIRONMENT
+    ddtrace.config.env = "live" if config.ENVIRONMENT in ("production", "nightly") else config.ENVIRONMENT
     ddtrace.config.service = config.DD_SERVICE
     ddtrace.config.version = config.GIT_COMMIT_SHA
     ddtrace.tracer.configure(


### PR DESCRIPTION
### Summary
Traces were being sent with 'production' environment instead of 'live', that's because the datadog patches were using the ENVIRONMENT variable which overrides the dd_env variable configured at the ECS task definition.

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
