### PR TITLE
Fix spell preparation logic to properly compare DC values.  Thanks @Rev

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -291,7 +291,8 @@ class BeyondSheetParser(SheetLoaderABC):
 
                 elif spell_prepared:  # prioritize prepared spells
                     if spells[result.name].prepared:
-                        spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.dc)
+                        if result.dc and spell_info.dc:
+                            spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.dc)
 
                     if not spells[result.name].prepared:
                         spells[result.name] = spell_info

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -293,9 +293,9 @@ class BeyondSheetParser(SheetLoaderABC):
                     if spells[result.name].prepared:
                         if result.dc and spell_info.dc:
                             spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.dc)
-                        if result.sab and spell_info.sab:
+                        elif result.sab and spell_info.sab:
                             spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.sab)
-                        if result.mod and spell_info.mod:
+                        elif result.mod and spell_info.mod:
                             spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.mod)
 
                     if not spells[result.name].prepared:

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -293,6 +293,10 @@ class BeyondSheetParser(SheetLoaderABC):
                     if spells[result.name].prepared:
                         if result.dc and spell_info.dc:
                             spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.dc)
+                        if result.sab and spell_info.sab:
+                            spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.sab)
+                        if result.mod and spell_info.mod:
+                            spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.mod)
 
                     if not spells[result.name].prepared:
                         spells[result.name] = spell_info


### PR DESCRIPTION
### Summary
Previously, the logic did not account for cases where the DC values were missing when comparing and prioritizing prepared spells. This update ensures that DC comparisons are only made when both values are present, preventing potential errors.

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
