### PR TITLE
fix: unify beyond sheet duplicate handling for compendium and homebrew spells

### DIFF
--- a/cogs5e/sheets/beyond.py
+++ b/cogs5e/sheets/beyond.py
@@ -286,26 +286,24 @@ class BeyondSheetParser(SheetLoaderABC):
                 spell_info = SpellbookSpell.from_spell(
                     result, sab=spell_ab, dc=spell_dc, mod=spell_mod, prepared=spell_prepared
                 )
-                if result.name not in spells:
-                    spells[result.name] = spell_info
-
-                elif spell_prepared:  # prioritize prepared spells
-                    if spells[result.name].prepared:
-                        if spell_info.dc and spells[result.name].dc:
-                            spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.dc)
-                        elif spell_info.sab and spells[result.name].sab:
-                            spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.sab)
-                        elif spell_info.mod and spells[result.name].mod:
-                            spells[result.name] = max(spell_info, spells[result.name], key=lambda x: x.mod)
-
-                    if not spells[result.name].prepared:
-                        spells[result.name] = spell_info
-
             else:
                 spell_info = SpellbookSpell(
                     spell["name"].strip(), sab=spell_ab, dc=spell_dc, mod=spell_mod, prepared=spell_prepared
                 )
+
+            if spell_info.name not in spells:
                 spells[spell_info.name] = spell_info
+            elif spell_prepared:  # prioritize prepared spells
+                if spells[spell_info.name].prepared:
+                    if spell_info.dc and spells[spell_info.name].dc:
+                        spells[spell_info.name] = max(spell_info, spells[spell_info.name], key=lambda x: x.dc)
+                    elif spell_info.sab and spells[spell_info.name].sab:
+                        spells[spell_info.name] = max(spell_info, spells[spell_info.name], key=lambda x: x.sab)
+                    elif spell_info.mod and spells[spell_info.name].mod:
+                        spells[spell_info.name] = max(spell_info, spells[spell_info.name], key=lambda x: x.mod)
+
+                if not spells[spell_info.name].prepared:
+                    spells[spell_info.name] = spell_info
 
         spells = list(spells.values())
 


### PR DESCRIPTION
### Summary
Fixed inconsistent spell duplicate handling between compendium and homebrew spells in D&D Beyond imports. Previously, homebrew spells would unconditionally overwrite existing spells with the same name, causing unprepared homebrew versions to replace prepared compedium versions. The fix unifies duplicate handling logic so both spell types follow the same rules for prioritizing prepared spells and comparing spell attack bonuses/DCs.

### Changelog Entry
Fixed homebrew spells incorrectly overwriting prepared compendium spells during D&D Beyond character import.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
