### PR TITLE
fix: reserve func names for cvar/uvar

### DIFF
--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -72,6 +72,32 @@ DEFAULT_BUILTINS = {
     "randchoice": randchoice,
     "randchoices": randchoices,
 }
+
+RESERVED_BUILTINS = set(DEFAULT_BUILTINS.keys()) | {
+    # ScriptingEvaluator built-in methods
+    "exists",
+    "get",
+    "combat",
+    "character",
+    "get_gvar",
+    "get_svar",
+    "set_uvar",
+    "get_uvars",
+    "get_uvar",
+    "delete_uvar",
+    "set_uvar_nx",
+    "uvar_exists",
+    "load_json",
+    "dump_json",
+    "load_yaml",
+    "dump_yaml",
+    "argparse",
+    "ctx",
+    "signature",
+    "verify_signature",
+    "using",
+}
+
 SCRIPTING_RE = re.compile(
     r"(?<!\\)(?:"  # backslash-escape
     r"{{(?P<drac1>.+?)}}"  # {{drac1}}

--- a/aliasing/helpers.py
+++ b/aliasing/helpers.py
@@ -259,6 +259,8 @@ def set_cvar(character, name, value):
         raise InvalidArgument(f"Cvar name must be shorter than {VAR_NAME_LIMIT} characters.")
     elif name in character.get_scope_locals(True):
         raise InvalidArgument(f"The variable `{name}` is already built in.")
+    elif name in evaluators.RESERVED_BUILTINS:
+        raise InvalidArgument(f"The variable `{name}` is a reserved function name.")
     elif len(value) > CVAR_SIZE_LIMIT:
         raise InvalidArgument(f"Cvars must be shorter than {CVAR_SIZE_LIMIT:,} characters.")
 
@@ -281,6 +283,8 @@ async def set_uvar(ctx, name, value):
         )
     elif len(name) > VAR_NAME_LIMIT:
         raise InvalidArgument(f"Uvar name must be shorter than {VAR_NAME_LIMIT} characters.")
+    elif name in evaluators.RESERVED_BUILTINS:
+        raise InvalidArgument(f"The variable `{name}` is a reserved function name.")
     elif len(value) > UVAR_SIZE_LIMIT:
         raise InvalidArgument(f"Uvars must be shorter than {UVAR_SIZE_LIMIT:,} characters.")
     await ctx.bot.mdb.uvars.update_one({"owner": str(ctx.author.id), "name": name}, {"$set": {"value": value}}, True)


### PR DESCRIPTION
### Summary
Adds validation to prevent cvars and uvars from using names that would shadow built-in functions.

### Changelog Entry
- Cvars and uvars can no longer shadow built-in function names

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
