### PR TITLE
fix: break circular import causing incomplete documentation build

### DIFF
--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -10,11 +10,11 @@ import disnake.ext.commands
 import disnake.utils
 import draconic
 
-from cogs5e.models.errors import AvraeException
 from cogs5e.utils.gameutils import parse_coin_args
 from utils import config
 from utils.dice import RerollableStringifier
 from .context import AliasAuthor, AliasChannel, AliasGuild
+from ..errors import AliasException
 from ..utils import ExecutionScope
 from draconic.types import approx_len_of
 
@@ -135,12 +135,6 @@ def safe_range(start, stop=None, step=None):
 
 
 # err()
-class AliasException(AvraeException):
-    def __init__(self, msg, pm_user):
-        super().__init__(msg)
-        self.pm_user = pm_user
-
-
 def err(reason, pm_user=False):
     """
     Stops evaluation of an alias and shows the user an error.

--- a/aliasing/errors.py
+++ b/aliasing/errors.py
@@ -49,3 +49,11 @@ class CollectableRequiresLicenses(AvraeException):
         self.entities = entities
         self.collectable = collectable
         self.has_connected_ddb = has_connected_ddb
+
+
+class AliasException(AvraeException):
+    """Raised when an alias calls err()."""
+
+    def __init__(self, msg, pm_user):
+        super().__init__(msg)
+        self.pm_user = pm_user

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -10,9 +10,14 @@ import draconic
 from disnake.ext.commands import ArgumentParsingError
 
 from aliasing import evaluators
-from aliasing.api.functions import AliasException
 from aliasing.constants import CVAR_SIZE_LIMIT, GVAR_SIZE_LIMIT, SVAR_SIZE_LIMIT, UVAR_SIZE_LIMIT, VAR_NAME_LIMIT
-from aliasing.errors import AliasNameConflict, CollectableNotFound, CollectableRequiresLicenses, EvaluationError
+from aliasing.errors import (
+    AliasException,
+    AliasNameConflict,
+    CollectableNotFound,
+    CollectableRequiresLicenses,
+    EvaluationError,
+)
 from aliasing.personal import Alias, Servalias, Servsnippet, Snippet
 from aliasing.utils import ExecutionScope
 from aliasing.workshop import WorkshopAlias, WorkshopCollection, WorkshopSnippet


### PR DESCRIPTION
### Summary
Moves `AliasException` to `aliasing/errors.py` to break circular import preventing full docs build.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
