### PR TITLE
`sb` fix

### DIFF
--- a/cogs5e/gametrack.py
+++ b/cogs5e/gametrack.py
@@ -410,8 +410,9 @@ class GameTrack(commands.Cog):
         flag_show_prepared_help = False
         flag_show_prepared_underline_help = False
 
+        version = await get_lookup_version(ctx)
         spells_known = collections.defaultdict(lambda: [])
-        choices = await get_spell_choices(ctx)
+        choices = list(filter(lambda s: s.rulesVersion == version, await get_spell_choices(ctx)))
         for sb_spell in character.spellbook.spells:
             if not (sb_spell.prepared or show_unprepared):
                 flag_show_prepared_help = True


### PR DESCRIPTION
### Summary
Put version checking in `sb`

### Changelog Entry
Fix an issue where `sb` would pull a 2014 and 2024 version of a spell, causing it to think it was from multiple sources

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
