### PR TITLE
feat(automation): Effects with specific saving throw bonuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Tests can either be run using Docker Compose, or manually.
 
 ```bash
 docker-compose -f docker-compose.ci.yml -p avrae up -d --build
-docker logs -f avrae_tests_1
+docker logs -f avrae-tests-1
 ```
 
 Once tests complete, it is recommended to clean up the containers with `docker-compose down`.

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -273,6 +273,15 @@ class SimpleCombatant(AliasStatBlock):
             raise InvalidSaveType
 
         sb = self._combatant.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+        # specific save bonus
+        stat = ability[:3].lower()
+        specific_save_bonus = self._combatant.active_effects(
+            mapper=lambda effect: effect.effects.specific_save_bonus,
+            # only chose the bonus(es) that applies to the current stat (str, dex, con, int, wis, cha)
+            reducer=lambda effects: [{k: v for k, v in x.items() if k == stat}.get(stat) for x in effects if stat in x],
+            default=list(),
+        )
+        sb += specific_save_bonus
         saveroll = save.d20(base_adv=adv)
         if sb:
             saveroll = f'{saveroll}+{"+".join(sb)}'

--- a/aliasing/api/validators.py
+++ b/aliasing/api/validators.py
@@ -37,7 +37,6 @@ class PassiveEffects(BaseModel):
     check_adv: Optional[Set[str]]
     check_dis: Optional[Set[str]]
     dc_bonus: Optional[int]
-    # TODO: Specific save bonuses?. Unsure of correct data type?
     specific_save_bonus: Optional[dict[str, str]]
 
     @validator("save_adv", "save_dis")

--- a/aliasing/api/validators.py
+++ b/aliasing/api/validators.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, conint, constr, validator
 import cogs5e.initiative as init
 from cogs5e.models.errors import InvalidArgument
 from utils import enums
+from utils.constants import STAT_ABBREVIATIONS
 
 str255 = constr(max_length=255)
 
@@ -36,6 +37,8 @@ class PassiveEffects(BaseModel):
     check_adv: Optional[Set[str]]
     check_dis: Optional[Set[str]]
     dc_bonus: Optional[int]
+    # TODO: Specific save bonuses?. Unsure of correct data type?
+    specific_save_bonus: Optional[dict[str, str]]
 
     @validator("save_adv", "save_dis")
     def check_valid_save_keys(cls, value):
@@ -50,6 +53,15 @@ class PassiveEffects(BaseModel):
             return init.effects.passive.resolve_check_advs(value)
         except InvalidArgument as e:
             raise ValueError(str(e)) from e
+
+    @validator("specific_save_bonus")
+    def check_valid_save_bonus_keys(cls, value):
+        if not isinstance(value, dict):
+            raise ValueError("Specific Save Bonus must be a dictionary.")
+        for val in value.keys():
+            if val not in STAT_ABBREVIATIONS:
+                raise ValueError(f"{val} is not an accepted stat abbreviation for a save bonus.")
+        return value
 
 
 class AttackInteraction(BaseModel):

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -982,8 +982,7 @@ class InitTracker(commands.Cog):
         `-vuln <damage type>` - Gives the combatant vulnerability to the given damage type.
         `-neutral <damage type>` - Removes the combatant's immunity, resistance, or vulnerability to the given damage type.
         __Checks/Saves__
-        `-sb <save bonus>` - Adds a bonus to all saving throws.
-        `-ssb <save bonus>|<mod>` - Adds a bonus to a specific save type. For example, `-ssb 3|dex` would add +3 to dexterity saves.
+        `-sb <save bonus>` - Adds a bonus to saving throws. To add to a specific saving throw, you can do `mod|stat` (e.g., `-sb 3|dex` or `-sb 1d4|str`)
         `-sadv/sdis <ability>` - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
         `-dc <dc>` - Adds a bonus to all saving throw DCs.
         `-cb <check bonus>` - Adds a bonus to all ability checks.

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -983,6 +983,7 @@ class InitTracker(commands.Cog):
         `-neutral <damage type>` - Removes the combatant's immunity, resistance, or vulnerability to the given damage type.
         __Checks/Saves__
         `-sb <save bonus>` - Adds a bonus to all saving throws.
+        `-ssb <save bonus>|<mod>` - Adds a bonus to a specific save type. For example, `-ssb 3|dex` would add +3 to dexterity saves.
         `-sadv/sdis <ability>` - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
         `-dc <dc>` - Adds a bonus to all saving throw DCs.
         `-cb <check bonus>` - Adds a bonus to all ability checks.

--- a/cogs5e/initiative/effects/passive.py
+++ b/cogs5e/initiative/effects/passive.py
@@ -197,7 +197,6 @@ class InitPassiveEffect:
     specific_save_bonus: dict[str, str] = _PassiveEffect(
         default=dict(),
         stringifier=_str_save_bonus,
-        # TODO: deserializer/serializer? I think not needed since it's just a dictionary.
     )
     check_bonus: str = _PassiveEffect(stringifier=_abstract_str_attr("Check Bonus"))
     check_adv: Set[str] = _PassiveEffect(
@@ -272,7 +271,6 @@ class InitPassiveEffect:
             check_adv=resolve_check_advs(args.get("cadv")),
             check_dis=resolve_check_advs(args.get("cdis")),
             dc_bonus=sum(args.get("dc", type_=int)),
-            # WIP: Specific Save Bonuses. TODO: Better arg name?
             specific_save_bonus=resolve_specific_save_bonuses(args.get("sb")),
         )
 

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -43,19 +43,17 @@ class LegacyIEffect(Effect):
 
     def to_dict(self):
         out = super().to_dict()
