### PR TITLE
test: enhance action stringify tests for NaN and unknown value handling

### DIFF
--- a/tests/gamedata/actions_test.py
+++ b/tests/gamedata/actions_test.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from cogs5e.models.automation import Automation
@@ -26,8 +28,34 @@ def test_action_stringify(action, bob):
     automation = get_action_automation(action)
     action_str = automation.build_str(caster=bob)
     assert action_str
-    assert "nan" not in action_str
-    assert "unknown" not in action_str
+
+    # Attack bonus errors: Attack.build_str generates "+{attack_bonus}" patterns where
+    # attack_bonus can be float("nan") from stringify_intexpr when IntExpression evaluation fails
+    assert not re.search(r"[+-]nan\b", action_str), f"Found malformed attack bonus in: {action_str}"
+
+    # Save DC errors: Save.build_str generates "DC {dc}" patterns where
+    # dc can be float("nan") from stringify_intexpr when DC IntExpression evaluation fails
+    assert not re.search(r"\bDC nan\b", action_str), f"Found malformed DC in: {action_str}"
+
+    # Value context errors: Various build_str methods generate "Property: {value}" patterns where
+    # value can be float("nan") from stringify_intexpr when numeric expressions fail
+    assert not re.search(r":\s*nan\b", action_str), f"Found 'nan' in value context in: {action_str}"
+
+    # UseCounter usage errors: UseCounter.build_str generates "uses {used}/{max}" patterns where
+    # used/max can be float("nan") from stringify_intexpr when counter expressions fail
+    assert not re.search(r"\buses\s+nan\b", action_str, re.IGNORECASE), f"Found 'uses nan' in: {action_str}"
+
+    # UseCounter restore errors: UseCounter.build_str generates "restores {amount}" patterns where
+    # amount can be float("nan") from stringify_intexpr when restore expressions fail
+    assert not re.search(r"\brestores\s+nan\b", action_str, re.IGNORECASE), f"Found 'restores nan' in: {action_str}"
+
+    # Unknown value errors: Various build_str methods use "Unknown" as fallback when
+    # data lookup fails, appearing in value contexts that suggest missing/invalid data
+    assert not re.search(r":\s*Unknown\b", action_str), f"Found 'Unknown' as value in: {action_str}"
+
+    # Effect description errors: Effect descriptions should not show "Unknown" as it indicates
+    # missing or malformed effect data rather than a legitimate effect name
+    assert not re.search(r"\bEffect:\s*Unknown\b", action_str), f"Found 'Effect: Unknown' in: {action_str}"
 
 
 # --- out of combat ---


### PR DESCRIPTION
### Summary
The `test_action_stringify()` check was preventing actions from having `nan` or `unknown` in them, so something like "Sustenance" would be flagged.

This change makes the test assert where those values would actually cause a problem.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
