### PR TITLE
Fix for AVR-1026

### DIFF
--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -882,6 +882,14 @@ class SheetManager(commands.Cog):
                     version = serv_settings.version
                 else:
                     version = "2024"
+            elif version not in ["2014","2024"]:
+                await ctx.send(
+                        f"Character-specific version override is value of {version} is not valid. Character will be imported using default version."
+                    )
+                if serv_settings:
+                    version = serv_settings.version
+                else:
+                    version = "2024"
             else:
                 # version was passed in, check allow_character_override
                 if serv_settings and version != serv_settings.version and not serv_settings.allow_character_override:
@@ -893,7 +901,7 @@ class SheetManager(commands.Cog):
                     version = version
         except:
             # We will get here when done in DM's
-            version = version if version else "2024"
+            version = version if version and version in ["2014","2024"] else "2024"
 
         url = await self._check_url(ctx, url)  # check for < >
         # Sheets in order: DDB, Dicecloud, Gsheet

--- a/cogs5e/sheetManager.py
+++ b/cogs5e/sheetManager.py
@@ -884,7 +884,7 @@ class SheetManager(commands.Cog):
                     version = "2024"
             elif version not in ["2014","2024"]:
                 await ctx.send(
-                        f"Character-specific version override is value of {version} is not valid. Character will be imported using default version."
+                        f"Character-specific version override {version} is not valid. Character will be imported using default version.  You can amend this via `{ctx.prefix}csettings` "
                     )
                 if serv_settings:
                     version = serv_settings.version


### PR DESCRIPTION
Validate version against "2014","2024" and apply default logic if it is not valid as if not supplied

### Summary
Validate version against "2014","2024" and apply default logic if it is not valid as if not supplied

Send message to user that version supplied was invalid

Similar logic for when in DMs but with no message

### Changelog Entry
Fix for AVR-1026 - validate version on import

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
