### PR TITLE
fix(alias): fix new lines in alias names

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -227,8 +227,12 @@ class CollectableManagementGroup(commands.Group):
             return await self.list(ctx)
 
         name = content_array[1]
+        if "\n" in name:
+            name, content = name.split("\n", maxsplit=1)  # prevents alias names like "test\nmultiline"...
+            content_array = [content_array[0], name, "\n" + content] + content_array[2:]
+
         if not self.quotations_check(name):
-            raise Exception(f"Unexpected quote mark on {name}")
+            raise InvalidArgument(f"Invalid alias name: Unexpected quote mark on {name}")
 
         code = " ".join(content_array[2:])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml==6.0.1
 # Already Updated Packages
 # Top Level Deps
 launchdarkly-server-sdk==9.0
-Pillow~=10.2.0
+Pillow~=10.3.0
 disnake~=2.10.1
 gspread~=6.1.1
 rapidfuzz~=3.6.1

--- a/tests/e2e/aliasing_mixed_test.py
+++ b/tests/e2e/aliasing_mixed_test.py
@@ -13,6 +13,14 @@ async def test_echo_alias(avrae, dhttp):
     await dhttp.receive_message(".+: foobar")
 
 
+async def test_alias_newlines(avrae, dhttp):
+    # ensure newlines directly after the alias name won't break anything.
+    avrae.message("!alias foobar\necho hello!")
+    await dhttp.receive_message("Alias `foobar` added.```py\n!alias foobar \necho hello!\n```")
+    avrae.message("!foobar")
+    await dhttp.drain()  # no expected output due to the newline before the alias command.
+
+
 async def test_variables(avrae, dhttp):
     avrae.message("!uvar foobar Hello world")
     await dhttp.receive_message()


### PR DESCRIPTION
### Summary

prevent newlines from being present in alias names ( Resolves #2160 )
fixed invisible error when creating alias name with an unmatched quote.
bump PILLOW [past cve](www.mend.io/vulnerability-database/CVE-2024-28219)

### Changelog Entry

Fixed an issue where alias names could become invalid.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
