### PR TITLE
Have the readonly check use `admin_or_permissions` rather than just a permission lookup

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -289,7 +289,6 @@ class BeyondSheetParser(SheetLoaderABC):
                 if result.name not in spells:
                     spells[result.name] = spell_info
 
-
                 elif spell_prepared:  # prioritize prepared spells
                     if spells[result.name].prepared:
                         if spell_info.dc and spells[result.name].dc:

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -1162,12 +1162,17 @@ class Customization(commands.Cog):
     async def server_settings(self, ctx):
         """Opens the server settings menu. You must have *Manage Server* permissions to edit any settings here"""
         guild_settings = await ctx.get_server_settings()
+        try:
+            readonly = not await checks.admin_or_permissions(manage_guild=True).predicate(ctx)
+        except:
+            readonly = True
+
         settings_ui = ui.ServerSettingsUI.new(
             ctx.bot,
             owner=ctx.author,
             settings=guild_settings,
             guild=ctx.guild,
-            readonly=not ctx.author.guild_permissions.manage_guild,
+            readonly=readonly,
         )
         await settings_ui.send_to(ctx)
 

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -1164,7 +1164,7 @@ class Customization(commands.Cog):
         guild_settings = await ctx.get_server_settings()
         try:
             readonly = not await checks.admin_or_permissions(manage_guild=True).predicate(ctx)
-        except:
+        except commands.CheckFailure:
             readonly = True
 
         settings_ui = ui.ServerSettingsUI.new(


### PR DESCRIPTION
### Summary
Improve server settings menu readonly logic to handle exceptions, and do the old `admin_or_permissions` check rather than just permissions

Run black and submite `beyond.py` to make Lint leave me alone. 

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
