### PR TITLE
Display Stat Blocks in 2024 Style

### DIFF
--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -681,11 +681,14 @@ class Lookup(commands.Cog):
                     embed_queue.append(disnake.Embed(colour=color, description=t))
 
         if visible:
-            embed_queue[-1].description = monster.get_meta()
+            embed_queue[-1].description = monster.get_upper_meta()
+            embed_queue[-1].add_field(value=monster.get_physical_stat_table(), inline=True)
+            embed_queue[-1].add_field(value=monster.get_mental_stat_table(), inline=True)
+            safe_append(None, monster.get_lower_meta())
             if monster.traits:
                 trait = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.traits)
                 if trait:
-                    safe_append("Special Abilities", trait)
+                    safe_append("Traits", trait)
             if monster.actions:
                 action = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.actions)
                 if action:
@@ -699,12 +702,11 @@ class Lookup(commands.Cog):
                 if reaction:
                     safe_append("Reactions", reaction)
             if monster.legactions:
-                proper_name = f"The {monster.name}" if not monster.proper else monster.name
+                proper = "The " if not monster.proper else ""
                 legendary = [
-                    f"{proper_name} can take {monster.la_per_round} legendary actions, choosing from "
-                    "the options below. Only one legendary action can be used at a time and only at the "
-                    f"end of another creature's turn. {proper_name} regains spent legendary actions at "
-                    "the start of its turn."
+                    f"*Legendary Action Uses: {monster.la_per_round}. Immediately after another creature's turn, "
+                    f"{proper.lower()}{monster.name} can expend a use to take one of the following actions. "
+                    f"{proper}{monster.name} regains all expended uses at the start of each of its turns.*"
                 ]
                 for a in monster.legactions:
                     if a.name:

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -682,9 +682,9 @@ class Lookup(commands.Cog):
 
         if visible:
             embed_queue[-1].description = monster.get_upper_meta()
-            embed_queue[-1].add_field(value=monster.get_physical_stat_table(), inline=True)
-            embed_queue[-1].add_field(value=monster.get_mental_stat_table(), inline=True)
-            safe_append(None, monster.get_lower_meta())
+            embed_queue[-1].add_field(name="", value=monster.get_physical_stat_table(), inline=True)
+            embed_queue[-1].add_field(name="", value=monster.get_mental_stat_table(), inline=True)
+            safe_append("", monster.get_lower_meta())
             if monster.traits:
                 trait = "\n\n".join(f"***{a.name}.*** {a.desc}" for a in monster.traits)
                 if trait:

--- a/cogs5e/models/sheet/base.py
+++ b/cogs5e/models/sheet/base.py
@@ -215,7 +215,7 @@ class Skills:
 
     def __str__(self):
         out = []
-        for skill_name in SKILL_NAMES:
+        for skill_name in set(SKILL_NAMES) - {"Initiative"}:
             skill = self.skills[skill_name]
             to_add = False
             modifiers = []

--- a/cogs5e/models/sheet/base.py
+++ b/cogs5e/models/sheet/base.py
@@ -215,7 +215,7 @@ class Skills:
 
     def __str__(self):
         out = []
-        for skill_name in set(SKILL_NAMES) - {"Initiative"}:
+        for skill_name in set(SKILL_NAMES) - {"initiative"}:
             skill = self.skills[skill_name]
             to_add = False
             modifiers = []

--- a/cogs5e/models/sheet/resistance.py
+++ b/cogs5e/models/sheet/resistance.py
@@ -32,14 +32,12 @@ class Resistances:
 
     @classmethod
     def from_args(cls, args, **kwargs):
