### PR TITLE
fix: upgrade .strip("<>{}") to .replace

### DIFF
--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -232,7 +232,7 @@ class AutomationContext:
 
         original_names = self.evaluator.builtins.copy()
         self.evaluator.builtins.update(self.metavars)
-        expr = annostr.strip("{}")
+        expr = annostr.replace("{", "").replace("}", "")
         try:
             out = self.evaluator.eval(expr)
         except Exception as ex:

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -330,7 +330,7 @@ class Character(StatBlock):
         """Evaluates a cvar expression in a MathEvaluator.
         :param varstr - the expression to evaluate.
         :returns int - the value of the expression."""
-        varstr = str(varstr).strip("<>{}")
+        varstr = str(varstr).replace("<", "").replace(">", "").replace("{", "").replace("}", "")
         evaluator = aliasing.evaluators.MathEvaluator.with_character(self)
 
         try:

--- a/cogs5e/models/sheet/attack.py
+++ b/cogs5e/models/sheet/attack.py
@@ -265,7 +265,8 @@ def old_to_automation(bonus: str | None = None, damage: str | None = None, detai
 
     if bonus:
         hit = [damage] if damage else []
-        attack_eff = [automation.Attack(hit=hit, miss=[], attackBonus=str(bonus).strip("{}<>"))]
+        sanitized_attack_bonus = str(bonus).replace("{", "").replace("}", "").replace("<", "").replace(">", "")
+        attack_eff = [automation.Attack(hit=hit, miss=[], attackBonus=sanitized_attack_bonus)]
     else:
         attack_eff = [damage] if damage else []
 


### PR DESCRIPTION
- fixes issues with multiple vars like: `{strengthMod}+{proficiencyBonus}`

### Summary
This fixes the issue brought up on [discord here](https://discord.com/channels/269275778867396608/795769081282297928/1401962233638031390). 

### Changelog Entry
Fixed attack bonus parsing for expressions with multiple bonus variables

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
