### PR TITLE
Flag custom automation

### DIFF
--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -51,7 +51,6 @@ async def run_attack(
     verb = attack.verb or "attacks with"
 
     if args.last("title") is not None:
-        ctx.footer_queue(f"attack: {attack.name}")
         embed.title = args.last("title").replace("[name]", name).replace("[aname]", attack_name).replace("[verb]", verb)
     else:
         embed.title = f"{name} {verb} {attack_name}!"
@@ -65,6 +64,7 @@ async def run_attack(
     }
     args.update_nx(arg_defaults)
 
+    if args.get("f"): ctx.footer_queue(f"attack: {attack.name}")
     result = await run_automation(
         ctx, embed, args, caster, attack.automation, targets, combat, **attack.__run_automation_kwargs__
     )

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -64,7 +64,7 @@ async def run_attack(
     }
     args.update_nx(arg_defaults)
 
-    if args.get("f"): ctx.footer_queue(f"attack: {attack.name}")
+    ctx.footer_queue(f"Action: {attack.name}")
     result = await run_automation(
         ctx, embed, args, caster, attack.automation, targets, combat, **attack.__run_automation_kwargs__
     )

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -111,6 +111,7 @@ async def run_action(
         embed.title = f"{name} uses {action.name}!"
 
     if action.automation:
+        ctx.footer_queue(f"automation: {action.name}")
         result = await run_automation(ctx, embed, args, caster, action.automation, targets, combat)
     else:
         # else, show action description and note that it can't be automated

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -51,6 +51,7 @@ async def run_attack(
     verb = attack.verb or "attacks with"
 
     if args.last("title") is not None:
+        ctx.footer_queue(f"attack: {attack.name}")
         embed.title = args.last("title").replace("[name]", name).replace("[aname]", attack_name).replace("[verb]", verb)
     else:
         embed.title = f"{name} {verb} {attack_name}!"
@@ -111,7 +112,6 @@ async def run_action(
         embed.title = f"{name} uses {action.name}!"
 
     if action.automation:
-        ctx.footer_queue(f"automation: {action.name}")
         result = await run_automation(ctx, embed, args, caster, action.automation, targets, combat)
     else:
         # else, show action description and note that it can't be automated


### PR DESCRIPTION
Add action name to footer when automation is used.

### Summary
To identify when custom automation has been used rather than built-in commands.

### Changelog Entry
Simply an extra line at the top of the footer generated for automation.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