-        out.update(
-            {
-                "name": self.name,
-                "duration": self.duration,
-                "effects": self.effects,
-                "end": self.tick_on_end,
-                "conc": self.concentration,
-                "desc": self.desc,
-                "stacking": self.stacking,
-                "save_as": self.save_as,
-                "parent": self.parent,
-            }
-        )
+        out.update({
+            "name": self.name,
+            "duration": self.duration,
+            "effects": self.effects,
+            "end": self.tick_on_end,
+            "conc": self.concentration,
+            "desc": self.desc,
+            "stacking": self.stacking,
+            "save_as": self.save_as,
+            "parent": self.parent,
+        })
         return out
 
     def run(self, autoctx):
@@ -210,23 +208,21 @@ class IEffect(Effect):
     def to_dict(self):
         out = super().to_dict()
         effects = self.effects.data if self.effects is not None else None
-        out.update(
-            {
-                "name": self.name,
-                "duration": self.duration,
-                "effects": effects,
-                "attacks": [a.to_dict() for a in self.attacks],
-                "buttons": [b.to_dict() for b in self.buttons],
-                "end": self.end_on_turn_end,
-                "conc": self.concentration,
-                "desc": self.desc,
-                "stacking": self.stacking,
-                "save_as": self.save_as,
-                "parent": self.parent,
-                "target_self": self.target_self,
-                "tick_on_caster": self.tick_on_caster,
-            }
-        )
+        out.update({
+            "name": self.name,
+            "duration": self.duration,
+            "effects": effects,
+            "attacks": [a.to_dict() for a in self.attacks],
+            "buttons": [b.to_dict() for b in self.buttons],
+            "end": self.end_on_turn_end,
+            "conc": self.concentration,
+            "desc": self.desc,
+            "stacking": self.stacking,
+            "save_as": self.save_as,
+            "parent": self.parent,
+            "target_self": self.target_self,
+            "tick_on_caster": self.tick_on_caster,
+        })
         return out
 
     def run(self, autoctx):

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -43,17 +43,19 @@ class LegacyIEffect(Effect):
 
     def to_dict(self):
         out = super().to_dict()
-        out.update({
-            "name": self.name,
-            "duration": self.duration,
-            "effects": self.effects,
-            "end": self.tick_on_end,
-            "conc": self.concentration,
-            "desc": self.desc,
-            "stacking": self.stacking,
-            "save_as": self.save_as,
-            "parent": self.parent,
-        })
+        out.update(
+            {
+                "name": self.name,
+                "duration": self.duration,
+                "effects": self.effects,
+                "end": self.tick_on_end,
+                "conc": self.concentration,
+                "desc": self.desc,
+                "stacking": self.stacking,
+                "save_as": self.save_as,
+                "parent": self.parent,
+            }
+        )
         return out
 
     def run(self, autoctx):
@@ -208,21 +210,23 @@ class IEffect(Effect):
     def to_dict(self):
         out = super().to_dict()
         effects = self.effects.data if self.effects is not None else None
-        out.update({
-            "name": self.name,
-            "duration": self.duration,
-            "effects": effects,
-            "attacks": [a.to_dict() for a in self.attacks],
-            "buttons": [b.to_dict() for b in self.buttons],
-            "end": self.end_on_turn_end,
-            "conc": self.concentration,
-            "desc": self.desc,
-            "stacking": self.stacking,
-            "save_as": self.save_as,
-            "parent": self.parent,
-            "target_self": self.target_self,
-            "tick_on_caster": self.tick_on_caster,
-        })
+        out.update(
+            {
+                "name": self.name,
+                "duration": self.duration,
+                "effects": effects,
+                "attacks": [a.to_dict() for a in self.attacks],
+                "buttons": [b.to_dict() for b in self.buttons],
+                "end": self.end_on_turn_end,
+                "conc": self.concentration,
+                "desc": self.desc,
+                "stacking": self.stacking,
+                "save_as": self.save_as,
+                "parent": self.parent,
+                "target_self": self.target_self,
+                "tick_on_caster": self.tick_on_caster,
+            }
+        )
         return out
 
     def run(self, autoctx):
@@ -416,6 +420,7 @@ class _PassiveEffectsWrapper:
             check_adv=self.resolve_check_advs(autoctx, "check_adv"),
             check_dis=self.resolve_check_advs(autoctx, "check_dis"),
             dc_bonus=self.resolve_intexpression(autoctx, "dc_bonus"),
+            specific_save_bonus=self.resolve_specific_save_bonuses(autoctx, "specific_save_bonus"),
         )
 
     def resolve_annotatedstring(self, autoctx, attr: str) -> str | None:
