### PR TITLE
revert(AVR-914): revert changes in v4.2.63 back to v4.2.62

### DIFF
--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -94,7 +94,7 @@ class AliasGuild:
     Represents the Discord guild (server) an alias was invoked in.
     """
 
-    def __init__(self, guild, servsettings=None):
+    def __init__(self, guild, servsettings):
         """
         :type guild: disnake.Guild
         """
@@ -122,12 +122,12 @@ class AliasGuild:
 
     def servsettings(self):
         """
-        Retrieves and returns the dict of server settings. Not present when retrieving from verify_signature.
+        Retrieves and returns the dict of server settings.
 
         :return: A dict of server settings.
         :rtype: dict or None
         """
-        return self._servsettings() if self._servsettings else None
+        return self._servsettings()
 
     def __str__(self):
         return self.name

--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -241,7 +241,7 @@ def verify_signature(ctx: disnake.ext.commands.Context, data: str):
     channel = ctx.bot.get_channel(channel_id)
     author = ctx.bot.get_user(author_id)
     guild = None
-    if channel is not None and isinstance(channel, (disnake.abc.GuildChannel, disnake.Thread)):
+    if channel is not None and isinstance(channel, disnake.abc.GuildChannel):
         guild = channel.guild
 
     return {
@@ -253,7 +253,7 @@ def verify_signature(ctx: disnake.ext.commands.Context, data: str):
         "user_data": user_data,
         "workshop_collection_id": collection_id,
         "guild_id": guild and guild.id,  # may be None
-        "guild": guild and AliasGuild(guild, None),  # may be None
+        "guild": guild and AliasGuild(guild),  # may be None
         "channel": channel and AliasChannel(channel),  # may be None
         "author": author and AliasAuthor(author),  # may be None
     }

--- a/confluent_client/producer.py
+++ b/confluent_client/producer.py
@@ -74,8 +74,8 @@ class KafkaProducer:
             "DISCORD_SERVER_ID": ctx.message.guild.id if ctx.message.guild else None,  # Guild ID is empty on a DM
             "COUNTRY_CODE": None,
             "IP_ADDRESS": None,
-            "COMMAND_ID": ctx.command.qualified_name if ctx.command else ctx.message.content,
-            "COMMAND_CATEGORY": ctx.command.cog_name if ctx.command else None,
+            "COMMAND_ID": ctx.command.qualified_name,
+            "COMMAND_CATEGORY": ctx.command.cog_name,
             "SUBCOMMAND_ID": None,
             "ARGS": ctx.message.content.split(" ")[1:],
         }

--- a/dbot.py
+++ b/dbot.py
@@ -367,9 +367,8 @@ async def on_command(ctx):
             "cmd: chan {0.message.channel} ({0.message.channel.id}), serv {0.message.guild} ({0.message.guild.id}), "
             "auth {0.message.author} ({0.message.author.id}): {0.message.content}".format(ctx)
         )
-        # send command to kafka only if env vars are present
-        if config.KAFKA_BOOTSTRAP_SERVER:
-            await producer.produce(ctx)
+        # send command to kafka
+        await producer.produce(ctx)
     except AttributeError:
         log.debug("Command in PM with {0.message.author} ({0.message.author.id}): {0.message.content}".format(ctx))
 

--- a/tests/e2e/aliasing_mixed_test.py
+++ b/tests/e2e/aliasing_mixed_test.py
@@ -134,12 +134,6 @@ async def test_alias_vs_servalias(avrae, dhttp):
     await dhttp.receive_message(r".+: this is foobar")
 
 
-async def test_alias_verify_signature(avrae, dhttp):
-    avrae.message("!test {{x = signature()}}{{verify_signature(x)}}")
-    # ensure it is json
-    await dhttp.receive_message(r".+: {.+}")
-
-
 @pytest.mark.usefixtures("character")
 class TestCharacterAliases:
     async def test_echo_attributes(self, avrae, dhttp):


### PR DESCRIPTION
### Summary
Something cause the bot to stop responding to requests that went out in v4.2.63. The changes themselves appear benign and they don't appear to cause issues on nightly. We are going to revert the changes and then release them one by one to see which change caused the problem..

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
