### PR TITLE
docs: add documenation for damage types cvars in Chromatic Orb and Sorcerous Burst

### DIFF
--- a/docs/cheatsheets/automation_quirks.rst
+++ b/docs/cheatsheets/automation_quirks.rst
@@ -54,6 +54,19 @@ You can specify the type of hindrance you want to apply with the ``-choice`` arg
 * ``-choice blindness`` for the Blindness option
 * ``-choice deafness`` for the Deafness option
 
+Chromatic Orb
+-----------------
+You can specify the type of damage you want to apply with the ``-choice`` argument or by setting the ``ChromaticOrbDType`` cvar.
+
+* ``-choice acid`` for Acid damage
+* ``-choice cold`` for Cold damage
+* ``-choice fire`` for Fire damage
+* ``-choice lightning`` for Lightning damage
+* ``-choice poison`` for Poison damage
+* ``-choice thunder`` for Thunder damage
+
+You can also set a default damage type using the ``ChromaticOrbDType`` cvar (e.g., ``!cvar ChromaticOrbDType fire``). The cvar will be used if no ``-choice`` is provided at cast time. If neither is provided, it will do [chromatic] damage by default.
+
 Dragon's Breath
 -----------------
 You can specify the type of damage you want to apply with the ``-choice`` argument. If a choice is *not* provided at cast time, it will do [chromatic] damage by default, and you will need to use ``-choice [element]`` to specify the damage type each time the breath attack is used, and adjustments may be required to the targets health, depending on resistances.
@@ -149,6 +162,20 @@ You can specify the affected ability score with ``-choice``. This also applies t
 Shield
 -----------------
 You can have the automation automatically heal you for the damage you absorb by adding ``-amt [amount]`` to the end of the command. (``-amt 5`` for instance). It will heal you for the amount you specify.
+
+Sorcerous Burst
+-----------------
+You can specify the type of damage you want to apply with the ``-choice`` argument or by setting the ``SorcerousBurstDType`` cvar.
+
+* ``-choice acid`` for Acid damage
+* ``-choice cold`` for Cold damage
+* ``-choice fire`` for Fire damage
+* ``-choice lightning`` for Lightning damage
+* ``-choice poison`` for Poison damage
+* ``-choice psychic`` for Psychic damage
+* ``-choice thunder`` for Thunder damage
+
+You can also set a default damage type using the ``SorcerousBurstDType`` cvar (e.g., ``!cvar SorcerousBurstDType lightning``). The cvar will be used if no ``-choice`` is provided at cast time. If neither is provided, it will do [elemental] damage by default.
 
 Spirit Guardians
 -------------------


### PR DESCRIPTION
### Summary
Added documentation for damage type `cvar`s for Sorcerours Burst and Chromatic Orb.

### Changelog Entry
Chromatic Orb and Sorcerous Burst damage type `cvar`s added to [automation quirks](https://avrae.readthedocs.io/en/stable/cheatsheets/automation_quirks.html).

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