@@ -471,6 +476,15 @@ class _PassiveEffectsWrapper:
         """check_adv: a list of AnnotatedString -> a set of str"""
         data = self.resolve_annotatedstring_list(autoctx, attr)
         return init.effects.passive.resolve_check_advs(data)
+
+    def resolve_specific_save_bonuses(self, autoctx, attr: str) -> dict[str, str]:
+        data = self.data.get(attr)
+        if not data:
+            return dict()
+        for stat, mod in data.items():
+            data[stat] = autoctx.parse_annostr(mod)
+
+        return init.effects.passive.resolve_specific_save_bonuses(data)
 
 
 class _AttackInteractionWrapper:

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -1,5 +1,3 @@
-import logging
-
 import d20
 
 from cogs5e.models.errors import InvalidSaveType

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -418,6 +418,7 @@ PassiveEffects
         check_adv: AnnotatedString[];
         check_dis: AnnotatedString[];
         dc_bonus: IntExpression;
+        specific_save_bonus: Dict[str, AnnotatedString];
     }
 
 Used to specify the passive effects granted by an initiative effect.
@@ -530,6 +531,10 @@ Used to specify the passive effects granted by an initiative effect.
     .. attribute:: dc_bonus
 
         *optional* - A bonus added to the all of the combatant's save DCs while this effect is active.
+
+    .. attribute:: specific_save_bonus
+
+        *optional* - Allows to create bonuses to specific saving throws. Is a dictionary that maps an ability score to a bonus. The bonus value is an `AnnotatedString`_. For example, ``{"str": 3}`` would create an effect that gives +3 to strength saving throws.
 
 .. _attackinteraction:
 
@@ -1109,6 +1114,7 @@ It must be inside a Target effect.
 - ``lastContestAbility`` (:class:`str` or ``None``) The title-case full name of the skill the caster rolled
   (e.g. ``"Animal Handling"``, ``"Arcana"``). ``None`` if no contest was made.
 - ``lastContestDidTie`` (:class:`bool`) Whether a ability contest resulted in a tie.
+
 
 AnnotatedString
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v4.2.1
+#git+https://github.com/avrae/automation-common@v4.2.1
+git+https://github.com/1drturtle/automation-common@main
 
 d20==1.1.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-git+https://github.com/avrae/automation-common@v4.2.0
+git+https://github.com/avrae/automation-common@v4.2.1
+
 d20==1.1.2
 
 # top-level deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # avrae org deps
 git+https://github.com/avrae/draconic@master
-#git+https://github.com/avrae/automation-common@v4.2.1
-git+https://github.com/1drturtle/automation-common@main
+git+https://github.com/avrae/automation-common@v4.2.1
 
 d20==1.1.2
 

--- a/tests/e2e/automation_effects_test.py
+++ b/tests/e2e/automation_effects_test.py
@@ -148,17 +148,15 @@ class TestIEffect:
         "type": "ieffect2",
         "name": "Burning",
         "effects": {"save_dis": ["all"], "damage_bonus": "1 [fire]"},
-        "attacks": [
-            {
-                "attack": {
-                    "name": "Burning Hand (not the spell)",
-                    "_v": 2,
-                    "automation": [
-                        {"type": "target", "target": "each", "effects": [{"type": "damage", "damage": "1d8[fire]"}]}
-                    ],
-                }
+        "attacks": [{
+            "attack": {
+                "name": "Burning Hand (not the spell)",
+                "_v": 2,
+                "automation": [
+                    {"type": "target", "target": "each", "effects": [{"type": "damage", "damage": "1d8[fire]"}]}
+                ],
             }
-        ],
+        }],
         "buttons": [
             {
                 "label": "Take Fire Damage",


### PR DESCRIPTION
### Summary
Adds specific saving throw bonuses.

Depends on https://github.com/avrae/automation-common/pull/14

Resolves (placeholder)

- `!i effect`
  - `-sb` now supports specific save (ignore typo of ssb in the screenshot, it's been fixed)
![image](https://github.com/user-attachments/assets/5193ba83-e2fd-4f9a-94e7-95d9094567aa)
- Automation
  - Now supports a specific_save_bonus under passive effects. Added to docs
![image](https://github.com/user-attachments/assets/27da3241-c9a1-4a57-a3db-0031cc1fb10e)
- Aliasing
  - SimpleCombatant.save now supports these as well.
- A single test has been added, and it passed on my end :)
Changes: (Looking for: nitpicks, major problems, all of the above)

- [X] cogs5e.models.automation.effects.ieffect 
- [X] aliasing.api.validators
- [X] cogs5e.models.initiative.cog.effect (docs)
- [X] docs.automation_ref#ieffect (docs)
- [X] the implementation of the new passive effect
    - [X] Automation -> Save
    - [X] Aliasing -> SimpleCombatant.save()
- [X] the automation-common library: validation.models.PassiveEffects (otherwise the norm step of !a import eats keys) 

### Changelog Entry

Adds `specific_save_bonus` to the Automation model, allowing for specific save bonuses in effects.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
