### PR TITLE
Add readonly mode to server settings UI and update permissions check

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -1159,11 +1159,16 @@ class Customization(commands.Cog):
 
     @commands.command(aliases=["servsettings"])
     @commands.guild_only()
-    @checks.admin_or_permissions(manage_guild=True)
     async def server_settings(self, ctx):
-        """Opens the server settings menu. You must have *Manage Server* permissions to use this command."""
+        """Opens the server settings menu. You must have *Manage Server* permissions to edit any settings here"""
         guild_settings = await ctx.get_server_settings()
-        settings_ui = ui.ServerSettingsUI.new(ctx.bot, owner=ctx.author, settings=guild_settings, guild=ctx.guild)
+        settings_ui = ui.ServerSettingsUI.new(
+            ctx.bot,
+            owner=ctx.author,
+            settings=guild_settings,
+            guild=ctx.guild,
+            readonly=not ctx.author.guild_permissions.manage_guild,
+        )
         await settings_ui.send_to(ctx)
 
     # temporary commands to aid testers with lack of dashboard


### PR DESCRIPTION
### Summary
Setup a readonly version of `!servsettings` if the user can't manage the guild. 

Resolves #AFR-1069

Dependent on #2151 to fix linting issue


### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
