### PR TITLE
feat: allow file uploads for cvar, uvar, and svar

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -888,6 +888,7 @@ class Customization(commands.Cog):
     @commands.group(invoke_without_command=True)
     async def cvar(self, ctx, name: str = None, *, value=None):
         """Commands to manage character variables for use in snippets and aliases.
+        Attach a UTF-8 file instead of a value to set the character variable to the file's contents.
         See the [aliasing guide](https://avrae.io/cheatsheets/aliasing) for more help."""
         if name is None:
             return await self.list_cvar(ctx)
@@ -961,6 +962,7 @@ class Customization(commands.Cog):
         Commands to manage user variables for use in snippets and aliases.
         User variables can be called in the `-phrase` tag by surrounding the variable name with `{}` (calculates) or `<>` (prints).
         Arguments surrounded with `{{}}` will be evaluated as a custom script.
+        Attach a UTF-8 file instead of a value to set the user variable to the file's contents.
         See https://avrae.io/cheatsheets/aliasing for more help."""
         if name is None:
             return await self.uvar_list(ctx)
@@ -1026,6 +1028,8 @@ class Customization(commands.Cog):
         must be explicitly retrieved in an alias, and are read-only.
 
         These are usually used to set server-wide defaults for aliases without editing the code.
+
+        Attach a UTF-8 file instead of a value to set the server variable to the file's contents.
 
         See https://avrae.io/cheatsheets/aliasing for more help.
         """

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -1263,7 +1263,10 @@ async def read_file_from_message(ctx, size_limit):
     if attached_file.size > size_limit:
         raise InvalidArgument(f"This file upload must be smaller than {size_limit} bytes.")
     file_bytes = await attached_file.read()
-    return file_bytes.decode("utf-8")
+    try:
+        return file_bytes.decode("utf-8")
+    except UnicodeError as e:
+        raise InvalidArgument("Uploaded file must be text in utf-8 format") from e
 
 
 def setup(bot):

--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -1261,7 +1261,7 @@ async def read_file_from_message(ctx, size_limit):
     """Takes a given message, pulls the first attachment, and returns the read string in utf-8 format"""
     attached_file = ctx.message.attachments[0]
     if attached_file.size > size_limit:
-        raise InvalidArgument(f"This file upload must be smaller than {size_limit} bytes.")
+        raise InvalidArgument(f"This file upload must not exceed {size_limit} bytes.")
     file_bytes = await attached_file.read()
     try:
         return file_bytes.decode("utf-8")


### PR DESCRIPTION
### Summary
Read file attachments if no value is provided so that longer variables than a discord message can be set. Avrae already provides longer variables as a text file anyways, so this just allows full support in both directions.

### Changelog Entry
`!cvar`, `!uvar`, and `!svar` now support reading file attachments

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
