### PR TITLE
feat: add initscore flag to !i madd/meta

### DIFF
--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -116,6 +116,7 @@ class InitTracker(commands.Cog):
         `dyn` - Dynamic initiative; Rerolls all initiatives at the start of a round.
         `turnnotif` - Notifies the controller of the next combatant in initiative.
         `deathdelete` - Disables deleting monsters below 0 hp.
+        `initscore` - Use initiative scores instead of rolling initiative for monsters by default.
         `-name <name>` - Sets a name for the combat instance.
         `norecord` - If the server has opted in to the Natural Language Training project, omit this combat from recording.
         """  # noqa E501
@@ -133,6 +134,8 @@ class InitTracker(commands.Cog):
             options.turnnotif = True
         if "deathdelete" in args:
             options.deathdelete = False
+        if "initscore" in args:
+            options.initscore = True
         norecord = "norecord" in args
 
         temp_summary_msg = await ctx.send("```Awaiting combatants...```")
@@ -246,6 +249,7 @@ class InitTracker(commands.Cog):
         `-group <group>` - Adds the combatant to a group.
         `adv`/`dis` - Give advantage or disadvantage to the initiative roll.
         `-b <condition bonus>` - Adds a bonus to the combatant's initiative roll.
+        `initscore` - Uses the monster's Initiative score instead of rolling. Applies adv/dis as ±5 bonuses.
         `rollhp` - Rolls the monsters HP, instead of using the default value.
         `-hp <hp>` - Sets starting HP.
         `-thp <thp>` - Sets starting THP.
@@ -272,6 +276,9 @@ class InitTracker(commands.Cog):
 
         combat = await ctx.get_combat()
 
+        # Use combat setting as default if initscore flag not explicitly provided
+        initscore = args.last("initscore", combat.options.initscore, bool)
+
         msgs = []
         to_pm = []
 
@@ -288,14 +295,20 @@ class InitTracker(commands.Cog):
                 break
 
             check_roll = None  # to make things happy
-            if p is None:
+            if p is not None:
+                init = int(p)
+            elif initscore:
+                init = 10 + init_skill.value
+                if adv is True:
+                    init += 5
+                elif adv is False:
+                    init -= 5
+            else:
                 if b:
                     check_roll = roll(f"{init_skill.d20(base_adv=adv)}+{b}")
                 else:
                     check_roll = roll(init_skill.d20(base_adv=adv))
                 init = check_roll.total
-            else:
-                init = int(p)
 
             # -controller (#1368)
             if args.last("controller"):
@@ -324,7 +337,19 @@ class InitTracker(commands.Cog):
 
             if group is None:
                 combat.add_combatant(me)
-                msgs.append(f"{name} was added to combat with initiative {check_roll.result if p is None else p}.")
+                if p is not None:
+                    init_display = p
+                elif initscore:
+                    base = 10 + init_skill.value
+                    if adv is True:
+                        init_display = f"{base} + 5 (adv) = {init}"
+                    elif adv is False:
+                        init_display = f"{base} - 5 (dis) = {init}"
+                    else:
+                        init_display = init
+                else:
+                    init_display = check_roll.result if check_roll else init
+                msgs.append(f"{name} was added to combat with initiative {init_display}.")
             else:
                 grp = combat.get_group(group, create=init)
                 grp.add_combatant(me)
@@ -570,6 +595,7 @@ class InitTracker(commands.Cog):
         `dyn` - Dynamic initiative; Rerolls all initiatives at the start of a round.
         `turnnotif` - Notifies the controller of the next combatant in initiative.
         `deathdelete` - Toggles removing monsters below 0 HP.
+        `initscore` - Use initiative scores instead of rolling initiative for monsters by default.
         `-name <name>` - Sets a name for the combat instance.
         `-combatdm <@mention>` - Changes this combat's DM.
         """
@@ -590,6 +616,9 @@ class InitTracker(commands.Cog):
         if args.last("deathdelete", default=False, type_=bool):
             options.deathdelete = not options.deathdelete
             out += f"Monsters at 0 HP will be {'removed' if options.deathdelete else 'left'}.\n"
+        if args.last("initscore", default=False, type_=bool):
+            options.initscore = not options.initscore
+            out += f"Initiative score (static init) turned {'on' if options.initscore else 'off'}.\n"
         if combat_dm := args.last("combatdm"):
             try:
                 member = await commands.MemberConverter().convert(ctx, combat_dm)

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -297,17 +297,14 @@ class InitTracker(commands.Cog):
             check_roll = None  # to make things happy
             if p is not None:
                 init = int(p)
-            elif initscore:
-                init = 10 + init_skill.value
-                if adv is True:
-                    init += 5
-                elif adv is False:
-                    init -= 5
             else:
-                if b:
-                    check_roll = roll(f"{init_skill.d20(base_adv=adv)}+{b}")
+                if initscore:
+                    base_init = 10 + init_skill.value
+                    adv_bonus = 5 if adv is True else -5 if adv is False else 0
+                    roll_str = f"{base_init + adv_bonus}{'+' + b if b else ''}"
                 else:
-                    check_roll = roll(init_skill.d20(base_adv=adv))
+                    roll_str = f"{init_skill.d20(base_adv=adv)}{'+' + b if b else ''}"
+                check_roll = roll(roll_str)
                 init = check_roll.total
 
             # -controller (#1368)
@@ -339,14 +336,6 @@ class InitTracker(commands.Cog):
                 combat.add_combatant(me)
                 if p is not None:
                     init_display = p
