### PR TITLE
feat: add option to hide ieffect

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -425,6 +425,7 @@ class SimpleCombatant(AliasStatBlock):
         attacks: list[dict] = None,
         buttons: list[dict] = None,
         tick_on_combatant_id: str = None,
+        hidden: bool = False,
     ):
         """
         Adds an effect to the combatant. Returns the added effect.
@@ -450,6 +451,7 @@ class SimpleCombatant(AliasStatBlock):
         :param attacks: The attacks granted by this effect. See :ref:`ieffectargs`.
         :param buttons: The buttons granted by this effect. See :ref:`ieffectargs`.
         :param tick_on_combatant_id: The ID of the combatant whose turn the effect duration ticks on (defaults to the combatant who the effect is on).
+        :param bool hidden: Whether the effect should be hidden in combat displays.
         :rtype: :class:`~aliasing.api.combat.SimpleEffect`
         """  # noqa: E501
         # validate types
@@ -469,6 +471,8 @@ class SimpleCombatant(AliasStatBlock):
             desc = str(desc)
         if tick_on_combatant_id is not None:
             tick_on_combatant_id = str(tick_on_combatant_id)
+        if hidden is not None:
+            hidden = bool(hidden)
 
         # parse v4.1 models (passive, attacks, buttons)
         parsed_passive = parsed_attacks = parsed_buttons = None
@@ -511,6 +515,7 @@ class SimpleCombatant(AliasStatBlock):
             attacks=parsed_attacks,
             buttons=parsed_buttons,
             tick_on_combatant_id=tick_on_combatant_id,
+            hidden=hidden,
         )
         if parent:
             effect_obj.set_parent(parent._effect)

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -992,6 +992,7 @@ class InitTracker(commands.Cog):
         `-ac <ac>` - modifies ac temporarily; adds if starts with +/- or sets otherwise.
         `-maxhp <hp>` - modifies maximum hp temporarily; adds if starts with +/- or sets otherwise.
         `-desc <description>` - Adds a description of the effect.
