### PR TITLE
Improve Local Test Docs

### DIFF
--- a/cogs5e/dice/inline.py
+++ b/cogs5e/dice/inline.py
@@ -16,6 +16,7 @@ INLINE_ROLLING_EMOJI = "\U0001f3b2"  # :game_die:
 INLINE_ROLLING_RE = re.compile(r"\[\[(.+?]?)]]")
 _sentinel = object()
 
+
 class InlineRoller:
     def __init__(self, bot):
         self.bot = bot

--- a/cogs5e/dice/inline.py
+++ b/cogs5e/dice/inline.py
@@ -16,9 +16,6 @@ INLINE_ROLLING_EMOJI = "\U0001f3b2"  # :game_die:
 INLINE_ROLLING_RE = re.compile(r"\[\[(.+?]?)]]")
 _sentinel = object()
 
-import logging
-log = logging.getLogger()
-
 class InlineRoller:
     def __init__(self, bot):
         self.bot = bot

--- a/cogs5e/dice/inline.py
+++ b/cogs5e/dice/inline.py
@@ -16,6 +16,8 @@ INLINE_ROLLING_EMOJI = "\U0001f3b2"  # :game_die:
 INLINE_ROLLING_RE = re.compile(r"\[\[(.+?]?)]]")
 _sentinel = object()
 
+import logging
+log = logging.getLogger()
 
 class InlineRoller:
     def __init__(self, bot):

--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -289,7 +289,6 @@ class BeyondSheetParser(SheetLoaderABC):
                 if result.name not in spells:
                     spells[result.name] = spell_info
 
-
                 elif spell_prepared:  # prioritize prepared spells
                     if spells[result.name].prepared:
                         if spell_info.dc and spells[result.name].dc:

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -894,7 +894,7 @@ class Customization(commands.Cog):
             if cvar is None:
                 return await ctx.send("This cvar is not defined.")
             return await send_long_code_text(
-                ctx, outside_codeblock=f"**{name}**:".replace("_", "\_"), inside_codeblock=cvar
+                ctx, outside_codeblock=f"**{name}**:".replace("_", r"\_"), inside_codeblock=cvar
             )
 
         helpers.set_cvar(character, name, value)
@@ -940,7 +940,7 @@ class Customization(commands.Cog):
         character: Character = await ctx.get_character()
         await ctx.send(
             "{}'s character variables:\n{}".format(character.name, ", ".join(sorted(character.cvars.keys()))).replace(
-                "_", "\_"
+                "_", r"\_"
             )
         )
 

--- a/cogsmisc/publicity.py
+++ b/cogsmisc/publicity.py
@@ -25,7 +25,7 @@ class Publicity(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        if bot.is_cluster_0:
+        if bot.is_cluster_0 and config.DBL_TOKEN is not None: # dont run without a DBL token
             self.bot.loop.create_task(self.background_update())
 
     async def update_server_count(self):

--- a/cogsmisc/publicity.py
+++ b/cogsmisc/publicity.py
@@ -25,7 +25,7 @@ class Publicity(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        if bot.is_cluster_0 and config.DBL_TOKEN is not None: # dont run without a DBL token
+        if bot.is_cluster_0 and config.DBL_TOKEN is not None:  # dont run without a DBL token
             self.bot.loop.create_task(self.background_update())
 
     async def update_server_count(self):

--- a/cogsmisc/stats.py
+++ b/cogsmisc/stats.py
@@ -26,7 +26,8 @@ class Stats(commands.Cog):
         self.bot = bot
         self.start_time = time.monotonic()
         self.command_stats = Counter()
-        self.bot.loop.create_task(self.scheduled_update())
+        if config.ENVIRONMENT != "development":  # do not run in tests
+            self.bot.loop.create_task(self.scheduled_update())
 
     # ===== listeners =====
     @commands.Cog.listener()

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   tests:
     image: avrae-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   bot:
     image: avrae

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,7 +55,7 @@ Running tests with docker is very simple. Once you have docker set-up as shown i
 docker compose down && docker compose -f docker-compose.ci.yml up -d --build && docker logs -f avrae-tests-1
 ```
 
-This will shut down your current docker (resetting the database), run the tests, and open the test logs.
+This will shut down your current Avrae instance (resetting the database), run the tests, and open the test logs.
 
 ## Writing Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,6 +47,16 @@ of pytest marks are provided to allow filtering the tests:
 Use the `-m` flag to select the marks to run. For example, to select only the non-gamedata tests, you could
 use `pytest -m "not gamedata"`.
 
+### Running Tests (Docker)
+
+Running tests with docker is very simple. Once you have docker set-up as shown in the README, you can run the following:
+
+```shell
+docker compose down && docker compose -f docker-compose.ci.yml up -d --build && docker logs -f avrae-tests-1
+```
+
+This will shut down your current docker (resetting the database), run the tests, and open the test logs.
+
 ## Writing Tests
 
 Pytest will automatically discover test files in the `tests/` directory, as long as the file is named in the pattern of

--- a/tests/unit/quickstartTutorial_test.py
+++ b/tests/unit/quickstartTutorial_test.py
@@ -154,7 +154,7 @@ async def test_quickstarttutorial_actions(
         mock_transition.assert_called_once_with(ctx_mock, state_map_mock)
 
 
-def test_roll():
+async def test_roll():
     roll_result = d20.roll("1d20")
     assert isinstance(roll_result, d20.RollResult)
     assert 0 < roll_result.total < 21

--- a/utils/argparser.py
+++ b/utils/argparser.py
@@ -154,7 +154,7 @@ class ParsedArguments:
     # Have to escape the _ in the type_ parameter for docs
     # noinspection PyIncorrectDocstring
     def get(self, arg, default=None, type_=str, ephem=False):
-        """
+        r"""
         Gets a list of all values of an argument.
 
         :param str arg: The name of the arg to get.
@@ -177,7 +177,7 @@ class ParsedArguments:
     # Have to escape the _ in the type_ parameter for docs
     # noinspection PyIncorrectDocstring
     def last(self, arg, default=None, type_=str, ephem=False):
-        """
+        r"""
         Gets the last value of an arg.
 
         :param str arg: The name of the arg to get.

--- a/utils/redisIO.py
+++ b/utils/redisIO.py
@@ -142,7 +142,7 @@ class RedisIO:
 
     # ==== misc ====
     async def close(self):
-        await self._db.close()
+        await self._db.aclose() # changed to aclose after close deprecated
 
 
 class _PubSubMessageBase(abc.ABC):

--- a/utils/redisIO.py
+++ b/utils/redisIO.py
@@ -142,7 +142,7 @@ class RedisIO:
 
     # ==== misc ====
     async def close(self):
-        await self._db.aclose() # changed to aclose after close deprecated
+        await self._db.aclose()  # changed to aclose after close deprecated
 
 
 class _PubSubMessageBase(abc.ABC):


### PR DESCRIPTION
### Summary

- Cleans up a few warnings in the tests
- Adds documentation for running tests on docker (including `docker compose down` beforehand to prevent intermittent dice_test failures.
- removes version tag from docker compose (deprecated, shows a warning when it is present)
- adds `r` to some raw-format strings to reduce test warnings
- gate Publicity and Stat loops from running without a token or production env, respectively
- **Change redis close mechanic** from .close to .aclose (showed as deprecated in test warnings) (only important change to review)

### Changelog Entry
none (not user facing)

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
