### PR TITLE
feat: specific save bonuses (v2)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -6,6 +6,7 @@ import cogs5e.initiative as init
 from aliasing.api.functions import SimpleRollResult
 from aliasing.api.statblock import AliasStatBlock
 from cogs5e.models.errors import InvalidSaveType
+from cogs5e.models.automation.utils import parse_save_bonuses
 from cogs5e.models.sheet.statblock import StatBlock
 from utils.argparser import ParsedArguments
 from . import validators
@@ -272,7 +273,9 @@ class SimpleCombatant(AliasStatBlock):
         except ValueError:
             raise InvalidSaveType
 
-        sb = self._combatant.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+        sb = parse_save_bonuses(
+            ability, self._combatant.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+        )
         saveroll = save.d20(base_adv=adv)
         if sb:
             saveroll = f'{saveroll}+{"+".join(sb)}'

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -982,7 +982,7 @@ class InitTracker(commands.Cog):
         `-vuln <damage type>` - Gives the combatant vulnerability to the given damage type.
         `-neutral <damage type>` - Removes the combatant's immunity, resistance, or vulnerability to the given damage type.
         __Checks/Saves__
-        `-sb <save bonus>` - Adds a bonus to all saving throws.
+        `-sb <save bonus>` - Adds a bonus to all saving throws. Per-stat bonuses can be specified using the stat's 3 letter abbreviation. (e.g. `-sb 1d4|dex`)
         `-sadv/sdis <ability>` - Gives advantage/disadvantage on saving throws for the provided ability, or "all" for all saves.
         `-dc <dc>` - Adds a bonus to all saving throw DCs.
         `-cb <check bonus>` - Adds a bonus to all ability checks.
@@ -1310,7 +1310,7 @@ class InitTracker(commands.Cog):
         aliases=["os"],
         help=f"""
         Rolls an ability save as another combatant.
-        {VALID_CHECK_ARGS}
+        {VALID_SAVE_ARGS}
         """,
     )
     async def offturnsave(self, ctx, combatant_name, save, *, args=""):

--- a/cogs5e/initiative/effects/passive.py
+++ b/cogs5e/initiative/effects/passive.py
@@ -103,6 +103,20 @@ def _str_save_dis(value: Set[str]):
     return f"Save Disadvantage: {saves}"
 
 
+def _str_save_bonus(value: str) -> str:
+    bonus_map: dict[str, list[str]] = {}
+    for split_value in value.split("+"):
+        if "|" in split_value:
+            dice, stat = split_value.split("|", 1)
+            bonus_map[stat] = bonus_map.get(stat, []) + [dice]
+        else:
+            bonus_map["all"] = bonus_map.get("all", []) + [split_value]
+    return "; ".join(
+        f"{stat_name.upper()+' ' if stat_name != 'all' else ''}Save Bonus: {'+'.join(dice_strs)}"
+        for stat_name, dice_strs in bonus_map.items()
+    )
+
+
 def _str_check_adv(value: Set[str]):
     if value.issuperset(STAT_NAMES):
         return "Check Advantage: All"
@@ -174,7 +188,7 @@ class InitPassiveEffect:
     ac_bonus: int = _PassiveEffect(stringifier=_abstract_str_attr("AC Bonus"))
     max_hp_value: int = _PassiveEffect(stringifier=_abstract_str_attr("Max HP"))
     max_hp_bonus: int = _PassiveEffect(stringifier=_abstract_str_attr("Max HP Bonus"))
-    save_bonus: str = _PassiveEffect(stringifier=_abstract_str_attr("Save Bonus"))
+    save_bonus: str = _PassiveEffect(stringifier=_str_save_bonus)
     save_adv: Set[str] = _PassiveEffect(
         default=set(),
         stringifier=_str_save_adv,

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -6,7 +6,7 @@ from utils.functions import maybe_mod, reconcile_adv, verbose_stat
 from . import Effect
 from ..errors import AutomationException, NoSpellDC, TargetException
 from ..results import SaveResult
-from ..utils import stringify_intexpr
+from ..utils import stringify_intexpr, parse_save_bonuses
 
 
 class Save(Effect):
@@ -46,7 +46,8 @@ class Save(Effect):
 
         # ==== args ====
         save = autoctx.args.last("save") or self.stat
-        sb = autoctx.args.get("sb", ephem=True)
+        # list of non-empty parsed save bonuses
+        sb = parse_save_bonuses(save, autoctx.args.get("sb", ephem=True))
         auto_pass = autoctx.args.last("pass", type_=bool, ephem=True)
         auto_fail = autoctx.args.last("fail", type_=bool, ephem=True)
         hide = autoctx.args.last("h", type_=bool)

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -8,7 +8,7 @@ import cogs5e.initiative.combatant as init
 from cogs5e.models import character as character_api, embeds
 from utils.enums import AdvantageType, CritDamageType
 from .errors import AutomationEvaluationException, AutomationException, InvalidIntExpression
-from .utils import maybe_alias_statblock
+from .utils import maybe_alias_statblock, parse_save_bonuses
 
 __all__ = ("AutomationContext", "AutomationTarget")
 
@@ -298,10 +298,13 @@ class AutomationTarget:
         # combatant
         combatant = self.combatant
         if combatant and self.autoctx.allow_target_ieffects:
+            parsed_sb = parse_save_bonuses(
+                save_skill[:3], combatant.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+            )
             if sb:
-                sb.extend(combatant.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[]))
+                sb.extend(parsed_sb)
             else:
-                sb = combatant.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+                sb = parsed_sb
 
         # character-specific arguments (#1443)
         reroll = None

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -174,3 +174,25 @@ def tree_map_prefix(func: Callable[[TreeType], tuple[TreeType, bool]], node: Tre
     for i, child in enumerate(copied.children):
         copied.set_child(i, tree_map_prefix(func, child))
     return operated
+
+
+def parse_save_bonuses(save_type: str, save_bonuses: list[str]) -> list[str]:
+    """
+    Parse a save bonus string.
+    """
+    out = []
+    for save_bonus_combo in save_bonuses:
+        current_out = []
+        for save_bonus in save_bonus_combo.split("+"):
+            if "|" not in save_bonus:
+                out.append(save_bonus)
+                continue
+            save_bonus_dice, bonus_save_type = save_bonus.split("|", 1)
+            bonus_save_type = bonus_save_type[:3]
+
+            if bonus_save_type == save_type:
+                current_out.append(save_bonus_dice)
+        if current_out:
+            out.append("+".join(current_out))
+
+    return out

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -7,6 +7,7 @@ import cogs5e.initiative as init
 from cogs5e.models import embeds
 from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.base import Skill
+from cogs5e.models.automation.utils import parse_save_bonuses
 from utils.constants import SKILL_MAP, STAT_ABBREVIATIONS, STAT_NAMES
 from utils.functions import a_or_an, camel_to_title, maybe_http_url, verbose_stat
 
@@ -123,7 +124,9 @@ def run_save(save_key, caster, args, embed):
     if isinstance(caster, init.Combatant):
         combat_context: dict[str, Any] = {}
         # -sb
-        combat_context["b"] = caster.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+        combat_context["b"] = parse_save_bonuses(
+            save_key, caster.active_effects(mapper=lambda effect: effect.effects.save_bonus, default=[])
+        )
         # -sadv/sdis
         sadv_effects = caster.active_effects(
             mapper=lambda effect: effect.effects.save_adv, reducer=lambda saves: set().union(*saves), default=set()

--- a/cogs5e/utils/help_constants.py
+++ b/cogs5e/utils/help_constants.py
@@ -2,6 +2,9 @@
 Constants to help write help docs.
 """
 
+# ignore flake errors on this file about lines too long
+# flake8: noqa
+
 __all__ = ("VALID_CHECK_ARGS", "VALID_SAVE_ARGS", "VALID_AUTOMATION_ARGS", "VALID_SPELLCASTING_ARGS")
 
 # ==== check args ====
@@ -30,6 +33,7 @@ __Valid Arguments__
 *adv/dis* - Give advantage/disadvantage to the save roll(s).
 *-b <bonus>* - Adds a bonus to the roll.
 -dc <dc> - Sets a DC and counts successes/failures.
+*-sb <bonus>* - Adds a bonus to saving throws. Per-stat bonuses can be specified using the stat's 3 letter abbreviation. (e.g. `-sb 1d4|dex`)
 *-mc <minimum roll>* - Sets the minimum roll on the dice (e.g. Starry Form: Dragon, Trance of Order)
 -rr <iterations> - How many saves to roll (does not apply to Death Saves).
 
@@ -70,7 +74,7 @@ An italicized argument below means the argument supports ephemeral arguments - e
 sadv/sdis - Gives the target advantage/disadvantage on the saving throw.
 -dc <dc> - Overrides the DC of the save.
 -dc <+X/-X> - Modifies the DC by a certain amount.
-*-sb <bonus>* - Adds a bonus to saving throws.
+*-sb <bonus>* - Adds a bonus to saving throws. Per-stat bonuses can be specified using the stat's 3 letter abbreviation. (e.g. `-sb 1d4|dex`)
 -save <save type> - Overrides the spell save type (e.g. `-save str`).
 
 **Damage**

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -498,7 +498,8 @@ Used to specify the passive effects granted by an initiative effect.
 
     .. attribute:: save_bonus
 
-        *optional* - A bonus that this effect grants to all of the combatant's saving throws.
+        *optional* - A bonus that this effect grants to all of the combatant's saving throws. Per-stat bonuses can be
+        added like ``1d4|dex``, and multiple specific bonuses can be added like ``1d4|str+1d4|dex``
 
     .. attribute:: save_adv
 


### PR DESCRIPTION
### Summary

Adds specific save bonuses to the original SB argument. No model changes needed!

<img width="408" height="206" alt="image" src="https://github.com/user-attachments/assets/6dba696f-fbda-4d37-a2c1-caef3fec2750" />

<img width="548" height="163" alt="image" src="https://github.com/user-attachments/assets/ccdd4d18-7dfe-4609-b613-fe0238d01bea" />

<img width="506" height="270" alt="image" src="https://github.com/user-attachments/assets/9841b9ff-6991-4cb9-9e14-f0806cdede8b" />


### Changelog Entry

Specific save bonuses can now be added to anywhere `-sb` is accepted.

For example, giving +1d4 to dex saves would be `-sb 1d4|dex`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
