### PR TITLE
AVR-1613 upgrade ddtrace to 3.16.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ boto3==1.34.106
 pymongo==4.7.2
 
 # Handling for Datadog
-ddtrace==3.16.2
+ddtrace~=3.16.2
 
 # BI Data Collection
 confluent-kafka==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ boto3==1.34.106
 pymongo==4.7.2
 
 # Handling for Datadog
-ddtrace~=2.21.3
+ddtrace==3.16.2
 
 # BI Data Collection
 confluent-kafka==2.8.0


### PR DESCRIPTION
### Summary
ddtrace upgraded to 3.16.2 to address the wrapt dependency issue breaking change. 

- The `ddtrace` library in this codebase is only used in `cogsmisc/adminUtils.py` and `utils/datadog.py` to configure the tracer and set the sampler percentage; `dbot.py` has the in-app datadog init commented out.
- Currently, no traces are being received in Datadog across environments, so tracer behavior is not observable via traces right now.
- Upon local configuration for sending traces, it was confirmed that datadog receive traces correctly with both the old and new version of the library

### Changelog Entry
ddtrace upgraded to 3.16.2

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