-        return cls.from_dict(
-            {
-                "resist": args.get("resist", [], **kwargs),
-                "immune": args.get("immune", [], **kwargs),
-                "vuln": args.get("vuln", [], **kwargs),
-                "neutral": args.get("neutral", [], **kwargs),
-            }
-        )
+        return cls.from_dict({
+            "resist": args.get("resist", [], **kwargs),
+            "immune": args.get("immune", [], **kwargs),
+            "vuln": args.get("vuln", [], **kwargs),
+            "neutral": args.get("neutral", [], **kwargs),
+        })
 
     def to_dict(self):
         return {

--- a/cogs5e/models/sheet/resistance.py
+++ b/cogs5e/models/sheet/resistance.py
@@ -32,12 +32,14 @@ class Resistances:
 
     @classmethod
     def from_args(cls, args, **kwargs):
-        return cls.from_dict({
-            "resist": args.get("resist", [], **kwargs),
-            "immune": args.get("immune", [], **kwargs),
-            "vuln": args.get("vuln", [], **kwargs),
-            "neutral": args.get("neutral", [], **kwargs),
-        })
+        return cls.from_dict(
+            {
+                "resist": args.get("resist", [], **kwargs),
+                "immune": args.get("immune", [], **kwargs),
+                "vuln": args.get("vuln", [], **kwargs),
+                "neutral": args.get("neutral", [], **kwargs),
+            }
+        )
 
     def to_dict(self):
         return {
@@ -225,7 +227,7 @@ class Resistance:
         out = []
         out.extend(f"non{u}" for u in self.unless)
         out.extend(self.only)
-        out.append(self.dtype)
+        out.append(self.dtype.title())
         return " ".join(out)
 
     def __repr__(self):

--- a/cogs5e/models/sheet/resistance.py
+++ b/cogs5e/models/sheet/resistance.py
@@ -121,13 +121,13 @@ class Resistances:
     def __str__(self):
         out = []
         if self.resist:
-            out.append(f"**Resistances**: {', '.join([str(r) for r in self.resist])}")
+            out.append(f"**Resistances**: {', '.join(sorted([str(r) for r in self.resist]))}")
         if self.immune:
-            out.append(f"**Immunities**: {', '.join([str(r) for r in self.immune])}")
+            out.append(f"**Immunities**: {', '.join(sorted([str(r) for r in self.immune]))}")
         if self.vuln:
-            out.append(f"**Vulnerabilities**: {', '.join([str(r) for r in self.vuln])}")
+            out.append(f"**Vulnerabilities**: {', '.join(sorted([str(r) for r in self.vuln]))}")
         if self.neutral:
-            out.append(f"**Ignored**: {', '.join([str(r) for r in self.neutral])}")
+            out.append(f"**Ignored**: {', '.join(sorted([str(r) for r in self.neutral]))}")
         return "\n".join(out)
 
 
@@ -154,7 +154,8 @@ class Resistance:
             only = set()
         else:
             only = set(t.lower() for t in only)
-        self.dtype = dtype.lower()
+        # Don't lowercase multiword displayed resistances.
+        self.dtype = dtype if " " in dtype else dtype.lower()
         self.unless = unless
         self.only = only
 
@@ -225,7 +226,8 @@ class Resistance:
         out = []
         out.extend(f"non{u}" for u in self.unless)
         out.extend(self.only)
-        out.append(self.dtype.title())
+        # Don't titlecase multiword displayed resistances and don't use .title() because of apostrophes.
+        out.append(self.dtype if " " in self.dtype else self.dtype.capitalize())
         return " ".join(out)
 
     def __repr__(self):

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -341,10 +341,21 @@ class Monster(StatBlock, Sourced):
         else:
             return f"passive Perception {self.passive}"
 
+    def get_init_str(self):
+        skill = self.skills.get("Initiative")
+        init_str = f"**Initiative** {skill.value:+} ("
+        if skill.adv is True:
+            init_str += f"{15 + skill.value}, adv)"
+        elif skill.adv is False:
+            init_str += f"{5 + skill.value}, dis)"
+        else:
+            init_str += f"{10 + skill.value})"
+        return init_str
+
     def get_upper_meta(self):
         """
         Returns a string describing the meta statistics of a monster.
-        Should be the portion between the embed title and special abilities.
+        Should be the portion between the embed title and ability score tables.
         """
         size = self.size
         type_ = self.creature_type
@@ -353,9 +364,13 @@ class Monster(StatBlock, Sourced):
         hp = f"{self.hp} ({self.hitdice})"
         speed = self.speed
 
-        return f"*{size} {type_}{alignment}*\n**AC** {ac}\n**HP** {hp}\n**Speed** {speed}\n"
+        return f"*{size} {type_}{alignment}*\n**AC** {ac}   {self.get_init_str()}\n**HP** {hp}\n**Speed** {speed}\n"
 
     def get_lower_meta(self):
+        """
+        Returns a string describing the meta statistics of a monster.
+        Should be the portion between the ability score tables and the traits.
+        """
         desc = ""
         if str(self.skills):
             desc += f"**Skills** {self.skills}\n"

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -306,7 +306,7 @@ class Monster(StatBlock, Sourced):
 
     def _get_stat_table_row(self, stat):
         save = self.saves.get(stat)
-        row = f"{stat[:3].upper()} {self.stats[stat]} {self.stats.get_mod(stat):+3} {save.value:+3}"
+        row = f"{stat[:3].upper()} {self.stats[stat]:>3} {self.stats.get_mod(stat):+3} {save.value:+3}"
         if save.adv is True:
             row += " (adv)"
         elif save.adv is False:

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -277,16 +277,14 @@ class Monster(StatBlock, Sourced):
 
     def get_hidden_stat_array(self):
         stats = ["Unknown", "Unknown", "Unknown", "Unknown", "Unknown", "Unknown"]
-        for i, stat in enumerate(
-            (
-                self.stats.strength,
-                self.stats.dexterity,
-                self.stats.constitution,
-                self.stats.intelligence,
-                self.stats.wisdom,
-                self.stats.charisma,
-            )
-        ):
+        for i, stat in enumerate((
+            self.stats.strength,
+            self.stats.dexterity,
+            self.stats.constitution,
+            self.stats.intelligence,
+            self.stats.wisdom,
+            self.stats.charisma,
+        )):
             if stat <= 3:
                 stats[i] = "Very Low"
             elif 3 < stat <= 7:
@@ -314,26 +312,22 @@ class Monster(StatBlock, Sourced):
         return row
 
     def get_physical_stat_table(self):
-        return "\n".join(
-            [
-                "```swift\n        MOD SAV",
-                self._get_stat_table_row("strength"),
-                self._get_stat_table_row("dexterity"),
-                self._get_stat_table_row("constitution"),
-                "```",
-            ]
-        )
+        return "\n".join([
+            "```swift\n        MOD SAV",
+            self._get_stat_table_row("strength"),
+            self._get_stat_table_row("dexterity"),
+            self._get_stat_table_row("constitution"),
+            "```",
+        ])
 
     def get_mental_stat_table(self):
-        return "\n".join(
-            [
-                "```swift\n        MOD SAV",
-                self._get_stat_table_row("intelligence"),
-                self._get_stat_table_row("wisdom"),
-                self._get_stat_table_row("charisma"),
-                "```",
-            ]
-        )
+        return "\n".join([
+            "```swift\n        MOD SAV",
+            self._get_stat_table_row("intelligence"),
+            self._get_stat_table_row("wisdom"),
+            self._get_stat_table_row("charisma"),
+            "```",
+        ])
 
     def get_senses_str(self):
         if self.senses:

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -369,12 +369,12 @@ class Monster(StatBlock, Sourced):
         if str(self.skills):
             desc += f"**Skills** {self.skills}\n"
         if self._displayed_resistances.vuln:
-            desc += f"**Vulnerabilities** {', '.join(str(r) for r in self._displayed_resistances.vuln)}\n"
+            desc += f"**Vulnerabilities** {', '.join(sorted([str(r) for r in self._displayed_resistances.vuln]))}\n"
         if self._displayed_resistances.resist:
-            desc += f"**Resistances** {', '.join(str(r) for r in self._displayed_resistances.resist)}\n"
+            desc += f"**Resistances** {', '.join(sorted([str(r) for r in self._displayed_resistances.resist]))}\n"
         immunities = []
         if self._displayed_resistances.immune:
-            immunities.append(", ".join(str(r) for r in self._displayed_resistances.immune))
+            immunities.append(", ".join(sorted([str(r) for r in self._displayed_resistances.immune])))
         if self.condition_immune:
             immunities.append(", ".join(map(str, self.condition_immune)))
         if immunities:

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -304,6 +304,39 @@ class Monster(StatBlock, Sourced):
             f"**INT**: {stats[3]} **WIS**: {stats[4]} **CHA**: {stats[5]}"
         )
 
+    def _get_stat_table_row(self, stat):
+        save = self.saves.get(stat)
+        row = f"{stat[:3].upper()} {self.stats.get(stat)} {self.stats.get_mod(stat):+3} {save.value:+3}"
+        if save.adv is True:
+            row += " (adv)"
+        elif save.adv is False:
+            row += " (dis)"
+        return row + "\n"
+
+    def get_physical_stat_table(self):
+        return "\n".join(
+            [
+                "```swift",
+                "        MOD SAV",
+                self._get_stat_table_row("strength"),
+                self._get_stat_table_row("dexterity"),
+                self._get_stat_table_row("constitution"),
+                "```",
+            ]
+        )
+
+    def get_mental_stat_table(self):
+        return "\n".join(
+            [
+                "```swift",
+                "        MOD SAV",
+                self._get_stat_table_row("intelligence"),
+                self._get_stat_table_row("wisdom"),
+                self._get_stat_table_row("charisma"),
+                "```",
+            ]
+        )
+
     def get_senses_str(self):
         if self.senses:
             return f"{self.senses}, passive Perception {self.passive}"

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -306,7 +306,7 @@ class Monster(StatBlock, Sourced):
 
     def _get_stat_table_row(self, stat):
         save = self.saves.get(stat)
-        row = f"{stat[:3].upper()} {self.stats.get(stat)} {self.stats.get_mod(stat):+3} {save.value:+3}"
+        row = f"{stat[:3].upper()} {self.stats[stat]} {self.stats.get_mod(stat):+3} {save.value:+3}"
         if save.adv is True:
             row += " (adv)"
         elif save.adv is False:

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -316,8 +316,7 @@ class Monster(StatBlock, Sourced):
     def get_physical_stat_table(self):
         return "\n".join(
             [
-                "```swift",
-                "        MOD SAV",
+                "```swift\n        MOD SAV",
                 self._get_stat_table_row("strength"),
                 self._get_stat_table_row("dexterity"),
                 self._get_stat_table_row("constitution"),
@@ -328,8 +327,7 @@ class Monster(StatBlock, Sourced):
     def get_mental_stat_table(self):
         return "\n".join(
             [
-                "```swift",
-                "        MOD SAV",
+                "```swift\n        MOD SAV",
                 self._get_stat_table_row("intelligence"),
                 self._get_stat_table_row("wisdom"),
                 self._get_stat_table_row("charisma"),

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -277,14 +277,16 @@ class Monster(StatBlock, Sourced):
 
     def get_hidden_stat_array(self):
         stats = ["Unknown", "Unknown", "Unknown", "Unknown", "Unknown", "Unknown"]
-        for i, stat in enumerate((
-            self.stats.strength,
-            self.stats.dexterity,
-            self.stats.constitution,
-            self.stats.intelligence,
-            self.stats.wisdom,
-            self.stats.charisma,
-        )):
+        for i, stat in enumerate(
+            (
+                self.stats.strength,
+                self.stats.dexterity,
+                self.stats.constitution,
+                self.stats.intelligence,
+                self.stats.wisdom,
+                self.stats.charisma,
+            )
+        ):
             if stat <= 3:
                 stats[i] = "Very Low"
             elif 3 < stat <= 7:
@@ -308,7 +310,7 @@ class Monster(StatBlock, Sourced):
         else:
             return f"passive Perception {self.passive}"
 
-    def get_meta(self):
+    def get_upper_meta(self):
         """
         Returns a string describing the meta statistics of a monster.
         Should be the portion between the embed title and special abilities.
@@ -320,29 +322,31 @@ class Monster(StatBlock, Sourced):
         hp = f"{self.hp} ({self.hitdice})"
         speed = self.speed
 
-        desc = f"*{size} {type_}{alignment}*\n**AC** {ac}\n**HP** {hp}\n**Speed** {speed}\n"
-        desc += f"{self.get_stat_array()}\n"
+        return f"*{size} {type_}{alignment}*\n**AC** {ac}\n**HP** {hp}\n**Speed** {speed}\n"
 
-        if str(self.saves):
-            desc += f"**Saving Throws** {self.saves}\n"
+    def get_lower_meta(self):
+        desc = ""
         if str(self.skills):
             desc += f"**Skills** {self.skills}\n"
-        desc += f"**Senses** {self.get_senses_str()}\n"
         if self._displayed_resistances.vuln:
             desc += f"**Vulnerabilities** {', '.join(str(r) for r in self._displayed_resistances.vuln)}\n"
         if self._displayed_resistances.resist:
             desc += f"**Resistances** {', '.join(str(r) for r in self._displayed_resistances.resist)}\n"
+        immunities = []
         if self._displayed_resistances.immune:
-            desc += f"**Damage Immunities** {', '.join(str(r) for r in self._displayed_resistances.immune)}\n"
+            immunities.append(", ".join(str(r) for r in self._displayed_resistances.immune))
         if self.condition_immune:
-            desc += f"**Condition Immunities** {', '.join(map(str, self.condition_immune))}\n"
+            immunities.append(", ".join(map(str, self.condition_immune)))
+        if immunities:
+            desc += f"**Immunities** {'; '.join(immunities)}\n"
+        desc += f"**Senses** {self.get_senses_str()}\n"
         if self.languages:
             desc += f"**Languages** {', '.join(self.languages)}\n"
         else:
             desc += "**Languages** --\n"
 
         if not self.hide_cr:
-            desc += f"**Challenge** {self.cr} ({self.xp:,} XP)"
+            desc += f"**CR** {self.cr} (XP {self.xp:,}; PB {self.stats.prof_bonus:+})"
         return desc
 
     def get_title_name(self):

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -311,7 +311,7 @@ class Monster(StatBlock, Sourced):
             row += " (adv)"
         elif save.adv is False:
             row += " (dis)"
-        return row + "\n"
+        return row
 
     def get_physical_stat_table(self):
         return "\n".join(

--- a/gamedata/monster.py
+++ b/gamedata/monster.py
@@ -342,7 +342,7 @@ class Monster(StatBlock, Sourced):
             return f"passive Perception {self.passive}"
 
     def get_init_str(self):
-        skill = self.skills.get("Initiative")
+        skill = self.skills.initiative
         init_str = f"**Initiative** {skill.value:+} ("
         if skill.adv is True:
             init_str += f"{15 + skill.value}, adv)"


### PR DESCRIPTION
### Summary
Multiple updates to make the monster lookup embed more closely resemble the 2024 style. Specifically:
- Initiative is now displayed next to AC, not as a skill. As part of this, `str(BaseSkills)` no longer includes initiative.
- Ability scores and save bonuses are now displayed in two code-block tables. These are inline fields so work nicely on mobile as well as desktop.
- Senses are reordered to just above Languages.
- The damage types in stringified Vulnerabilities, Resistances, and Immunities are title case. For now, this only applies to the final word, not any of the "only" or "except" words. For example, `nonmagical nonsilvered piercing` becomes `nonmagical nonsilvered Piercing`. I'd appreciate feedback on whether this is the right approach.
- "Challenge" shortened to "CR" and now includes PB (as well as XP) in the parentheses.
- "Special Abilities" renamed to "Traits"
- The Legendary Actions header text uses the 2024 wording.

### Changelog Entry
Updated monster stat blocks to match D&D 2024 format and layout

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
