### PR TITLE
Add caster to list_display_override

### DIFF
--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -4,6 +4,7 @@ from typing import Callable, List, Optional, TYPE_CHECKING, TypeVar
 import disnake
 
 import aliasing.evaluators
+import aliasing.api.statblock
 import cogs5e.models.character
 from cogs5e.models.sheet.attack import AttackList
 from cogs5e.models.sheet.base import BaseStats, Levels, Saves, Skill, Skills
@@ -470,6 +471,7 @@ class Combatant(BaseCombatant, StatBlock):
         :returns str - the string with annotations evaluated
         """
         evaluator = aliasing.evaluators.AutomationEvaluator.with_caster(self)
+        evaluator.builtins["caster"] = aliasing.api.statblock.AliasStatBlock(self)
 
         try:
             return evaluator.transformed_str(varstr)

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -5,6 +5,7 @@ import cachetools
 from disnake.ext.commands import NoPrivateMessage
 
 import aliasing.evaluators
+import aliasing.api.statblock
 from cogs5e.models.ddbsync import DDBSheetSync
 from cogs5e.models.dicecloud.integration import DicecloudIntegration
 from cogs5e.models.embeds import EmbedWithCharacter
@@ -344,6 +345,7 @@ class Character(StatBlock):
         :returns str - the string with annotations evaluated
         """
         evaluator = aliasing.evaluators.AutomationEvaluator.with_character(self)
+        evaluator.builtins["caster"] = aliasing.api.statblock.AliasStatBlock(self)
 
         try:
             return evaluator.transformed_str(varstr)

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -289,7 +289,6 @@ class BeyondSheetParser(SheetLoaderABC):
                 if result.name not in spells:
                     spells[result.name] = spell_info
 
-
                 elif spell_prepared:  # prioritize prepared spells
                     if spells[result.name].prepared:
                         if spell_info.dc and spells[result.name].dc:

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -1531,7 +1531,7 @@ Hand-written custom attacks may be written in JSON or YAML and imported using th
         
         *optional* - The display text to display in the action list (such as ``!a list`` ).
 
-        ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock)`
+        ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock)` is available in this attribute.
 
     .. attribute:: activation_type
 

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -1531,6 +1531,8 @@ Hand-written custom attacks may be written in JSON or YAML and imported using th
         
         *optional* - The display text to display in the action list (such as ``!a list`` ).
 
+        ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock)`
+
     .. attribute:: activation_type
 
         *optional* - What action type to display this attack as in an action list (such as ``!a list``).


### PR DESCRIPTION
### Summary
Adds caster to list_display_override for characters.

Motivation: Allow safe handling of retrieving character level.

This does not affect automation because AutomationContext overrides the caster variable at runtime.

![image](https://github.com/user-attachments/assets/85924acd-0dc1-44db-bbe7-ec233bcae989)


### Changelog Entry

- `caster` (of type `AliasStatBlock`) is now available in list display override.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
