### PR TITLE
Adding workflows to manually rollback ECS task's if failed deploy

### DIFF
--- a/.github/workflows/rollback-ecs-live.yml
+++ b/.github/workflows/rollback-ecs-live.yml
@@ -31,7 +31,7 @@ jobs:
               name: Get current task definition
               run: |
                 TASK_DEF=$(aws ecs describe-services \
-                --cluster "$ECS_CLUSTER" \
+                --cluster "$CLUSTER_NAME" \
                 --services "$SERVICE_NAME" \
                 --query "services[0].taskDefinition" \
                 --output text)
@@ -53,6 +53,6 @@ jobs:
             - name: Update ECS Service to rollback revision
               run: |
                 aws ecs update-service \
-                --cluster "$ECS_CLUSTER" \
+                --cluster "$CLUSTER_NAME" \
                 --service "$SERVICE_NAME" \
                 --task-definition "${{ steps.rollback-taskdef.outputs.rollback }}"

--- a/.github/workflows/rollback-ecs-live.yml
+++ b/.github/workflows/rollback-ecs-live.yml
@@ -6,10 +6,13 @@ on:
             revision:
                 description: 'Task definition revision number (leave blank to use previous one)'
                 required: false
+            environment:
+                description: 'ECS environment (live or nightly)'
+                required: true
 
 env:
     CLUSTER_NAME: avrae-live
-    SERVICE_NAME: avrae-bot
+    SERVICE_NAME: ${{ github.event.inputs.environment == 'live' && 'avrae-bot' || 'avrae-bot-nightly' }}
     REGION: us-east-1
 
 jobs:

--- a/.github/workflows/rollback-ecs-live.yml
+++ b/.github/workflows/rollback-ecs-live.yml
@@ -1,0 +1,58 @@
+name: Rollback Avrae to prior version
+
+on:
+    workflow_dispatch:
+        inputs:
+            revision:
+                description: 'Task definition revision number (leave blank to use previous one)'
+                required: false
+
+env:
+    CLUSTER_NAME: avrae-live
+    SERVICE_NAME: avrae-bot
+    REGION: us-east-1
+
+jobs:
+    rollback:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+
+        steps:
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.AVRAE_GITHUB_OIDC_ROLE_ARN }}
+                  role-session-name: "avrae-avrae-deploy-live"
+                  aws-region: ${{ env.REGION }}
+
+            - id: get-taskdef
+              name: Get current task definition
+              run: |
+                TASK_DEF=$(aws ecs describe-services \
+                --cluster "$ECS_CLUSTER" \
+                --services "$SERVICE_NAME" \
+                --query "services[0].taskDefinition" \
+                --output text)
+                echo "taskdef=$TASK_DEF" >> $GITHUB_OUTPUT
+
+            - id: rollback-taskdef
+              name: Derive rollback revision
+              run: |
+                BASE=$(echo "${{ steps.get-taskdef.outputs.taskdef }}" | cut -d: -f1-2)
+                if [ -n "${{ github.event.inputs.revision }}" ]; then
+                  ROLLBACK="$BASE:${{ github.event.inputs.revision }}"
+                else
+                  CURR_REV=$(echo "${{ steps.get-taskdef.outputs.taskdef }}" | cut -d: -f3)
+                  PREV_REV=$((CURR_REV-1))
+                  ROLLBACK="$BASE:$PREV_REV"
+                fi
+                echo "rollback=$ROLLBACK" >> $GITHUB_OUTPUT
+
+            - name: Update ECS Service to rollback revision
+              run: |
+                aws ecs update-service \
+                --cluster "$ECS_CLUSTER" \
+                --service "$SERVICE_NAME" \
+                --task-definition "${{ steps.rollback-taskdef.outputs.rollback }}"

--- a/.github/workflows/rollback-ecs-live.yml
+++ b/.github/workflows/rollback-ecs-live.yml
@@ -1,4 +1,4 @@
-name: Rollback Avrae to prior version
+name: Rollback Live Avrae to prior version
 
 on:
     workflow_dispatch:

--- a/.github/workflows/rollback-ecs-stg.yml
+++ b/.github/workflows/rollback-ecs-stg.yml
@@ -31,7 +31,7 @@ jobs:
               name: Get current task definition
               run: |
                 TASK_DEF=$(aws ecs describe-services \
-                --cluster "$ECS_CLUSTER" \
+                --cluster "$CLUSTER_NAME" \
                 --services "$SERVICE_NAME" \
                 --query "services[0].taskDefinition" \
                 --output text)
