### PR TITLE
fix: remove markdownify from bestiary builder trait descriptions

### DIFF
--- a/cogs5e/models/homebrew/bestiary.py
+++ b/cogs5e/models/homebrew/bestiary.py
@@ -427,7 +427,7 @@ def parse_bestiary_builder_traits(data, key):
     attacks = []
     for trait in data[key]:
         name = trait["name"]
-        desc = markdownify(trait["description"]).strip()
+        desc = trait["description"].strip()
         automation = trait["automation"]
 
         if automation is not None:


### PR DESCRIPTION
### Summary
Removes unnecessary `markdownify()` call from Bestiary Builder trait description parsing. Bestiary Builder returns plain text/markdown, while CritterDB returns HTML. This fix ensures trait descriptions from Bestiary Builder are properly displayed without double-processing.

### Changelog Entry
Fixed Bestiary Builder trait descriptions being incorrectly processed through markdownify

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.

