### PR TITLE
Afr 1087

### DIFF
--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -9,10 +9,12 @@ from pydantic import BaseModel
 
 from cogs5e.models.errors import NoCharacter
 from utils.functions import search_and_select
+from utils.argparser import argparse
 from .combatant import Combatant, MonsterCombatant, PlayerCombatant
 from .errors import *
 from .group import CombatantGroup
 from .types import CombatantType
+from cogs5e.utils.checkutils import ieffect_handler
 
 COMBAT_TTL = 60 * 60 * 24 * 7  # 1 week TTL
 
@@ -365,7 +367,29 @@ class Combat:
         """
         rolls = {}
         for c in self._combatants:
-            init_roll = roll(c.init_skill.d20())
+            if isinstance(c, CombatantGroup):
+                gc = c.get_combatants()[0]
+                args = ieffect_handler(gc, argparse(""), "initiative")
+                b = args.join("b", "+", ephem=True)
+
+                # set up dice. Note that we still use the first combatant in the group for consistency with the ieffects
+                roll_str = gc.init_skill.d20(base_adv=args.adv(boolwise=True, ephem=True))
+                if b is not None:
+                    roll_str = f"{roll_str}+{b}"
+
+                # roll
+                init_roll = roll(roll_str)
+            else:
+                args = ieffect_handler(c, argparse(""), "initiative")
+                b = args.join("b", "+", ephem=True)
+
+                # set up dice
+                roll_str = c.init_skill.d20(base_adv=args.adv(boolwise=True, ephem=True))
+                if b is not None:
+                    roll_str = f"{roll_str}+{b}"
+
+                # roll
+                init_roll = roll(roll_str)
             c.init = init_roll.total
             rolls[c] = init_roll
         self.sort_combatants()

--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -374,22 +374,19 @@ class Combat:
 
                 # set up dice. Note that we still use the first combatant in the group for consistency with the ieffects
                 roll_str = gc.init_skill.d20(base_adv=args.adv(boolwise=True, ephem=True))
-                if b is not None:
-                    roll_str = f"{roll_str}+{b}"
-
-                # roll
-                init_roll = roll(roll_str)
+                
             else:
                 args = ieffect_handler(c, argparse(""), "initiative")
                 b = args.join("b", "+", ephem=True)
 
                 # set up dice
                 roll_str = c.init_skill.d20(base_adv=args.adv(boolwise=True, ephem=True))
-                if b is not None:
-                    roll_str = f"{roll_str}+{b}"
+                
+            if b is not None:
+                roll_str = f"{roll_str}+{b}"
 
-                # roll
-                init_roll = roll(roll_str)
+            # roll
+            init_roll = roll(roll_str)
             c.init = init_roll.total
             rolls[c] = init_roll
         self.sort_combatants()
@@ -417,7 +414,8 @@ class Combat:
     @overload
     async def select_combatant(
         self, ctx, name: str, choice_message: Optional[str] = None, select_group: Literal[True] = False
-    ) -> Optional[Combatant | CombatantGroup]: ...
+    ) -> Optional[Combatant | CombatantGroup]:
+        ...
 
     async def select_combatant(
         self, ctx, name: str, choice_message: Optional[str] = None, select_group: Literal[False] = False

--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -104,17 +104,19 @@ class Combatant(BaseCombatant, StatBlock):
 
     def to_dict(self):
         d = super().to_dict()
-        d.update({
-            "controller_id": self.controller_id,
-            "init": self.init,
-            "private": self.is_private,
-            "index": self.index,
-            "notes": self.notes,
-            "effects": [e.to_dict() for e in self._effects],
-            "group_id": self._group_id,
-            "type": self.type.value,
-            "id": self.id,
-        })
+        d.update(
+            {
+                "controller_id": self.controller_id,
+                "init": self.init,
+                "private": self.is_private,
+                "index": self.index,
+                "notes": self.notes,
+                "effects": [e.to_dict() for e in self._effects],
+                "group_id": self._group_id,
+                "type": self.type.value,
+                "id": self.id,
+            }
+        )
         return d
 
     @property

--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -104,19 +104,17 @@ class Combatant(BaseCombatant, StatBlock):
 
     def to_dict(self):
         d = super().to_dict()
-        d.update(
-            {
-                "controller_id": self.controller_id,
-                "init": self.init,
-                "private": self.is_private,
-                "index": self.index,
-                "notes": self.notes,
-                "effects": [e.to_dict() for e in self._effects],
-                "group_id": self._group_id,
-                "type": self.type.value,
-                "id": self.id,
-            }
-        )
+        d.update({
+            "controller_id": self.controller_id,
+            "init": self.init,
+            "private": self.is_private,
+            "index": self.index,
+            "notes": self.notes,
+            "effects": [e.to_dict() for e in self._effects],
+            "group_id": self._group_id,
+            "type": self.type.value,
+            "id": self.id,
+        })
         return d
 
     @property
@@ -306,7 +304,6 @@ class Combatant(BaseCombatant, StatBlock):
         else:
             c_group = self.combat.get_group(group_name, create=self.init)
             c_group.add_combatant(self)
-            self.combat.sort_combatants()
             if was_current:
                 self.combat.goto_turn(self, True)
             return c_group

--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -104,17 +104,19 @@ class Combatant(BaseCombatant, StatBlock):
 
     def to_dict(self):
         d = super().to_dict()
-        d.update({
-            "controller_id": self.controller_id,
-            "init": self.init,
-            "private": self.is_private,
-            "index": self.index,
-            "notes": self.notes,
-            "effects": [e.to_dict() for e in self._effects],
-            "group_id": self._group_id,
-            "type": self.type.value,
-            "id": self.id,
-        })
+        d.update(
+            {
+                "controller_id": self.controller_id,
+                "init": self.init,
+                "private": self.is_private,
+                "index": self.index,
+                "notes": self.notes,
+                "effects": [e.to_dict() for e in self._effects],
+                "group_id": self._group_id,
+                "type": self.type.value,
+                "id": self.id,
+            }
+        )
         return d
 
     @property
@@ -304,6 +306,7 @@ class Combatant(BaseCombatant, StatBlock):
         else:
             c_group = self.combat.get_group(group_name, create=self.init)
             c_group.add_combatant(self)
+            self.combat.sort_combatants()
             if was_current:
                 self.combat.goto_turn(self, True)
             return c_group

--- a/cogs5e/initiative/group.py
+++ b/cogs5e/initiative/group.py
@@ -74,9 +74,11 @@ class CombatantGroup(Combatant):
 
     @property
     def init_skill(self):
-        # groups: return the first one's skill if present, otherwise +0
-        
-        if len(self._combatants) > 0 and self._combatants[0].init_skill:
+        # groups: if all combatants are the same type, return the first one's skill, otherwise +0
+        if (
+            all(c.type == CombatantType.MONSTER for c in self._combatants)
+            and len(set(c.monster_name for c in self._combatants)) == 1
+        ):
             return self._combatants[0].init_skill
         return Skill(0)
 

--- a/cogs5e/initiative/group.py
+++ b/cogs5e/initiative/group.py
@@ -74,11 +74,9 @@ class CombatantGroup(Combatant):
 
     @property
     def init_skill(self):
-        # groups: if all combatants are the same type, return the first one's skill, otherwise +0
-        if (
-            all(c.type == CombatantType.MONSTER for c in self._combatants)
-            and len(set(c.monster_name for c in self._combatants)) == 1
-        ):
+        # groups: return the first one's skill if present, otherwise +0
+        
+        if len(self._combatants) > 0 and self._combatants[0].init_skill:
             return self._combatants[0].init_skill
         return Skill(0)
 

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -61,29 +61,32 @@ def run_check(skill_key, caster, args, embed):
 
     # ieffect handling
     if isinstance(caster, init.Combatant):
-        combat_context: dict[str, Any] = {}
-
-        # -cb
-        combat_context["b"] = caster.active_effects(mapper=lambda effect: effect.effects.check_bonus, default=[])
-
-        # -cadv/cdis
-        cadv_effects = caster.active_effects(
-            mapper=lambda effect: effect.effects.check_adv, reducer=lambda checks: set().union(*checks), default=set()
-        )
-        cdis_effects = caster.active_effects(
-            mapper=lambda effect: effect.effects.check_dis, reducer=lambda checks: set().union(*checks), default=set()
-        )
-        if skill_key in cadv_effects or base_ability_key in cadv_effects:
-            combat_context["adv"] = ["True"]
-        if skill_key in cdis_effects or base_ability_key in cdis_effects:
-            combat_context["dis"] = ["True"]
-
-        args.add_context("combat", combat_context)
-        args.set_context("combat")
+        args = ieffect_handler(caster, args, skill_key)
 
     result = _run_common(skill, args, embed, mod_override=mod)
     return CheckResult(rolls=result.rolls, skill=skill, skill_name=skill_name, skill_roll_result=result)
 
+def ieffect_handler(caster, args, skill_key):
+    combat_context: dict[str, Any] = {}
+    base_ability_key = SKILL_MAP[skill_key]
+    # -cb
+    combat_context["b"] = caster.active_effects(mapper=lambda effect: effect.effects.check_bonus, default=[])
+
+    # -cadv/cdis
+    cadv_effects = caster.active_effects(
+        mapper=lambda effect: effect.effects.check_adv, reducer=lambda checks: set().union(*checks), default=set()
+    )
+    cdis_effects = caster.active_effects(
+        mapper=lambda effect: effect.effects.check_dis, reducer=lambda checks: set().union(*checks), default=set()
+    )
+    if skill_key in cadv_effects or base_ability_key in cadv_effects:
+        combat_context["adv"] = ["True"]
+    if skill_key in cdis_effects or base_ability_key in cdis_effects:
+        combat_context["dis"] = ["True"]
+
+    args.add_context("combat", combat_context)
+    args.set_context("combat")
+    return args
 
 def run_save(save_key, caster, args, embed):
     """

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -66,6 +66,7 @@ def run_check(skill_key, caster, args, embed):
     result = _run_common(skill, args, embed, mod_override=mod)
     return CheckResult(rolls=result.rolls, skill=skill, skill_name=skill_name, skill_roll_result=result)
 
+
 def ieffect_handler(caster, args, skill_key):
     combat_context: dict[str, Any] = {}
     base_ability_key = SKILL_MAP[skill_key]
@@ -87,6 +88,7 @@ def ieffect_handler(caster, args, skill_key):
     args.add_context("combat", combat_context)
     args.set_context("combat")
     return args
+
 
 def run_save(save_key, caster, args, embed):
     """


### PR DESCRIPTION
### Summary
AFR-1087 Use init skill of first combatant in a group to avoid resorting of init when adding combatants to groups

### Changelog Entry
AFR-1087 Use init skill of first combatant in a group to avoid resorting of init when adding combatants to groups

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
