### PR TITLE
fix: use interaction as ctx instead of interaction.ctx

### DIFF
--- a/confluent_client/producer.py
+++ b/confluent_client/producer.py
@@ -133,9 +133,7 @@ class KafkaProducer:
         if not self._validate_producer_ready():
             return None
 
-        ddb_user: Optional[BeyondUser] = await interaction.bot.ddb.get_ddb_user(
-            interaction.context, interaction.author.id
-        )
+        ddb_user: Optional[BeyondUser] = await interaction.bot.ddb.get_ddb_user(interaction, interaction.author.id)
 
         avrae_command = {
             "EVENT_TIME": time.strftime("%Y-%m-%dT%H:%M:%SZ", interaction.created_at.timetuple()),


### PR DESCRIPTION
### Summary
`interaction.ctx` does not have `bot` which is causing an error to be thrown. Pass `interaction` instead.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