@@ -53,6 +53,6 @@ jobs:
             - name: Update ECS Service to rollback revision
               run: |
                 aws ecs update-service \
-                --cluster "$ECS_CLUSTER" \
+                --cluster "$CLUSTER_NAME" \
                 --service "$SERVICE_NAME" \
                 --task-definition "${{ steps.rollback-taskdef.outputs.rollback }}"

--- a/.github/workflows/rollback-ecs-stg.yml
+++ b/.github/workflows/rollback-ecs-stg.yml
@@ -1,4 +1,4 @@
-name: Rollback Avrae to prior version
+name: Rollback Staging Avrae to prior version
 
 on:
     workflow_dispatch:

--- a/.github/workflows/rollback-ecs-stg.yml
+++ b/.github/workflows/rollback-ecs-stg.yml
@@ -1,0 +1,58 @@
+name: Rollback Avrae to prior version
+
+on:
+    workflow_dispatch:
+        inputs:
+            revision:
+                description: 'Task definition revision number (leave blank to use previous one)'
+                required: false
+
+env:
+    CLUSTER_NAME: avrae-stg
+    SERVICE_NAME: avrae-bot
+    REGION: us-east-2
+
+jobs:
+    rollback:
+        runs-on: ubuntu-latest
+        permissions:
+            id-token: write
+            contents: read
+
+        steps:
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.AVRAE_GITHUB_OIDC_ROLE_ARN }}
+                  role-session-name: "avrae-avrae-deploy-live"
+                  aws-region: ${{ env.REGION }}
+
+            - id: get-taskdef
+              name: Get current task definition
+              run: |
+                TASK_DEF=$(aws ecs describe-services \
+                --cluster "$ECS_CLUSTER" \
+                --services "$SERVICE_NAME" \
+                --query "services[0].taskDefinition" \
+                --output text)
+                echo "taskdef=$TASK_DEF" >> $GITHUB_OUTPUT
+
+            - id: rollback-taskdef
+              name: Derive rollback revision
+              run: |
+                BASE=$(echo "${{ steps.get-taskdef.outputs.taskdef }}" | cut -d: -f1-2)
+                if [ -n "${{ github.event.inputs.revision }}" ]; then
+                  ROLLBACK="$BASE:${{ github.event.inputs.revision }}"
+                else
+                  CURR_REV=$(echo "${{ steps.get-taskdef.outputs.taskdef }}" | cut -d: -f3)
+                  PREV_REV=$((CURR_REV-1))
+                  ROLLBACK="$BASE:$PREV_REV"
+                fi
+                echo "rollback=$ROLLBACK" >> $GITHUB_OUTPUT
+
+            - name: Update ECS Service to rollback revision
+              run: |
+                aws ecs update-service \
+                --cluster "$ECS_CLUSTER" \
+                --service "$SERVICE_NAME" \
+                --task-definition "${{ steps.rollback-taskdef.outputs.rollback }}"

--- a/.github/workflows/rollback-ecs-stg.yml
+++ b/.github/workflows/rollback-ecs-stg.yml
@@ -24,7 +24,7 @@ jobs:
               uses: aws-actions/configure-aws-credentials@v4
               with:
                   role-to-assume: ${{ secrets.AVRAE_GITHUB_OIDC_ROLE_ARN }}
-                  role-session-name: "avrae-avrae-deploy-live"
+                  role-session-name: "avrae-avrae-deploy-stg"
                   aws-region: ${{ env.REGION }}
 
             - id: get-taskdef


### PR DESCRIPTION
### Summary
This pull request introduces two new GitHub Actions workflows for rolling back the Avrae ECS service to a previous task definition revision in both the live and staging environments. These workflows provide a manual way to quickly revert deployments by either specifying a revision or using the previous one by default.

### Changelog Entry
Added GitHub Actions workflows to enable manual ECS service rollbacks for live and staging environments.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
[ ] This PR is a code change that implements a feature request.
[ ] This PR fixes an issue.
[X] This PR adds a new feature that is not an open feature request.
[ ] This PR is not a code change (e.g. documentation, README, ...)

#### Other
[ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
[ ] If code changes were made then they have been tested.
[ ] I have updated the documentation to reflect the changes.