### PR TITLE
Add empty rulesVersion field to homebrew spell data

### DIFF
--- a/gamedata/spell.py
+++ b/gamedata/spell.py
@@ -89,6 +89,7 @@ class Spell(AutomatibleMixin, DescribableMixin, Sourced):
         data["components"] = parse_homebrew_components(data["components"])
         data["range_"] = data.pop("range")
         data["automation"] = data.get("automation")
+        data["rulesVersion"] = ""
         return cls(homebrew=True, source=source, **data).initialize_automation(data)
 
     def get_school(self):


### PR DESCRIPTION
### Summary
Update homebrew loading to set `rulesVersion` to `""` instead of `None`


### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
