### PR TITLE
feat: add /madd slash cmd

### DIFF
--- a/cogs5e/homebrew.py
+++ b/cogs5e/homebrew.py
@@ -20,11 +20,11 @@ class Homebrew(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def clear_cache(self, ctx, entity_type):
+    async def _clear_entity_cache(self, ctx, entity_type, guild_wide=False):
+        """Clear entity cache by delegating to the Lookup cog."""
         lookup = self.bot.get_cog("Lookup")
-        if lookup is None:
-            return await ctx.send("Error: Lookup cog not loaded.")
-        await lookup.clear_cache(ctx, entity_type)
+        if lookup is not None:
+            await lookup.clear_cache(ctx, entity_type, guild_wide=guild_wide)
 
     @commands.group(invoke_without_command=True)
     async def bestiary(self, ctx, *, name=None):
@@ -46,7 +46,7 @@ class Homebrew(commands.Cog):
             except NoSelectionElements:
                 return await ctx.send("Bestiary not found.")
             await bestiary.set_active(ctx)
-            await self.clear_cache(ctx, "monster")
+            await self._clear_entity_cache(ctx, "monster")
         embed = HomebrewEmbedWithAuthor(ctx)
         embed.title = bestiary.name
         if bestiary.desc:
@@ -79,6 +79,7 @@ class Homebrew(commands.Cog):
 
         if resp:
             await bestiary.unsubscribe(ctx)
+            await self._clear_entity_cache(ctx, "monster")
             return await ctx.send("{} has been deleted.".format(bestiary.name))
         else:
             return await ctx.send("OK, cancelling.")
@@ -126,6 +127,7 @@ class Homebrew(commands.Cog):
 
         await bestiary.subscribe(ctx)
         await bestiary.set_active(ctx)
+        await self._clear_entity_cache(ctx, "monster")
 
         await loading.edit(content=f"Imported {bestiary.name}!")
         embed = HomebrewEmbedWithAuthor(ctx)
@@ -161,6 +163,8 @@ class Homebrew(commands.Cog):
             await bestiary.subscribe(ctx)
             await bestiary.add_server_subscriptions(ctx, old_server_subs)
             await bestiary.set_active(ctx)
+            # Guild-wide if server subs exist, otherwise personal only
+            await self._clear_entity_cache(ctx, "monster", guild_wide=bool(old_server_subs))
 
         await loading.edit(content=f"Imported and updated {bestiary.name}!")
         embed = HomebrewEmbedWithAuthor(ctx)
@@ -180,6 +184,7 @@ class Homebrew(commands.Cog):
         Requires __Manage Server__ permissions or a role named "Server Brewer" or "Dragonspeaker" to run."""
         bestiary = await Bestiary.from_ctx(ctx)
         is_server_active = await bestiary.toggle_server_active(ctx)
+        await self._clear_entity_cache(ctx, "monster", guild_wide=True)
         if is_server_active:
             await ctx.send(f"Ok, {bestiary.name} is now active on {ctx.guild.name}!")
         else:
@@ -206,6 +211,7 @@ class Homebrew(commands.Cog):
 
         bestiary = await search_and_select(ctx, bestiaries, bestiary_name, lambda b: b.name)
         await bestiary.toggle_server_active(ctx)
+        await self._clear_entity_cache(ctx, "monster", guild_wide=True)
         await ctx.send(f"Ok, {bestiary.name} is no longer active on {ctx.guild.name}.")
 
     @commands.group(invoke_without_command=True)
@@ -230,7 +236,7 @@ class Homebrew(commands.Cog):
             except NoSelectionElements:
                 return await ctx.send("Pack not found.")
             await pack.set_active(ctx)
-            await self.clear_cache(ctx, "item")
+            await self._clear_entity_cache(ctx, "item")
         embed = HomebrewEmbedWithAuthor(ctx)
         embed.title = pack.name
         embed.description = pack.desc
@@ -354,7 +360,7 @@ class Homebrew(commands.Cog):
             except NoSelectionElements:
                 return await ctx.send("Tome not found.")
             await tome.set_active(ctx)
-            await self.clear_cache(ctx, "spell")
+            await self._clear_entity_cache(ctx, "spell")
         embed = HomebrewEmbedWithAuthor(ctx)
         embed.title = tome.name
         embed.description = tome.desc

--- a/cogs5e/initiative/cog.py
+++ b/cogs5e/initiative/cog.py
@@ -4,19 +4,31 @@ import logging
 from contextlib import suppress
 
 import disnake
+import gamedata
 from d20 import roll
 from disnake.ext import commands
 from disnake.ext.commands import NoPrivateMessage
 
 from aliasing import helpers
 from cogs5e.models.character import Character
-from cogs5e.models.embeds import EmbedWithAuthor, EmbedWithCharacter, EmbedWithColor
+from cogs5e.models.embeds import EmbedPaginator, EmbedWithAuthor, EmbedWithCharacter, EmbedWithColor
 from cogs5e.models.errors import InvalidArgument, NoSelectionElements, SelectionException
 from cogs5e.models.sheet.attack import Attack
 from cogs5e.utils import actionutils, checkutils, gameutils, targetutils
 from cogs5e.utils.help_constants import *
 from cogsmisc.stats import Stats
-from gamedata.lookuputils import select_monster_full, select_spell_full
+from gamedata.lookuputils import (
+    AUTOCOMPLETE_FAVORITES_LIMIT,
+    AUTOCOMPLETE_MAX_RESULTS,
+    USER_MONSTER_FAVORITES_CACHE,
+    create_selectkey,
+    get_monster_choices,
+    get_user_favorite_monsters,
+    madd_monster_converter,
+    select_monster_full,
+    select_spell_full,
+    slash_match_key,
+)
 from utils import checks, constants
 from utils.argparser import argparse
 from utils.functions import (
@@ -24,6 +36,7 @@ from utils.functions import (
     get_guild_member,
     get_initials,
     get_selection,
+    search,
     search_and_select,
     try_delete,
     camel_to_title,
@@ -237,31 +250,12 @@ class InitTracker(commands.Cog):
         await ctx.send("\n".join(msgs))
         await combat.final(ctx)
 
-    @init.command()
-    async def madd(self, ctx, monster_name: str, *, args=""):
-        """Adds a monster to combat.
-        __Valid Arguments__
-        `-name <name>` - Sets the combatant's name. Use "#" for auto-numbering, e.g. "Orc#"
-        `-n <number or dice>` - Adds more than one monster. Supports dice.
-        `-h` - Hides HP, AC, Resists, etc. Default: True.
-        `-p <value>` - Places combatant at the given value, instead of rolling.
-        `-controller <controller>` - Pings a different person on turn.
-        `-group <group>` - Adds the combatant to a group.
-        `adv`/`dis` - Give advantage or disadvantage to the initiative roll.
-        `-b <condition bonus>` - Adds a bonus to the combatant's initiative roll.
-        `initscore` - Uses the monster's Initiative score instead of rolling. Applies adv/dis as ±5 bonuses.
-        `rollhp` - Rolls the monsters HP, instead of using the default value.
-        `-hp <hp>` - Sets starting HP.
-        `-thp <thp>` - Sets starting THP.
-        `-ac <ac>` - Sets the combatant's starting AC.
-        `-note <note>` - Sets the combatant's note.
-        """
-
-        monster = await select_monster_full(ctx, monster_name, pm=True)
-
-        args = argparse(args)
+    async def _madd_impl(self, ctx, monster, args_str):
+        """Shared implementation for !madd and /madd."""
+        args = argparse(args_str)
         private = not args.last("h", type_=bool)
         controller = ctx.author.id
+        author_id = ctx.author.id
         group = args.last("group")
         adv = args.adv(boolwise=True)
         b = args.join("b", "+")
@@ -274,7 +268,7 @@ class InitTracker(commands.Cog):
         name_template = args.last("name", f"{get_name(monster)}#")
         init_skill = monster.skills.initiative
 
-        combat = await ctx.get_combat()
+        combat = await Combat.from_ctx(ctx)
 
         # Use combat setting as default if initscore flag not explicitly provided
         initscore = args.last("initscore", combat.options.initscore, bool)
@@ -287,6 +281,7 @@ class InitTracker(commands.Cog):
             msgs.append(roll_result)
         name_builder = combatant_builders.CombatantNameBuilder(name_template, combat, always_number_first_name=False)
 
+        monster_added = False
         for _ in range(num_combatants):
             try:
                 name = name_builder.next()
@@ -344,10 +339,136 @@ class InitTracker(commands.Cog):
                 grp.add_combatant(me)
                 msgs.append(f"{name} was added to combat with initiative {grp.init} as part of group {grp.name}.")
 
+            monster_added = True
+
+        if monster_added:
+            try:
+                await ctx.bot.mdb.analytics_monster_usage.update_one(
+                    {
+                        "user_id": author_id,
+                        "monster_name": monster.name,
+                        "monster_id": getattr(monster, "entity_id", None),
+                    },
+                    {"$inc": {"count": 1}, "$currentDate": {"last_used": True}},
+                    upsert=True,
+                )
+            except Exception:
+                log.exception("Failed to track monster usage for user %s, monster %s", author_id, monster.name)
+
+            try:
+                del USER_MONSTER_FAVORITES_CACHE[author_id]
+            except KeyError:
+                pass
+
         await combat.final(ctx)
         await ctx.send("\n".join(msgs))
         if to_pm:
             await ctx.author.send("\n".join(to_pm))
+
+    @init.command()
+    async def madd(self, ctx, monster_name: str, *, args=""):
+        """Adds a monster to combat.
+        __Valid Arguments__
+        `-name <name>` - Sets the combatant's name. Use "#" for auto-numbering, e.g. "Orc#"
+        `-n <number or dice>` - Adds more than one monster. Supports dice.
+        `-h` - Hides HP, AC, Resists, etc. Default: True.
+        `-p <value>` - Places combatant at the given value, instead of rolling.
+        `-controller <controller>` - Pings a different person on turn.
+        `-group <group>` - Adds the combatant to a group.
+        `adv`/`dis` - Give advantage or disadvantage to the initiative roll.
+        `-b <condition bonus>` - Adds a bonus to the combatant's initiative roll.
+        `initscore` - Uses the monster's Initiative score instead of rolling. Applies adv/dis as ±5 bonuses.
+        `rollhp` - Rolls the monsters HP, instead of using the default value.
+        `-hp <hp>` - Sets starting HP.
+        `-thp <thp>` - Sets starting THP.
+        `-ac <ac>` - Sets the combatant's starting AC.
+        `-note <note>` - Sets the combatant's note.
+        """
+        monster = await select_monster_full(ctx, monster_name, pm=True)
+        await self._madd_impl(ctx, monster, args)
+
+    @commands.slash_command(name="madd", description="Adds a monster to combat.")
+    async def slash_madd(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        monster: gamedata.Monster = commands.Param(
+            description="The monster to add to combat", converter=madd_monster_converter
+        ),
+        args: str = commands.Param(description="Additional arguments (same format as !i madd)", default=""),
+    ):
+        """Adds a monster to combat."""
+        await inter.response.defer(ephemeral=True)
+        await self._madd_impl(inter, monster, args)
+
+    @slash_madd.autocomplete("monster")
+    async def slash_madd_auto(self, inter: disnake.ApplicationCommandInteraction, user_input: str):
+        """Autocomplete handler for monster parameter."""
+        lookup_cog = self.bot.get_cog("Lookup")
+        choices = await lookup_cog._get_entities(inter, "monster", get_monster_choices)
+
+        favorites = await get_user_favorite_monsters(inter, inter.author.id)
+
+        available_ids = {"monster": await self.bot.ddb.get_accessible_entities(inter, inter.author.id, "monster")}
+        select_key = create_selectkey(available_ids)
+
+        if not user_input:
+            choices_by_id = {}
+            choices_by_name_homebrew = {}
+            for m in choices:
+                eid = getattr(m, "entity_id", None)
+                if eid is not None:
+                    choices_by_id[eid] = m
+                else:
+                    choices_by_name_homebrew.setdefault(m.name, []).append(m)
+
+            # Build recent list from favorites, matching by id (official) or name (homebrew)
+            recent = []
+            seen_objects = set()
+            for name, mid in favorites:
+                if mid and mid in choices_by_id:
+                    monster = choices_by_id[mid]
+                    if monster not in seen_objects:
+                        recent.append(monster)
+                        seen_objects.add(monster)
+                elif name in choices_by_name_homebrew:
+                    for monster in choices_by_name_homebrew[name]:
+                        if monster not in seen_objects:
+                            recent.append(monster)
+                            seen_objects.add(monster)
+                if len(recent) >= AUTOCOMPLETE_MAX_RESULTS:
+                    break
+
+            # Backfill with SRD only if <7 favorites
+            if len(favorites) < 7 and len(recent) < AUTOCOMPLETE_MAX_RESULTS:
+                for m in choices:
+                    if m.is_free and m not in seen_objects:
+                        recent.append(m)
+                        if len(recent) >= AUTOCOMPLETE_MAX_RESULTS:
+                            break
+
+            return [select_key(m, True) for m in recent[:AUTOCOMPLETE_MAX_RESULTS]]
+
+        # Boost user favorites to top
+        result, strict = search(choices, user_input, slash_match_key)
+
+        if strict:
+            return [select_key(result, True)]
+
+        limited_results = result[:AUTOCOMPLETE_FAVORITES_LIMIT]
+
+        favorite_ids = {(name, mid) for name, mid in favorites}
+
+        favorite_results = []
+        other_results = []
+        for monster in limited_results:
+            monster_id = getattr(monster, "entity_id", None)
+            if (monster.name, monster_id) in favorite_ids:
+                favorite_results.append(monster)
+            else:
+                other_results.append(monster)
+
+        boosted = favorite_results + other_results
+        return [select_key(r, True) for r in boosted[:AUTOCOMPLETE_MAX_RESULTS]]
 
     @init.command(name="join", aliases=["cadd", "dcadd"])
     async def join(self, ctx, *, args: str = ""):
@@ -1607,6 +1728,30 @@ class InitTracker(commands.Cog):
             "ask a server administrator to disable `Contribute Message Data to Natural Language AI Training` in the "
             f"`{ctx.clean_prefix}servsettings` command."
         )
+
+    @commands.command(hidden=True)
+    async def mfav(self, ctx):
+        """Lists your most frequently used monsters."""
+        results = (
+            await ctx.bot.mdb.analytics_monster_usage.find({"user_id": ctx.author.id})
+            .sort([("count", -1), ("last_used", -1)])
+            .limit(AUTOCOMPLETE_FAVORITES_LIMIT)
+            .to_list(None)
+        )
+
+        if not results:
+            return await ctx.send("You haven't added any monsters to combat yet!")
+
+        ep = EmbedPaginator(colour=disnake.Colour.blurple())
+        ep.add_title(f"{ctx.author.display_name}'s Favorite Monsters ({len(results)} total)")
+        ep.add_field(name="Most Frequently Used", value="")
+
+        for idx, data in enumerate(results, 1):
+            timestamp = f"<t:{int(data['last_used'].timestamp())}:F>"
+            line = f"`{idx:>3}.` **{data['monster_name']}** - {data['count']}x - {timestamp}\n"
+            ep.extend_field(line)
+
+        await ep.send_to(ctx)
 
 
 monster_name_exceptions = (294945, 2059697)

--- a/cogs5e/lookup.py
+++ b/cogs5e/lookup.py
@@ -1239,14 +1239,40 @@ class Lookup(commands.Cog):
         await self.bot.rdb.jsetex(key, [m.to_dict() for m in converted_entities], ENTITY_TTL)
         return converted_entities
 
-    async def clear_cache(self, ctx, entity_type):
-        if ctx.guild is None:
-            key = f"{entity_type}.{ctx.author.id}"
+    async def clear_cache(self, ctx, entity_type, guild_wide=False):
+        """Clear entity cache. If guild_wide=True, clears all users in guild, otherwise only the acting user."""
+        if guild_wide:
+            if ctx.guild is None:
+                prefix = f"{entity_type}.{ctx.author.id}"
+                pattern = f"{entity_type}.{ctx.author.id}"
+            else:
+                prefix = f"{entity_type}.{ctx.guild.id}."
+                pattern = f"{entity_type}.{ctx.guild.id}.*"
+
+            # Clear L1 (in-memory) cache
+            l1_keys_to_delete = [k for k in ENTITY_CACHE if k.startswith(prefix)]
+            for k in l1_keys_to_delete:
+                del ENTITY_CACHE[k]
+
+            # Clear L2 (redis) cache in batches
+            batch = []
+            batch_size = 100
+            async for key in self.bot.rdb.iscan(match=pattern):
+                batch.append(key)
+                if len(batch) >= batch_size:
+                    await self.bot.rdb.delete(*batch)
+                    batch.clear()
+
+            if batch:
+                await self.bot.rdb.delete(*batch)
         else:
-            key = f"{entity_type}.{ctx.guild.id}.{ctx.author.id}"
-        if key in ENTITY_CACHE:
-            del ENTITY_CACHE[key]
-        await self.bot.rdb.delete(key)
+            if ctx.guild is None:
+                key = f"{entity_type}.{ctx.author.id}"
+            else:
+                key = f"{entity_type}.{ctx.guild.id}.{ctx.author.id}"
+            if key in ENTITY_CACHE:
+                del ENTITY_CACHE[key]
+            await self.bot.rdb.delete(key)
 
     # ==== listeners ====
     @commands.Cog.listener()

--- a/gamedata/lookuputils.py
+++ b/gamedata/lookuputils.py
@@ -4,6 +4,7 @@ Created on Jan 13, 2017
 @author: andrew
 """
 
+import cachetools
 import itertools
 import logging
 from typing import Dict, List, TYPE_CHECKING, TypeVar, Callable
@@ -33,6 +34,38 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 VALID_VERSIONS = ["2024", "2014", "Homebrew"]
+
+USER_FAVORITES_TTL = 5 * 60
+USER_MONSTER_FAVORITES_CACHE: cachetools.TTLCache[int, list[tuple[str, int | None]]] = cachetools.TTLCache(
+    maxsize=1000, ttl=USER_FAVORITES_TTL
+)
+AUTOCOMPLETE_FAVORITES_LIMIT = 150
+AUTOCOMPLETE_MAX_RESULTS = 25
+
+
+async def get_user_favorite_monsters(
+    ctx, user_id: int, limit: int = AUTOCOMPLETE_FAVORITES_LIMIT
+) -> list[tuple[str, int | None]]:
+    """Get user's most frequently used monsters (cached, MFU with recency tiebreaker).
+
+    Returns:
+        List of (monster_name, monster_id) tuples for priority-based matching.
+    """
+    try:
+        return USER_MONSTER_FAVORITES_CACHE[user_id]
+    except KeyError:
+        results = (
+            await ctx.bot.mdb.analytics_monster_usage.find(
+                {"user_id": user_id}, {"monster_name": 1, "monster_id": 1, "_id": 0}
+            )
+            .sort([("count", -1), ("last_used", -1)])
+            .limit(limit)
+            .to_list(None)
+        )
+
+        favorites = [(r["monster_name"], r["monster_id"]) for r in results]
+        USER_MONSTER_FAVORITES_CACHE[user_id] = favorites
+        return favorites
 
 
 # ==== entitlement search helpers ====
@@ -234,43 +267,55 @@ def source_slug(source):
 
 
 # ==== search ====
-async def _handle_legacy_preference(
-    ctx: "AvraeContext", choices: List["Sourced"], available_ids: dict[str, set[int]]
+def _select_preferred_entity(
+    a: "Sourced", b: "Sourced", legacy_preference: LegacyPreference, available_ids: set[int]
 ) -> "Sourced | None":
-    """
-    Auto-select between legacy and modern entities based on guild preferences.
-
-    Returns the preferred entity if auto-selection applies, None otherwise.
-    """
-    # Only applies to exactly 2 choices in a guild context
-    if len(choices) != 2 or ctx.guild is None:
-        return None
-
-    # Only applies if one is legacy and one is modern
-    a, b = choices
+    """Auto-select between legacy/modern entities based on preference."""
     if a.is_legacy == b.is_legacy:
         return None
 
-    legacy: "Sourced" = a if a.is_legacy else b
-    latest: "Sourced" = a if not a.is_legacy else b
+    legacy = a if a.is_legacy else b
+    latest = a if not a.is_legacy else b
 
-    guild_settings = await ctx.get_server_settings()
-
-    # If set to ASK, don't auto-select
-    if guild_settings.legacy_preference == LegacyPreference.ASK:
+    if legacy_preference == LegacyPreference.ASK:
         return None
 
-    # Auto-select preferred entity if user has access
-    if guild_settings.legacy_preference == LegacyPreference.LATEST and can_access(
-        latest, available_ids[latest.entitlement_entity_type]
-    ):
+    if legacy_preference == LegacyPreference.LATEST and can_access(latest, available_ids):
         return latest
-    elif guild_settings.legacy_preference == LegacyPreference.LEGACY and can_access(
-        legacy, available_ids[legacy.entitlement_entity_type]
-    ):
+    elif legacy_preference == LegacyPreference.LEGACY and can_access(legacy, available_ids):
         return legacy
 
     return None
+
+
+async def _handle_legacy_preference(
+    ctx: "AvraeContext", choices: List["Sourced"], available_ids: dict[str, set[int]]
+) -> "Sourced | None":
+    """Auto-select between legacy/modern entities based on guild settings."""
+    if len(choices) != 2 or ctx.guild is None:
+        return None
+
+    a, b = choices
+    guild_settings = await ctx.get_server_settings()
+
+    return _select_preferred_entity(a, b, guild_settings.legacy_preference, available_ids[a.entitlement_entity_type])
+
+
+async def _handle_legacy_preference_slash(
+    inter: "disnake.ApplicationCommandInteraction", result: list, entity_type: str, available_ids: set[int] = None
+) -> "Sourced | None":
+    """Handle legacy preference for slash commands."""
+    if len(result) != 2 or inter.guild is None:
+        return None
+
+    a, b = result
+    if a.is_legacy == b.is_legacy:
+        return None
+
+    guild_settings = await ServerSettings.for_guild(mdb=inter.bot.mdb, guild_id=inter.guild.id)
+    if available_ids is None:
+        available_ids = await inter.bot.ddb.get_accessible_entities(inter, inter.author.id, entity_type)
+    return _select_preferred_entity(a, b, guild_settings.legacy_preference, available_ids)
 
 
 def create_selectkey(available_ids: dict[str, set[int]]):
@@ -302,6 +347,63 @@ def slash_match_key(entity):
     return (
         f"{entity.name} ({'🍺 - ' if entity.homebrew else ''}{entity.source}{f'; legacy' if entity.is_legacy else ''})"
     )
+
+
+async def _fetch_single_monster(ctx, cached_monster) -> gamedata.Monster:
+    """
+    Efficiently fetch a single monster using metadata in ENTITY_CACHE.
+
+    :param ctx: Context or ApplicationCommandInteraction
+    :param cached_monster: CachedSourced object from ENTITY_CACHE
+    :return: Full Monster object
+    """
+    if cached_monster.entity_id is not None:
+        monster = compendium.lookup_entity("monster", cached_monster.entity_id)
+        if monster:
+            return monster
+        log.warning(
+            f"Monster '{cached_monster.name}' has entity_id {cached_monster.entity_id} "
+            f"but not found in compendium, cache may be stale"
+        )
+
+    if cached_monster.homebrew:
+        bestiary_name = cached_monster.source
+
+        bestiary_data = await ctx.bot.mdb.bestiaries.find_one(
+            {"name": bestiary_name, "monsters.name": cached_monster.name},
+            {"monsters.$": 1, "name": 1},  # $ returns only the matching element
+        )
+
+        if bestiary_data and "monsters" in bestiary_data and bestiary_data["monsters"]:
+            return gamedata.Monster.from_bestiary(bestiary_data["monsters"][0], bestiary_name)
+
+    raise ValueError(f"Monster '{cached_monster.name}' not found")
+
+
+async def madd_monster_converter(inter: disnake.ApplicationCommandInteraction, arg: str) -> gamedata.Monster:
+    """Converter for /madd that applies legacy preference and license checks."""
+    lookup_cog = inter.bot.get_cog("Lookup")
+    cached_choices = await lookup_cog._get_entities(inter, "monster", get_monster_choices)
+
+    result, strict = search(cached_choices, arg, slash_match_key)
+
+    if not result:
+        raise ValueError("That monster doesn't exist")
+
+    available_ids = await inter.bot.ddb.get_accessible_entities(inter, inter.author.id, "monster")
+
+    if not isinstance(result, list):
+        cached_monster = result
+    else:
+        preferred = await _handle_legacy_preference_slash(inter, result, "monster", available_ids)
+        cached_monster = preferred if preferred is not None else result[0]
+
+    if not can_access(cached_monster, available_ids):
+        raise RequiresLicense(cached_monster, available_ids is not None)
+
+    monster = await _fetch_single_monster(inter, cached_monster)
+
+    return monster
 
 
 def lookup_converter(entity_type: str) -> Callable:

--- a/scripts/ensure_indices.py
+++ b/scripts/ensure_indices.py
@@ -26,6 +26,11 @@ INDICES = {
         IndexModel("guild_id"),
     ],
     "analytics_ddb_activity": [IndexModel("user_id", unique=True), IndexModel([("last_link_time", DESCENDING)])],
+    "analytics_monster_usage": [
+        IndexModel([("user_id", ASCENDING), ("monster_name", ASCENDING), ("monster_id", ASCENDING)], unique=True),
+        IndexModel([("user_id", ASCENDING), ("count", DESCENDING), ("last_used", DESCENDING)]),
+        IndexModel("last_used", expireAfterSeconds=63072000),
+    ],
     "analytics_nsrd_lookup": [IndexModel("type")],
     "analytics_alias_events": [IndexModel("object_id"), IndexModel("type"), IndexModel([("timestamp", DESCENDING)])],
     "analytics_daily": [IndexModel([("timestamp", DESCENDING)])],

--- a/tests/unit/slash_madd_test.py
+++ b/tests/unit/slash_madd_test.py
@@ -1,0 +1,541 @@
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+from datetime import datetime
+from contextlib import asynccontextmanager
+
+from gamedata.lookuputils import madd_monster_converter
+from gamedata.shared import Sourced
+from utils.settings.guild import LegacyPreference
+
+
+class MockSourced(Sourced):
+    entity_type = "test"
+
+    def __init__(self, name, is_legacy=False, is_free=True, entitlement_entity_type=None, entitlement_entity_id=1):
+        self.name = name
+        self.is_legacy = is_legacy
+        self.is_free = is_free
+        self.homebrew = False
+        self.source = "TEST"
+        self.entity_id = entitlement_entity_id
+        self.page = None
+        self._url = None
+        self.entitlement_entity_type = entitlement_entity_type or self.entity_type
+        self.entitlement_entity_id = entitlement_entity_id
+        self.limited_use_only = False
+        self.rulesVersion = None
+
+
+class MockMonster(MockSourced):
+    entity_type = "monster"
+
+    def __init__(self, name, is_legacy=False, is_free=True):
+        super().__init__(name, is_legacy, is_free, "monster")
+
+
+@pytest.fixture
+def mock_inter():
+    inter = Mock()
+    inter.guild = Mock()
+    inter.guild.id = 123456789
+    inter.author = Mock()
+    inter.author.id = 12345
+    inter.bot = Mock()
+    inter.bot.mdb = Mock()
+    inter.bot.ddb = Mock()
+    inter.bot.ddb.get_accessible_entities = AsyncMock(return_value={1})
+
+    mock_lookup_cog = Mock()
+
+    async def _get_entities_side_effect(ctx, entity_type, fn):
+        return await fn(ctx)
+
+    mock_lookup_cog._get_entities = AsyncMock(side_effect=_get_entities_side_effect)
+    inter.bot.get_cog = Mock(return_value=mock_lookup_cog)
+
+    return inter
+
+
+@pytest.fixture
+def mock_inter_dm():
+    inter = Mock()
+    inter.guild = None
+    inter.author = Mock()
+    inter.author.id = 12345
+    inter.bot = Mock()
+    inter.bot.ddb = Mock()
+    inter.bot.ddb.get_accessible_entities = AsyncMock(return_value={1})
+
+    mock_lookup_cog = Mock()
+
+    async def _get_entities_side_effect(ctx, entity_type, fn):
+        return await fn(ctx)
+
+    mock_lookup_cog._get_entities = AsyncMock(side_effect=_get_entities_side_effect)
+    inter.bot.get_cog = Mock(return_value=mock_lookup_cog)
+
+    return inter
+
+
+@pytest.fixture
+def mock_ctx():
+    ctx = Mock()
+    ctx.author = Mock()
+    ctx.author.id = 12345
+    ctx.author.send = AsyncMock()
+    ctx.bot = Mock()
+    ctx.bot.mdb = Mock()
+    ctx.bot.mdb.analytics_monster_usage = Mock()
+    ctx.bot.mdb.analytics_monster_usage.update_one = AsyncMock()
+    ctx.send = AsyncMock()
+    return ctx
+
+
+@pytest.fixture
+def mock_monster():
+    monster = Mock()
+    monster.name = "Goblin"
+    monster.entity_id = 1
+    monster.hitdice = "2d6"
+    monster.skills = Mock()
+    monster.skills.initiative = Mock()
+    monster.skills.initiative.d20 = Mock(return_value="1d20+2")
+    monster.skills.initiative.value = 2
+    return monster
+
+
+@pytest.fixture
+def mock_monster_homebrew():
+    monster = Mock()
+    monster.name = "Custom Dragon"
+    monster.entity_id = None
+    monster.hitdice = "10d12"
+    monster.skills = Mock()
+    monster.skills.initiative = Mock()
+    monster.skills.initiative.d20 = Mock(return_value="1d20+0")
+    monster.skills.initiative.value = 0
+    return monster
+
+
+@asynccontextmanager
+async def mock_monster_lookup(choices, search_result, is_strict=False, settings_preference=None):
+    """Mock monster lookup with optional server settings.
+    Requires mock_inter/mock_inter_dm fixture for bot.get_cog() setup."""
+    with patch("gamedata.lookuputils.get_monster_choices", new_callable=AsyncMock) as mock_choices:
+        mock_choices.return_value = choices
+        with patch("gamedata.lookuputils.search") as mock_search:
+            mock_search.return_value = (search_result, is_strict)
+
+            if settings_preference is not None:
+                with patch("gamedata.lookuputils.ServerSettings.for_guild", new_callable=AsyncMock) as mock_settings:
+                    settings = Mock()
+                    settings.legacy_preference = settings_preference
+                    mock_settings.return_value = settings
+                    yield
+            else:
+                yield
+
+
+@asynccontextmanager
+async def mock_cog_lookup(choices, search_result=None, is_strict=False, favorites=None):
+    """Mock cog autocomplete lookup.
+    Requires mock_cog fixture for bot.get_cog() setup."""
+    with patch("cogs5e.initiative.cog.get_monster_choices", new_callable=AsyncMock) as mock_choices:
+        mock_choices.return_value = choices
+        with patch("cogs5e.initiative.cog.get_user_favorite_monsters", new_callable=AsyncMock) as mock_fav:
+            mock_fav.return_value = favorites or []
+
+            if search_result is not None:
+                with patch("cogs5e.initiative.cog.search") as mock_search:
+                    mock_search.return_value = (search_result, is_strict)
+                    yield choices
+            else:
+                yield choices
+
+
+@asynccontextmanager
+async def mock_combat_add(mock_ctx):
+    """Mock combat operations for _madd_impl tests."""
+    with patch("cogs5e.initiative.cog.Combat") as MockCombat:
+        mock_combat = Mock()
+        mock_combat.add_combatant = Mock()
+        mock_combat.get_combatant = Mock(return_value=None)
+        mock_combat.final = AsyncMock()
+        MockCombat.from_ctx = AsyncMock(return_value=mock_combat)
+
+        with patch("cogs5e.initiative.cog.MonsterCombatant") as MockMonsterCombatant:
+            mock_combatant = Mock()
+            mock_combatant.name = "Goblin 1"
+            mock_combatant.init = 15
+            MockMonsterCombatant.from_monster = Mock(return_value=mock_combatant)
+
+            with patch("cogs5e.initiative.cog.roll") as mock_roll:
+                mock_roll.return_value = Mock(total=15, result="15")
+                yield mock_combat, mock_combatant
+
+
+class TestMaddMonsterConverter:
+    @pytest.mark.asyncio
+    async def test_no_results_raises_error(self, mock_inter):
+        async with mock_monster_lookup([], []):
+            with pytest.raises(ValueError, match="doesn't exist"):
+                await madd_monster_converter(mock_inter, "nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_exact_match_returns_directly(self, mock_inter):
+        cached_goblin = MockMonster("Goblin", is_legacy=False)
+        full_goblin = Mock(name="Full Goblin")
+
+        with patch("gamedata.lookuputils._fetch_single_monster", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = full_goblin
+            async with mock_monster_lookup([cached_goblin], cached_goblin, is_strict=True):
+                result = await madd_monster_converter(mock_inter, "Goblin")
+
+                assert result == full_goblin
+                assert result != cached_goblin
+                mock_fetch.assert_called_once()
+                assert mock_fetch.call_args[0][1] == cached_goblin
+
+    @pytest.mark.asyncio
+    async def test_single_fuzzy_match_returns_first(self, mock_inter):
+        cached_goblin = MockMonster("Goblin", is_legacy=False)
+        full_goblin = Mock(name="Full Goblin")
+
+        with patch("gamedata.lookuputils._fetch_single_monster", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = full_goblin
+            async with mock_monster_lookup([cached_goblin], [cached_goblin]):
+                result = await madd_monster_converter(mock_inter, "gob")
+
+                assert result == full_goblin
+                assert result != cached_goblin
+                mock_fetch.assert_called_once()
+                assert mock_fetch.call_args[0][1] == cached_goblin
+
+    @pytest.mark.asyncio
+    async def test_three_results_returns_first(self, mock_inter):
+        cached_goblins = [
+            MockMonster("Goblin", is_legacy=False),
+            MockMonster("Goblin Boss", is_legacy=False),
+            MockMonster("Goblin Shaman", is_legacy=False),
+        ]
+        full_goblin = Mock(name="Full Goblin")
+
+        with patch("gamedata.lookuputils._fetch_single_monster", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = full_goblin
+            with patch("gamedata.lookuputils._handle_legacy_preference_slash", new_callable=AsyncMock) as mock_pref:
+                mock_pref.return_value = None
+                async with mock_monster_lookup(cached_goblins, cached_goblins):
+                    result = await madd_monster_converter(mock_inter, "goblin")
+
+                    assert result == full_goblin
+                    assert result != cached_goblins[0]
+                    mock_pref.assert_called_once()
+                    mock_fetch.assert_called_once()
+                    assert mock_fetch.call_args[0][1] == cached_goblins[0]
+
+    @pytest.mark.asyncio
+    async def test_dm_context_returns_first(self, mock_inter_dm):
+        cached_legacy = MockMonster("Goblin", is_legacy=True)
+        cached_modern = MockMonster("Goblin", is_legacy=False)
+        full_goblin = Mock(name="Full Goblin")
+
+        with patch("gamedata.lookuputils._fetch_single_monster", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = full_goblin
+            with patch("gamedata.lookuputils._handle_legacy_preference_slash", new_callable=AsyncMock) as mock_pref:
+                mock_pref.return_value = None
+                async with mock_monster_lookup([cached_legacy, cached_modern], [cached_legacy, cached_modern]):
+                    result = await madd_monster_converter(mock_inter_dm, "goblin")
+
+                    assert result == full_goblin
+                    assert result != cached_legacy
+                    mock_pref.assert_called_once()
+                    mock_fetch.assert_called_once()
+                    assert mock_fetch.call_args[0][1] == cached_legacy
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "preference,expected_idx",
+        [
+            (LegacyPreference.ASK, 0),
+            (LegacyPreference.LATEST, 1),
+            (LegacyPreference.LEGACY, 0),
+        ],
+    )
+    async def test_legacy_pair_preferences(self, mock_inter, preference, expected_idx):
+        cached_legacy = MockMonster("Goblin", is_legacy=True)
+        cached_modern = MockMonster("Goblin", is_legacy=False)
+        cached_expected = [cached_legacy, cached_modern][expected_idx]
+        full_goblin = Mock(name="Full Goblin")
+
+        mock_inter.bot.ddb.get_accessible_entities = AsyncMock(return_value={1})
+        with patch("gamedata.lookuputils._fetch_single_monster", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = full_goblin
+            async with mock_monster_lookup(
+                [cached_legacy, cached_modern], [cached_legacy, cached_modern], settings_preference=preference
+            ):
+                result = await madd_monster_converter(mock_inter, "goblin")
+
+                assert result == full_goblin
+                assert result != cached_expected
+                mock_fetch.assert_called_once()
+                assert mock_fetch.call_args[0][1] == cached_expected
+
+    @pytest.mark.asyncio
+    async def test_legacy_pair_no_access_raises_license_error(self, mock_inter):
+        from cogs5e.models.errors import RequiresLicense
+
+        legacy = MockMonster("Goblin", is_legacy=True, is_free=False)
+        modern = MockMonster("Goblin", is_legacy=False, is_free=False)
+        mock_inter.bot.ddb.get_accessible_entities = AsyncMock(return_value=set())
+
+        with patch("gamedata.lookuputils._fetch_single_monster", new_callable=AsyncMock) as mock_fetch:
+            async with mock_monster_lookup(
+                [legacy, modern], [legacy, modern], settings_preference=LegacyPreference.LATEST
+            ):
+                with pytest.raises(RequiresLicense):
+                    await madd_monster_converter(mock_inter, "goblin")
+                mock_fetch.assert_not_called()
+
+
+class TestGetUserFavoriteMonsters:
+    @pytest.mark.asyncio
+    async def test_mfu_ordering_with_recency(self, mock_ctx):
+        from gamedata.lookuputils import get_user_favorite_monsters, USER_MONSTER_FAVORITES_CACHE
+
+        USER_MONSTER_FAVORITES_CACHE.clear()
+
+        mock_cursor = Mock()
+        mock_cursor.limit.return_value = mock_cursor
+        mock_cursor.to_list = AsyncMock(
+            return_value=[
+                {"monster_name": "Goblin", "monster_id": 1, "count": 5, "last_used": datetime(2024, 1, 15)},
+                {"monster_name": "Orc", "monster_id": 2, "count": 3, "last_used": datetime(2024, 1, 14)},
+                {"monster_name": "Kobold", "monster_id": 3, "count": 3, "last_used": datetime(2024, 1, 10)},
+            ]
+        )
+        mock_ctx.bot.mdb.analytics_monster_usage.find.return_value.sort.return_value = mock_cursor
+
+        result = await get_user_favorite_monsters(mock_ctx, 12345, limit=25)
+
+        assert result == [("Goblin", 1), ("Orc", 2), ("Kobold", 3)]
+        mock_ctx.bot.mdb.analytics_monster_usage.find.return_value.sort.assert_called_once_with(
+            [("count", -1), ("last_used", -1)]
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_no_db_query(self, mock_ctx):
+        from gamedata.lookuputils import get_user_favorite_monsters, USER_MONSTER_FAVORITES_CACHE
+
+        USER_MONSTER_FAVORITES_CACHE[12345] = [("Goblin", 1), ("Orc", 2)]
+
+        result = await get_user_favorite_monsters(mock_ctx, 12345, limit=25)
+
+        assert result == [("Goblin", 1), ("Orc", 2)]
+        mock_ctx.bot.mdb.analytics_monster_usage.find.assert_not_called()
+
+
+class TestSlashMaddAutocomplete:
+    @pytest.fixture
+    def mock_inter(self):
+        inter = Mock()
+        inter.author = Mock()
+        inter.author.id = 12345
+        inter.bot = Mock()
+        inter.bot.ddb = Mock()
+        inter.bot.ddb.get_accessible_entities = AsyncMock(return_value={1, 2, 3})
+        return inter
+
+    @pytest.fixture
+    def mock_cog(self):
+        from cogs5e.initiative.cog import InitTracker
+
+        mock_bot = Mock()
+        mock_bot.ddb = Mock()
+        mock_bot.ddb.get_accessible_entities = AsyncMock(return_value={1, 2, 3})
+
+        mock_lookup_cog = Mock()
+
+        async def _get_entities_side_effect(ctx, entity_type, fn):
+            return await fn(ctx)
+
+        mock_lookup_cog._get_entities = AsyncMock(side_effect=_get_entities_side_effect)
+        mock_bot.get_cog = Mock(return_value=mock_lookup_cog)
+
+        cog = InitTracker(mock_bot)
+        return cog
+
+    @pytest.mark.asyncio
+    async def test_empty_input_with_favorites_and_srd_backfill(self, mock_inter, mock_cog):
+        goblin = MockMonster("Goblin", is_free=False)
+        goblin.entity_id = 1
+        orc = MockMonster("Orc", is_free=False)
+        orc.entity_id = 2
+        kobold = MockMonster("Kobold", is_free=True)
+        kobold.entity_id = 3
+
+        async with mock_cog_lookup([goblin, orc, kobold], favorites=[("Goblin", 1), ("Orc", 2)]):
+            result = await mock_cog.slash_madd_auto(mock_inter, "")
+            assert len(result) == 3
+            assert "Goblin" in result[0]
+            assert "Orc" in result[1]
+            assert "Kobold" in result[2]
+
+            result_names = [r.split("(")[0].strip() for r in result]
+            assert len(result_names) == len(set(result_names))
+
+    @pytest.mark.asyncio
+    async def test_empty_input_no_favorites_returns_srd(self, mock_inter, mock_cog):
+        goblin = MockMonster("Goblin", is_free=True)
+        goblin.entity_id = 1
+        kobold = MockMonster("Kobold", is_free=True)
+        kobold.entity_id = 2
+
+        async with mock_cog_lookup([goblin, kobold], favorites=[]):
+            result = await mock_cog.slash_madd_auto(mock_inter, "")
+            assert len(result) == 2
+            assert "Goblin" in result[0]
+            assert "Kobold" in result[1]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_id_priority_matching(self, mock_inter, mock_cog):
+        goblin_legacy = MockMonster("Goblin", is_free=False)
+        goblin_legacy.entity_id = 1
+        goblin_modern = MockMonster("Goblin", is_free=False)
+        goblin_modern.entity_id = 999
+
+        async with mock_cog_lookup([goblin_legacy, goblin_modern], favorites=[("Goblin", 1)]):
+            result = await mock_cog.slash_madd_auto(mock_inter, "")
+            assert len(result) >= 1
+            assert "Goblin" in result[0]
+            assert "(TEST)" in result[0] or "1" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_empty_input_name_fallback_homebrew(self, mock_inter, mock_cog):
+        homebrew_dragon = MockMonster("Custom Dragon", is_free=True)
+        homebrew_dragon.homebrew = True
+        homebrew_dragon.entity_id = None
+
+        async with mock_cog_lookup([homebrew_dragon], favorites=[("Custom Dragon", None)]):
+            result = await mock_cog.slash_madd_auto(mock_inter, "")
+            assert len(result) >= 1
+            assert "Custom Dragon" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_search_query_favorites_boosted(self, mock_inter, mock_cog):
+        goblin = MockMonster("Goblin", is_free=True)
+        goblin.entity_id = 1
+        goblin_boss = MockMonster("Goblin Boss", is_free=True)
+        goblin_boss.entity_id = 2
+        goblin_shaman = MockMonster("Goblin Shaman", is_free=True)
+        goblin_shaman.entity_id = 3
+
+        async with mock_cog_lookup(
+            [goblin, goblin_boss, goblin_shaman], [goblin, goblin_boss, goblin_shaman], favorites=[("Goblin Shaman", 3)]
+        ):
+            result = await mock_cog.slash_madd_auto(mock_inter, "gob")
+            assert "Goblin Shaman" in result[0]
+
+    @pytest.mark.asyncio
+    async def test_search_strict_match_returns_immediately(self, mock_inter, mock_cog):
+        goblin = MockMonster("Goblin", is_free=True)
+        goblin.entity_id = 1
+
+        async with mock_cog_lookup([goblin], goblin, is_strict=True, favorites=[]):
+            result = await mock_cog.slash_madd_auto(mock_inter, "Goblin")
+            assert len(result) == 1
+            assert "Goblin" in result[0]
+
+
+class TestMonsterUsageTracking:
+    @pytest.fixture
+    def tracking_cog(self, mock_ctx):
+        from cogs5e.initiative.cog import InitTracker
+        from gamedata.lookuputils import USER_MONSTER_FAVORITES_CACHE
+
+        USER_MONSTER_FAVORITES_CACHE.clear()
+        return InitTracker(mock_ctx.bot)
+
+    @pytest.mark.asyncio
+    async def test_tracking_single_monster(self, mock_ctx, mock_monster, tracking_cog):
+        cog = tracking_cog
+
+        async with mock_combat_add(mock_ctx):
+            await cog._madd_impl(mock_ctx, mock_monster, "")
+            mock_ctx.bot.mdb.analytics_monster_usage.update_one.assert_called_once_with(
+                {"user_id": 12345, "monster_name": "Goblin", "monster_id": 1},
+                {"$inc": {"count": 1}, "$currentDate": {"last_used": True}},
+                upsert=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_tracking_multiple_monsters_n_arg(self, mock_ctx, mock_monster, tracking_cog):
+        cog = tracking_cog
+
+        async with mock_combat_add(mock_ctx):
+            await cog._madd_impl(mock_ctx, mock_monster, "-n 5")
+            mock_ctx.bot.mdb.analytics_monster_usage.update_one.assert_called_once_with(
+                {"user_id": 12345, "monster_name": "Goblin", "monster_id": 1},
+                {"$inc": {"count": 1}, "$currentDate": {"last_used": True}},
+                upsert=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_tracking_homebrew_monster_no_entity_id(self, mock_ctx, mock_monster_homebrew, tracking_cog):
+        cog = tracking_cog
+
+        async with mock_combat_add(mock_ctx):
+            await cog._madd_impl(mock_ctx, mock_monster_homebrew, "")
+            mock_ctx.bot.mdb.analytics_monster_usage.update_one.assert_called_once_with(
+                {"user_id": 12345, "monster_name": "Custom Dragon", "monster_id": None},
+                {"$inc": {"count": 1}, "$currentDate": {"last_used": True}},
+                upsert=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_cache_invalidation_after_tracking(self, mock_ctx, mock_monster, tracking_cog):
+        """Cache is invalidated once after loop completes."""
+        from gamedata.lookuputils import USER_MONSTER_FAVORITES_CACHE
+
+        USER_MONSTER_FAVORITES_CACHE[12345] = [("Old Monster", 99)]
+        cog = tracking_cog
+
+        async with mock_combat_add(mock_ctx):
+            await cog._madd_impl(mock_ctx, mock_monster, "-n 3")
+            assert 12345 not in USER_MONSTER_FAVORITES_CACHE
+
+    @pytest.mark.asyncio
+    async def test_tracking_failure_does_not_break_combat(self, mock_ctx, mock_monster, tracking_cog):
+        """Analytics DB failure logs error but doesn't break combat."""
+        mock_ctx.bot.mdb.analytics_monster_usage.update_one = AsyncMock(side_effect=Exception("DB connection lost"))
+        cog = tracking_cog
+
+        async with mock_combat_add(mock_ctx) as (mock_combat, _):
+            await cog._madd_impl(mock_ctx, mock_monster, "")
+            mock_combat.add_combatant.assert_called_once()
+            mock_combat.final.assert_called_once()
+            mock_ctx.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_tracking_with_custom_controller(self, mock_ctx, mock_monster, tracking_cog):
+        cog = tracking_cog
+
+        mock_member = Mock()
+        mock_member.id = 99999
+        mock_member.bot = False
+
+        with patch("cogs5e.initiative.cog.commands.MemberConverter") as MockConverter:
+            mock_converter = AsyncMock()
+            mock_converter.convert = AsyncMock(return_value=mock_member)
+            MockConverter.return_value = mock_converter
+
+            async with mock_combat_add(mock_ctx):
+                await cog._madd_impl(mock_ctx, mock_monster, "-controller @OtherUser")
+                mock_ctx.bot.mdb.analytics_monster_usage.update_one.assert_called_once_with(
+                    {"user_id": 12345, "monster_name": "Goblin", "monster_id": 1},
+                    {"$inc": {"count": 1}, "$currentDate": {"last_used": True}},
+                    upsert=True,
+                )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
### Summary
Implements a new `/madd` slash command as a secondary way of adding monsters to combat initiative. `/madd` learns user's favourite monsters over time as they keep adding monsters to combat, it then boosts user's frequently added monsters to the top of the autocomplete search results.

### Changelog Entry
- Added new slash command `/madd` as a secondary way of adding monsters to combat initiative.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
