### PR TITLE
Add `-tickon` parameter in !i effect to support tick_on_combatant_id

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -1010,15 +1010,16 @@ class InitTracker(commands.Cog):
             else:
                 targets.append(target)
 
-        tickon = None
-
-        for t in [target_name] + args.get("tickon")[-1:]:
+        tick_on_combatant_id = None
+        tickon_arg = args.last("tickon")
+        if tickon_arg:
             tickon = await combat.select_combatant(
                 ctx,
-                t,
+                tickon_arg,
                 f"Pick the combatant in whose turn this effect timer would tick.",
                 select_group=False,
             )
+            tick_on_combatant_id = tickon.id
 
         duration = args.last("dur", -1, int)
         conc = args.last("conc", False, bool)
@@ -1049,7 +1050,7 @@ class InitTracker(commands.Cog):
                     end_on_turn_end=end,
                     concentration=conc,
                     desc=desc,
-                    tick_on_combatant_id=tickon.id,
+                    tick_on_combatant_id=tick_on_combatant_id,
                 )
                 result = combatant.add_effect(effect_obj)
                 if parent:


### PR DESCRIPTION
### Summary
Even though `InitiativeEffect` has the `tick_on_combatant_id` argument to specify when an effect timer would tick (as seen in https://github.com/avrae/avrae/blob/nightly/cogs5e/initiative/effects/effect.py#L99), it is not yet included as one of the parameters in `!i effect` command.

This PR adds the `-tickon <combatant>` additional argument to `!i effect` to support that use case.

### Changelog Entry
Add `-tickon <combatant>` argument to `!i effect`

### Checklist
#### PR Type
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