-                elif initscore:
-                    base = 10 + init_skill.value
-                    if adv is True:
-                        init_display = f"{base} + 5 (adv) = {init}"
-                    elif adv is False:
-                        init_display = f"{base} - 5 (dis) = {init}"
-                    else:
-                        init_display = init
                 else:
                     init_display = check_roll.result if check_roll else init
                 msgs.append(f"{name} was added to combat with initiative {init_display}.")

--- a/cogs5e/initiative/combat.py
+++ b/cogs5e/initiative/combat.py
@@ -30,6 +30,7 @@ class CombatOptions(BaseModel):
     dynamic: bool = False
     turnnotif: bool = False
     deathdelete: bool = True
+    initscore: bool = False
     name: Optional[str] = None
 
 

--- a/tests/e2e/cogs/initTracker_test.py
+++ b/tests/e2e/cogs/initTracker_test.py
@@ -408,3 +408,135 @@ class TestInitiativeShuffleWithIEffects:
         message_content = match.string
         assert "+ 15" in message_content
         assert "+ 20" not in message_content
+
+
+@pytest.mark.usefixtures("init_fixture", "character")
+class TestInitScoreFeature:
+    async def test_per_monster_initscore_override(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init begin")
+        await dhttp.drain()
+        avrae.message("!init madd kobold initscore")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 12, f"Expected static init 12 with initscore flag, got {kobold.init}"
+        avrae.message("!init madd kobold")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold2 = combat.get_combatant("KO2")
+        assert 3 <= kobold2.init <= 22, f"Expected rolled init (3-22), got {kobold2.init}"
+        dhttp.clear()
+        avrae.message("!i remove KO1")
+        await dhttp.drain()
+        avrae.message("!i remove KO2")
+        await dhttp.drain()
+
+    async def test_initscore_with_advantage(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init madd kobold initscore adv")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 17, f"Expected static init with adv 17 (12+5), got {kobold.init}"
+        dhttp.clear()
+        avrae.message("!i remove KO1")
+        await dhttp.drain()
+
+    async def test_initscore_with_disadvantage(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init madd kobold initscore dis")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 7, f"Expected static init with dis 7 (12-5), got {kobold.init}"
+        dhttp.clear()
+        avrae.message("!i remove KO1")
+        await dhttp.drain()
+
+    async def test_initscore_with_bonus_roll(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init madd kobold initscore -b 2")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 14, f"Expected static init with +2 bonus = 14 (12+2), got {kobold.init}"
+        await end_init(avrae, dhttp)
+
+    async def test_combat_wide_initscore_setting(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init begin initscore")
+        await dhttp.drain()
+        avrae.message("!init madd kobold")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 12, f"Expected static init 12 (10+2), got {kobold.init}"
+        dhttp.clear()
+        avrae.message("!i remove KO1")
+        await dhttp.drain()
+
+    async def test_initscore_overridden_by_manual_init(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init madd kobold -p 25")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 25, f"Expected manual init 25, got {kobold.init}"
+        dhttp.clear()
+        avrae.message("!i remove KO1")
+        await dhttp.drain()
+
+    async def test_multiple_monsters_same_static_init(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init madd kobold -n 3")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        ko1 = combat.get_combatant("KO1")
+        ko2 = combat.get_combatant("KO2")
+        ko3 = combat.get_combatant("KO3")
+        assert ko1.init == 12, f"KO1 expected 12, got {ko1.init}"
+        assert ko2.init == 12, f"KO2 expected 12, got {ko2.init}"
+        assert ko3.init == 12, f"KO3 expected 12, got {ko3.init}"
+        dhttp.clear()
+        avrae.message("!i remove KO1")
+        await dhttp.drain()
+        avrae.message("!i remove KO2")
+        await dhttp.drain()
+        avrae.message("!i remove KO3")
+        await dhttp.drain()
+
+    async def test_initscore_with_different_monsters(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init madd kobold")
+        await dhttp.drain()
+        avrae.message("!init madd mage")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        mage = combat.get_combatant("MA1")
+        assert kobold.init == 12, f"Kobold expected 12, got {kobold.init}"
+        assert mage.init == 12, f"Mage expected 12, got {mage.init}"
+        await end_init(avrae, dhttp)
+
+    async def test_initscore_meta_toggle(self, avrae, dhttp):
+        dhttp.clear()
+        avrae.message("!init begin")
+        await dhttp.drain()
+        avrae.message("!init meta initscore")
+        await dhttp.drain()
+        avrae.message("!init madd kobold")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold = combat.get_combatant("KO1")
+        assert kobold.init == 12, f"Expected static init 12 after meta toggle on, got {kobold.init}"
+        avrae.message("!init meta initscore")
+        await dhttp.drain()
+        avrae.message("!init madd kobold")
+        await dhttp.drain()
+        combat = await active_combat(avrae)
+        kobold2 = combat.get_combatant("KO2")
+        assert 3 <= kobold2.init <= 22, f"Expected rolled init (3-22) after toggle off, got {kobold2.init}"
+
+    async def test_initscore_teardown(self, avrae, dhttp):
+        await end_init(avrae, dhttp)


### PR DESCRIPTION
### Summary
Adds `initscore` flag to `!init madd` and `!init meta`. Uses monster's initiative score (10 + modifier) instead of rolling, as per [MM2024 optional rule](https://www.dndbeyond.com/sources/dnd/mm-2024/how-to-use-a-monster#Initiative).

### Changelog Entry
Added `initscore` flag to `!init madd` and `!init meta` as per MM2024 optional rule.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [x] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
