### PR TITLE
Avr 1020 monk ability version filtering

### DIFF
--- a/cogs5e/sheets/utils.py
+++ b/cogs5e/sheets/utils.py
@@ -3,8 +3,6 @@ import re
 
 from cogs5e.models.sheet.action import Action
 from gamedata import compendium
-from utils.settings.guild import ServerSettings
-from cogs5e.models.character import Character
 
 
 # ==== Name => Action Discovery ====
@@ -122,10 +120,7 @@ async def resolve_version_context(ctx) -> str:
     
     try:
         # Get server settings
-        if hasattr(ctx, 'get_server_settings'):
-            serv_settings = await ctx.get_server_settings() if ctx.guild else None
-        else:
-            serv_settings = await ServerSettings.for_guild(mdb=ctx.bot.mdb, guild_id=ctx.guild.id)
+        serv_settings = await ctx.get_server_settings() if ctx.guild else None
         
         if serv_settings:
             version = serv_settings.version
@@ -133,10 +128,7 @@ async def resolve_version_context(ctx) -> str:
         # Check if character override is allowed
         if serv_settings and serv_settings.allow_character_override or not serv_settings:
             try:
-                if hasattr(ctx, 'get_character'):
-                    character = await ctx.get_character()
-                else:
-                    character = await Character.from_ctx(ctx)
+                character = await ctx.get_character()
                 
                 if character.options.version:
                     version = character.options.version


### PR DESCRIPTION
## Summary
   Fixes monk abilities randomly requiring "Ki Points" (D&D 2014) vs "Focus Points" (D&D 2024) due to action discovery not filtering by D&D rules version. Uses the server settings to decide instead of guessing.

   ## Changelog Entry
   Fix monk abilities version filtering for D&D 2014/2024 compatibility (AVR-1020)

   ## PR Type
   - [x] Bug fix (non-breaking change which fixes an issue)

   ## Breaking Change
   - [x] No breaking changes

   ## Testing
   - [x] Unit tests pass (63/63)
   - [x] Sheet manager tests pass (45/48, failures unrelated)
   - [x] Syntax validation complete
   - [x] Backward compatible

   ## Changes Made
   - Enhanced core action discovery system to filter by D&D rules version
   - Updated all sheet processors (D&D Beyond, Dicecloud, DicecloudV2, Google Sheets)

   Closes AVR-1020