+        `-h` - Hides the effect description and modifiers in combat displays. Shows effect name, duration, and concentration if applicable.
         """  # noqa: E501
         combat = await ctx.get_combat()
         args = argparse(args)
@@ -1026,6 +1027,7 @@ class InitTracker(commands.Cog):
         end = args.last("end", False, bool)
         parent = args.last("parent")
         desc = args.last("desc")
+        hidden = args.last("h", False, bool)
 
         if parent is not None:
             parent = parent.split("|", 1)
@@ -1051,6 +1053,7 @@ class InitTracker(commands.Cog):
                     concentration=conc,
                     desc=desc,
                     tick_on_combatant_id=tick_on_combatant_id,
+                    hidden=hidden,
                 )
                 result = combatant.add_effect(effect_obj)
                 if parent:

--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -460,7 +460,11 @@ class Combatant(BaseCombatant, StatBlock):
         resists = self._get_resist_string(private) if resistances else ""
         note_str = "\n# " + self.notes if self.notes and notes else ""
         effects = self._get_long_effects(
-            duration=duration, parenthetical=parenthetical, concentration=concentration, description=description
+            private=private,
+            duration=duration,
+            parenthetical=parenthetical,
+            concentration=concentration,
+            description=description,
         )
         return f"{name} {hp_ac} {resists}{note_str}\n{effects}".strip()
 
@@ -478,8 +482,15 @@ class Combatant(BaseCombatant, StatBlock):
         except Exception as e:
             raise InvalidArgument(f"Cannot evaluate `{varstr}`: {e}")
 
-    def _get_long_effects(self, **kwargs) -> str:
-        return "\n".join(f"* {e.get_str(**kwargs)}" for e in self.get_effects())
+    def _get_long_effects(self, private=False, **kwargs) -> str:
+        # Remove parenthetical and description from kwargs to avoid conflicts
+        kwargs.pop("parenthetical", None)
+        kwargs.pop("description", None)
+
+        return "\n".join(
+            f"* {e.get_str(description=private or not e.hidden, parenthetical=private or not e.hidden, **kwargs)}"
+            for e in self.get_effects()
+        )
 
     def _get_effects_and_notes(self) -> str:
         out = []

--- a/cogs5e/initiative/effects/effect.py
+++ b/cogs5e/initiative/effects/effect.py
@@ -49,6 +49,7 @@ class InitiativeEffect:
         parent: Optional[InitEffectReference] = None,
         desc: str = None,
         tick_on_combatant_id: Optional[str] = None,
+        hidden: bool = False,
     ):
         if effects is None:
             effects = InitPassiveEffect()
@@ -80,6 +81,7 @@ class InitiativeEffect:
         self.parent = parent
         self.desc = desc
         self.tick_on_combatant_id = tick_on_combatant_id
+        self.hidden = bool(hidden)
 
     @classmethod
     def new(
@@ -97,6 +99,7 @@ class InitiativeEffect:
         attacks: list[AttackInteraction] = None,
         buttons: list[ButtonInteraction] = None,
         tick_on_combatant_id: Optional[str] = None,
+        hidden: bool = False,
     ):
         # either parse effect_args or passive_effects/attacks
         if effect_args is not None and (passive_effects is not None or attacks is not None):
@@ -160,6 +163,7 @@ class InitiativeEffect:
             concentration=concentration,
             desc=desc,
             tick_on_combatant_id=tick_on_combatant_id,
+            hidden=hidden,
         )
 
     @classmethod
@@ -193,6 +197,7 @@ class InitiativeEffect:
             parent=parent,
             desc=d["desc"],
             tick_on_combatant_id=d.get("tick_on_combatant_id"),
+            hidden=d.get("hidden", False),
         )
 
     def to_dict(self):
@@ -215,6 +220,7 @@ class InitiativeEffect:
             "parent": parent,
             "desc": self.desc,
             "tick_on_combatant_id": self.tick_on_combatant_id,
+            "hidden": self.hidden,
             "_v": 2,
         }
 
@@ -250,23 +256,28 @@ class InitiativeEffect:
 
     # --- stringification ---
     def __str__(self):
-        return self.get_str(duration=True, parenthetical=True, concentration=True, description=True)
+        return self.get_str(duration=True, parenthetical=True, concentration=True, description=True, hidden=True)
 
     def get_short_str(self) -> str:
         """Gets a short string describing the effect (for display in init summary)"""
-        return self.get_str(duration=True, parenthetical=False, concentration=False, description=False)
+        return self.get_str(duration=True, parenthetical=False, concentration=False, description=False, hidden=False)
 
-    def get_str(self, duration=True, parenthetical=True, concentration=True, description=True) -> str:
+    def get_str(self, duration=True, parenthetical=True, concentration=True, description=True, hidden=True) -> str:
         """More customizable as to what actually shows."""
+
         out = [self.name]
         if duration:
             the_duration = self._duration_str()
             if the_duration:
                 out.append(the_duration)
         if parenthetical:
-            out.append(self._parenthetical_str())
+            parenthetical_str = self._parenthetical_str()
+            if parenthetical_str:
+                out.append(parenthetical_str)
         if concentration and self.concentration:
             out.append("<C>")
+        if hidden and self.hidden:
+            out.append("<Hidden>")
         if description and self.desc:
             out.append(f"\n - {self.desc}")
         return " ".join(out).strip()

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -28,6 +28,7 @@ class LegacyIEffect(Effect):
         stacking: bool = False,
         save_as: str = None,
         parent: str = None,
+        hidden: bool = False,
         **kwargs,
     ):
         super().__init__("ieffect", **kwargs)
@@ -40,6 +41,7 @@ class LegacyIEffect(Effect):
         self.stacking = stacking
         self.save_as = save_as
         self.parent = parent
+        self.hidden = hidden
 
     def to_dict(self):
         out = super().to_dict()
@@ -53,6 +55,7 @@ class LegacyIEffect(Effect):
             "stacking": self.stacking,
             "save_as": self.save_as,
             "parent": self.parent,
+            "hidden": self.hidden,
         })
         return out
 
@@ -91,6 +94,7 @@ class LegacyIEffect(Effect):
                 end_on_turn_end=self.tick_on_end,
                 concentration=self.concentration,
                 desc=desc,
+                hidden=self.hidden,
             )
             conc_parent = None
             stack_parent = None
@@ -113,6 +117,7 @@ class LegacyIEffect(Effect):
                     combatant=autoctx.target.target,
                     name=new_name,
                     effect_args=effect_args,
+                    hidden=self.hidden,
                 )
 
             # parenting
@@ -131,7 +136,8 @@ class LegacyIEffect(Effect):
 
             # add
             effect_result = autoctx.target.target.add_effect(effect)
-            autoctx.queue(f"**Effect**: {effect.get_str(description=False)}")
+            is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
+            autoctx.queue(f"**Effect**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}")
             if conc_conflict := effect_result["conc_conflict"]:
                 autoctx.queue(f"**Concentration**: dropped {', '.join([e.name for e in conc_conflict])}")
 
@@ -148,8 +154,10 @@ class LegacyIEffect(Effect):
                 end_on_turn_end=self.tick_on_end,
                 concentration=self.concentration,
                 desc=desc,
+                hidden=self.hidden,
             )
-            autoctx.queue(f"**Effect**: {effect.get_str(description=False)}")
+            is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
+            autoctx.queue(f"**Effect**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}")
 
         return IEffectResult(effect=effect, conc_conflict=conc_conflict)
 
@@ -174,6 +182,7 @@ class IEffect(Effect):
         parent: str = None,
         target_self: bool = False,
         tick_on_caster: bool = False,
+        hidden: bool = False,
         **kwargs,
     ):
         if attacks is None:
@@ -194,6 +203,7 @@ class IEffect(Effect):
         self.parent = parent
         self.target_self = target_self
         self.tick_on_caster = tick_on_caster
+        self.hidden = hidden
 
     @classmethod
     def from_data(cls, data):
@@ -222,6 +232,7 @@ class IEffect(Effect):
             "parent": self.parent,
             "target_self": self.target_self,
             "tick_on_caster": self.tick_on_caster,
+            "hidden": self.hidden,
         })
         return out
 
@@ -287,6 +298,7 @@ class IEffect(Effect):
                 concentration=self.concentration,
                 desc=desc,
                 tick_on_combatant_id=tick_on_combatant_id,
+                hidden=self.hidden,
             )
             conc_parent = None
             stack_parent = None
@@ -310,6 +322,7 @@ class IEffect(Effect):
                     combatant=combatant,
                     name=new_name,
                     passive_effects=effects,
+                    hidden=self.hidden,
                 )
 
             # parenting
@@ -340,7 +353,10 @@ class IEffect(Effect):
 
             # add
             effect_result = combatant.add_effect(effect)
-            autoctx.queue(f"**Effect{effect_target}**: {effect.get_str(description=False)}")
+            is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
+            autoctx.queue(
+                f"**Effect{effect_target}**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}"
+            )
             if conc_conflict := effect_result["conc_conflict"]:
                 autoctx.queue(f"**Concentration{effect_target}**: dropped {', '.join([e.name for e in conc_conflict])}")
 
@@ -360,7 +376,10 @@ class IEffect(Effect):
                 concentration=self.concentration,
                 desc=desc,
             )
-            autoctx.queue(f"**Effect{effect_target}**: {effect.get_str(description=False)}")
+            is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
+            autoctx.queue(
+                f"**Effect{effect_target}**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}"
+            )
 
         return IEffectResult(effect=effect, conc_conflict=conc_conflict)
 

--- a/cogs5e/utils/actionutils.py
+++ b/cogs5e/utils/actionutils.py
@@ -38,7 +38,9 @@ async def run_attack(
     """
     Runs an attack: adds title, handles -f and -thumb args, commits combat, runs automation, edits embed.
     """
-    if not args.last("h", type_=bool):
+    ieffect = getattr(attack, "__run_automation_kwargs__", {}).get("ieffect")
+    is_hidden = args.last("h", type_=bool) or (ieffect and ieffect.hidden)
+    if not is_hidden:
         name = caster.get_title_name()
     else:
         name = "An unknown creature"

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -295,6 +295,7 @@ IEffect
         parent?: string;
         target_self?: boolean;
         tick_on_caster?: boolean;
+        hidden?: boolean;
     }
 
 Adds an InitTracker Effect to a targeted creature, if the automation target is in combat.
@@ -385,6 +386,11 @@ It must be inside a Target effect.
         *caster's* next turn, rather than the *target's*.
 
         If the caster is not in combat, this has no effect.
+
+    .. attribute:: hidden
+
+        *optional, default false* - If true, the effect's stat bonuses and description will be hidden in combat 
+        displays while still showing the effect name and duration.
 
 **Variables**
 

--- a/tests/unit/hidden_effects_test.py
+++ b/tests/unit/hidden_effects_test.py
@@ -1,0 +1,282 @@
+"""
+Hidden Effects Tests
+"""
+
+import unittest
+
+from cogs5e.initiative.effects.effect import InitiativeEffect
+
+
+class TestHiddenEffects(unittest.TestCase):
+
+    def test_hidden_effect_creation(self):
+        """Test hidden=True creates hidden effect"""
+        effect = InitiativeEffect.new(None, None, "Test Effect", hidden=True)
+        self.assertTrue(effect.hidden)
+
+    def test_visible_effect_creation_default(self):
+        """Test hidden defaults to False"""
+        effect = InitiativeEffect.new(None, None, "Test Effect")
+        self.assertFalse(effect.hidden)
+
+    def test_hidden_effect_serialization(self):
+        """Test hidden field survives serialization roundtrip"""
+        effect = InitiativeEffect.new(None, None, "Test Effect", hidden=True)
+        data = effect.to_dict()
+        restored = InitiativeEffect.from_dict(data, None, None)
+        self.assertTrue(restored.hidden)
+
+    def test_backwards_compatibility_serialization(self):
+        """Test missing hidden field defaults to False"""
+        effect = InitiativeEffect.new(None, None, "Test Effect", hidden=False)
+        data = effect.to_dict()
+        del data["hidden"]
+        restored = InitiativeEffect.from_dict(data, None, None)
+        self.assertFalse(restored.hidden)
+
+    def test_hidden_effect_with_mechanical_effects(self):
+        """Test hidden effect hides parenthetical mechanics from players"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        effect = InitiativeEffect.new(None, None, "Buff", desc="Secret buff", effect_args="-ac 2", hidden=True)
+
+        # Mock a combatant with the hidden effect
+        combatant = Combatant(
+            ctx=Mock(), combat=Mock(), id="test_id", name="Test", controller_id=12345, init=10, private=False, index=0
+        )
+        combatant._effects = [effect]
+        effect.combatant = combatant
+
+        # Player view should hide details
+        player_display = combatant._get_long_effects(private=False)
+        self.assertIn("Buff", player_display)
+        self.assertNotIn("Secret buff", player_display)
+        self.assertNotIn("AC", player_display)
+
+    def test_hidden_effect_display_hidden(self):
+        """Test hidden effect hides description and parenthetical"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        effect = InitiativeEffect.new(
+            None, None, "Secret Effect", desc="Secret description", duration=5, concentration=True, hidden=True
+        )
+
+        # Mock a combatant with the hidden effect
+        combatant = Combatant(
+            ctx=Mock(), combat=Mock(), id="test_id", name="Test", controller_id=12345, init=10, private=False, index=0
+        )
+        combatant._effects = [effect]
+        effect.combatant = combatant
+
+        # Player view should hide details
+        player_display = combatant._get_long_effects(private=False)
+        self.assertIn("Secret Effect", player_display)
+        self.assertNotIn("Secret description", player_display)
+        # For player view, concentration marker should still show since it's not parenthetical
+        self.assertIn("<C>", player_display)
+
+    def test_hidden_effect_with_duration_only(self):
+        """Test hidden effect shows name only without combat context"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        effect = InitiativeEffect.new(
+            None, None, "Timed Effect", desc="Secret description", duration=3, concentration=False, hidden=True
+        )
+
+        # Mock a combatant with the hidden effect
+        combatant = Combatant(
+            ctx=Mock(), combat=Mock(), id="test_id", name="Test", controller_id=12345, init=10, private=False, index=0
+        )
+        combatant._effects = [effect]
+        effect.combatant = combatant
+
+        # Player view should show name only (no duration without combat context)
+        player_display = combatant._get_long_effects(private=False)
+        self.assertIn("Timed Effect", player_display)
+        self.assertNotIn("Secret description", player_display)
+        # Duration only shows with combat context
+        self.assertNotIn("[3 rounds]", player_display)
+
+    def test_hidden_effect_infinite_vs_timed(self):
+        """Test hidden effect display difference between infinite and timed"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        # Infinite effect (no duration)
+        infinite_effect = InitiativeEffect.new(
+            None, None, "Infinite Effect", desc="Secret description", duration=None, concentration=False, hidden=True
+        )
+
+        # Timed effect (with duration)
+        timed_effect = InitiativeEffect.new(
+            None, None, "Timed Effect", desc="Secret description", duration=3, concentration=False, hidden=True
+        )
+
+        # Mock a combatant with both hidden effects
+        combatant = Combatant(
+            ctx=Mock(), combat=Mock(), id="test_id", name="Test", controller_id=12345, init=10, private=False, index=0
+        )
+        combatant._effects = [infinite_effect, timed_effect]
+        infinite_effect.combatant = combatant
+        timed_effect.combatant = combatant
+
+        # Player view should show names only (no duration without combat context)
+        player_display = combatant._get_long_effects(private=False)
+        self.assertIn("Infinite Effect", player_display)
+        self.assertIn("Timed Effect", player_display)
+        self.assertNotIn("Secret description", player_display)
+        # Duration only shows with combat context
+        self.assertNotIn("[3 rounds]", player_display)
+
+    def test_hidden_effect_with_combat_context(self):
+        """Test hidden effect shows duration but hides description"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        class MockCombat:
+            def __init__(self):
+                self.round_num = 1
+                self.index = 0
+
+        mock_combat = MockCombat()
+
+        timed_effect = InitiativeEffect.new(
+            mock_combat, None, "Timed Effect", desc="Secret description", duration=3, concentration=True, hidden=True
+        )
+
+        # Mock a combatant with the hidden effect
+        combatant = Combatant(
+            ctx=Mock(),
+            combat=mock_combat,
+            id="test_id",
+            name="Test",
+            controller_id=12345,
+            init=10,
+            private=False,
+            index=0,
+        )
+        combatant._effects = [timed_effect]
+        timed_effect.combatant = combatant
+
+        # Player view should show name, duration, and concentration but hide description
+        player_display = combatant._get_long_effects(private=False)
+        self.assertIn("Timed Effect", player_display)
+        self.assertNotIn("Secret description", player_display)
+        self.assertIn("[3 rounds]", player_display)
+        # Concentration marker should still show
+        self.assertIn("<C>", player_display)
+
+    def test_hidden_effect_always_hidden(self):
+        """Test hidden effect is always hidden from players"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        effect = InitiativeEffect.new(None, None, "Secret Effect", desc="Secret description", hidden=True)
+
+        # Mock a combatant with the hidden effect
+        combatant = Combatant(
+            ctx=Mock(), combat=Mock(), id="test_id", name="Test", controller_id=12345, init=10, private=False, index=0
+        )
+        combatant._effects = [effect]
+        effect.combatant = combatant
+
+        # Player view should hide description
+        player_display = combatant._get_long_effects(private=False)
+        self.assertIn("Secret Effect", player_display)
+        self.assertNotIn("Secret description", player_display)
+
+    def test_visible_effect_display_always_shown(self):
+        """Test visible effect always shows everything"""
+        effect = InitiativeEffect.new(
+            None, None, "Public Effect", desc="Public description", duration=5, concentration=True, hidden=False
+        )
+
+        display = effect.get_str()
+
+        # Visible effects show everything
+        self.assertIn("Public description", display)
+        self.assertIn("<C>", display)
+
+    def test_hidden_effect_status_dm_privilege(self):
+        """Test that DMs/controllers can see hidden effect details in status via private param"""
+        from cogs5e.initiative.combatant import Combatant
+        from unittest.mock import Mock
+
+        # Create hidden effect with description
+        effect = InitiativeEffect.new(
+            combat=None, combatant=None, name="Secret Buff", desc="Grants +2 AC and advantage", hidden=True
+        )
+
+        # Mock a combatant with the hidden effect
+        combatant = Combatant(
+            ctx=Mock(), combat=Mock(), id="test_id", name="Test", controller_id=12345, init=10, private=False, index=0
+        )
+        combatant._effects = [effect]
+        effect.combatant = combatant
+
+        # Test normal status (should hide details)
+        normal_status = combatant._get_long_effects(private=False)
+        self.assertIn("Secret Buff", normal_status)
+        self.assertNotIn("Grants +2 AC", normal_status)
+
+        # Test DM status (should show details)
+        dm_status = combatant._get_long_effects(private=True)
+
+        # Debug: Test direct get_str call with explicit override
+        direct_call = effect.get_str(description=True, parenthetical=True)
+        print(f"Direct get_str with override: '{direct_call}'")
+        print(f"DM status output: '{dm_status}'")
+
+        self.assertIn("Secret Buff", dm_status)
+        self.assertIn("Grants +2 AC", dm_status)
+
+
+# Uncomment after PR #15 on automation-common is merged: https://github.com/avrae/automation-common/pull/15
+
+# class TestHiddenEffectsAPIInterface(unittest.TestCase):
+#     """Test hidden effects through automation import/export interface"""
+
+#     def test_hidden_effect_import_export_preservation(self):
+#         """Test hidden field is preserved through full import flow (mimics !a import)"""
+#         from typing import List
+#         import automation_common
+#         from pydantic import parse_obj_as
+#         from cogs5e.models.sheet.attack import AttackList
+
+#         # Create attack JSON with hidden IEffect
+#         attack_json = [{
+#             "_v": 2,
+#             "name": "Test Attack with Hidden Effect",
+#             "automation": [{
+#                 "type": "ieffect2",
+#                 "name": "Hidden Test Effect",
+#                 "hidden": True,
+#                 "duration": 3,
+#                 "desc": "This should be hidden",
+#                 "effects": {"ac_bonus": -2},
+#             }],
+#         }]
+
+#         # Test pydantic validation (now preserves hidden field)
+#         normalized_obj = parse_obj_as(
+#             List[automation_common.validation.models.AttackModel], attack_json, type_name="AttackList"
+#         )
+
+#         # Test round-trip through AttackList
+#         attacks = AttackList.from_dict([atk.dict() for atk in normalized_obj])
+#         attack = attacks[0]
+
+#         # Verify the automation object has the hidden field
+#         automation_effect = attack.automation.effects[0]
+#         self.assertTrue(
+#             automation_effect.hidden,
+#             "Hidden field should be preserved through full import flow with updated pydantic models",
+#         )
+
+#         # Test serialization back to dict
+#         export_dict = attack.to_dict()
+#         ieffect_dict = export_dict["automation"][0]
+#         self.assertTrue(ieffect_dict.get("hidden", False), "Hidden field should be present in exported dict")


### PR DESCRIPTION
### Summary
- only hides effect description and parenthetical
- shows duration, conc, and name for combat context
- also adds automation docs about the new hidden bool for ieffects

<img width="655" height="470" alt="image" src="https://github.com/user-attachments/assets/015ac49c-56c4-4244-a470-a2bc1a78113c" />

### Changelog Entry
added option to hide user-added init effect's description and modifiers

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
