### PR TITLE
docs: add documentation for the Elemental Weapon and Destructive Wave `-choice` options

### DIFF
--- a/docs/cheatsheets/automation_quirks.rst
+++ b/docs/cheatsheets/automation_quirks.rst
@@ -73,6 +73,16 @@ You can specify the type of damage you want to apply with the ``-choice`` argume
 
 In this case, it does not check against a value, but instead just inputs whatever is given. This means you can technically give someone Pizza Breath with ``-choice pizza``.
 
+Elemental Weapon
+-----------------
+You can specify the type of elemental damage you want to apply with the ``-choice`` argument.
+
+* ``-choice acid`` for Acid damage
+* ``-choice cold`` for Cold damage
+* ``-choice fire`` for Fire damage
+* ``-choice lightning`` for Lightning damage
+* ``-choice thunder`` for Thunder damage
+
 Eldritch Blast
 -----------------
 Eldritch Blast has a number of Eldritch Invocations that can affect it. You can add these to your ``invocations`` cvar to have them automatically applied when you cast Eldritch Blast.

--- a/docs/cheatsheets/automation_quirks.rst
+++ b/docs/cheatsheets/automation_quirks.rst
@@ -67,6 +67,13 @@ You can specify the type of damage you want to apply with the ``-choice`` argume
 
 You can also set a default damage type using the ``ChromaticOrbDType`` cvar (e.g., ``!cvar ChromaticOrbDType fire``). The cvar will be used if no ``-choice`` is provided at cast time. If neither is provided, it will do [chromatic] damage by default.
 
+Destructive Wave
+-----------------
+You can specify the type of additional damage you want to apply with the ``-choice`` argument.
+
+* ``-choice necrotic`` for Necrotic damage
+* No choice or any other value defaults to Radiant damage
+
 Dragon's Breath
 -----------------
 You can specify the type of damage you want to apply with the ``-choice`` argument. If a choice is *not* provided at cast time, it will do [chromatic] damage by default, and you will need to use ``-choice [element]`` to specify the damage type each time the breath attack is used, and adjustments may be required to the targets health, depending on resistances.


### PR DESCRIPTION
### Summary
Update the [Additional Automation Support](https://avrae.readthedocs.io/en/stable/cheatsheets/automation_quirks.html) page to include the new `-choice` options added to Elemental Weapon and Destructive Wave.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
