### PR TITLE
use dot notation for class attributes

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -294,10 +294,10 @@ class BeyondSheetParser(SheetLoaderABC):
                     spells[result.name] = spell_info
 
                 elif spell_prepared:  # prioritize prepared spells
-                    if spells[result.name]["prepared"]:
-                        spells[result.name] = max(result.name, spells[result.name], key=lambda x: x["dc"])
+                    if spells[result.name].prepared:
+                        spells[result.name] = max(result.name, spells[result.name], key=lambda x: x.dc)
 
-                    if not spells[result.name]["prepared"]:
+                    if not spells[result.name].prepared:
                         spells[result.name] = spell_info
 
             else:


### PR DESCRIPTION
correction for spell preparedness

### Summary
Dot notation should be used for class attributes when sorting spells by preparedness

### Changelog Entry
fingers crossed this does it

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
