### PR TITLE
Feat: Add AutomationCombatants!

### DIFF
--- a/cogs5e/models/automation/effects/castspell.py
+++ b/cogs5e/models/automation/effects/castspell.py
@@ -5,6 +5,7 @@ from cogs5e.models.errors import RequiresLicense, InvalidArgument
 from utils.functions import smart_trim
 from . import Effect
 from .ieffect import IEffectMetaVar
+from ..entities import AutomationEffect
 from ..results import CastSpellResult
 
 
@@ -81,7 +82,7 @@ class CastSpell(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect, AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an IEffectMetaVar "
                         f"(got `{type(parent_ref).__name__}`)."

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -10,6 +10,7 @@ from cogs5e.models.sheet.resistance import Resistance
 from utils.enums import AdvantageType
 from utils.functions import smart_trim
 from . import Effect
+from ..entities import AutomationEffect
 from ..errors import AutomationException, InvalidIntExpression, TargetException
 from ..results import IEffectResult
 
@@ -118,7 +119,7 @@ class LegacyIEffect(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect, AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an IEffectMetaVar "
                         f"(got `{type(parent_ref).__name__}`)."
@@ -315,7 +316,7 @@ class IEffect(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect, AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an initiative effect "
                         f"(expected IEffectMetaVar or SimpleEffect, got `{type(parent_ref).__name__}`)."
@@ -324,7 +325,7 @@ class IEffect(Effect):
                 explicit_parent = parent_ref._effect
             # explicit support for parenting to the parent of this ieffect's parent
             elif self.parent == "ieffect.parent" and (parent_ref := autoctx.metavars.get("ieffect", None)) is not None:
-                if not isinstance(parent_ref, aliasing.api.combat.SimpleEffect):
+                if not isinstance(parent_ref, (aliasing.api.combat.SimpleEffect, AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an initiative effect "
                         f"(expected SimpleEffect, got `{type(parent_ref).__name__}`)."

--- a/cogs5e/models/automation/effects/target.py
+++ b/cogs5e/models/automation/effects/target.py
@@ -2,6 +2,7 @@ from typing import Any, List, TYPE_CHECKING, Tuple, Union
 
 from . import Effect
 from .. import results, utils
+from ..entities import wrap_automation_entity
 from ..errors import TargetException
 from ..runtime import AutomationTarget
 
@@ -60,7 +61,7 @@ class Target(Effect):
 
         # restore the previous target
         autoctx.target = previous_target
-        autoctx.metavars["target"] = utils.maybe_alias_statblock(previous_target)  # #1335
+        autoctx.metavars["target"] = wrap_automation_entity(previous_target)  # #1335
 
         return results.TargetResult(iteration_results)
 
@@ -143,7 +144,7 @@ class Target(Effect):
     def run_effects(self, autoctx, target, target_index=0, original_target_index=None) -> list[results.TargetIteration]:
         # set up autoctx and metavars
         autoctx.target = AutomationTarget(autoctx, target)
-        autoctx.metavars["target"] = utils.maybe_alias_statblock(target)  # #1335
+        autoctx.metavars["target"] = wrap_automation_entity(target)  # #1335
         autoctx.metavars["targetIndex"] = target_index  # #1711
         autoctx.metavars["targetNumber"] = target_index + 1
 

--- a/cogs5e/models/automation/entities.py
+++ b/cogs5e/models/automation/entities.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import Any, Callable, List, Optional, TypeVar
+
+import aliasing.api.statblock
+import cogs5e.initiative.combatant as init
+from cogs5e.initiative.group import CombatantGroup
+
+from .utils import maybe_alias_statblock
+
+__all__ = ("AutomationEffect", "AutomationCombatant", "AutomationGroup", "wrap_automation_entity")
+
+_IntermediateT = TypeVar("_IntermediateT")
+T = TypeVar("T")
+
+
+class AutomationEffect:
+    """Read-only wrapper around an initiative effect."""
+
+    def __init__(self, effect: init.InitiativeEffect):
+        self._effect = effect
+        self.id = effect.id
+        self.name = effect.name
+        self.duration = effect.duration
+        self.remaining = effect.remaining
+        self.description = effect.desc
+        self.concentration = effect.concentration
+        self.ends_on_turn_end = effect.end_on_turn_end
+        self.effect = effect.effects.to_dict()
+        self.attacks = [attack.to_dict() for attack in effect.attacks]
+        self.buttons = [button.to_dict() for button in effect.buttons]
+        self.combatant_id = getattr(effect.combatant, "id", None)
+        self.combatant_name = getattr(effect.combatant, "name", None)
+
+    @cached_property
+    def parent(self) -> Optional["AutomationEffect"]:
+        parent = self._effect.get_parent_effect()
+        return AutomationEffect(parent) if parent else None
+
+    @cached_property
+    def children(self) -> List["AutomationEffect"]:
+        return [AutomationEffect(child) for child in self._effect.get_children_effects()]
+
+    def __repr__(self):
+        return f"<AutomationEffect name={self.name!r} remaining={self.remaining!r}>"
+
+
+class AutomationCombatant(aliasing.api.statblock.AliasStatBlock):
+    """
+    Read-only automation-friendly wrapper around an initiative combatant.
+    Exposes statblock data along with a handful of combat attributes.
+    """
+
+    def __init__(self, combatant: init.Combatant):
+        super().__init__(combatant)
+        self._combatant = combatant
+
+    @property
+    def id(self) -> str:
+        return self._combatant.id
+
+    @property
+    def controller_id(self) -> int:
+        return self._combatant.controller_id
+
+    @property
+    def init(self) -> int:
+        return self._combatant.init
+
+    @property
+    def initiative_bonus(self) -> int:
+        return int(self._combatant.init_skill)
+
+    @property
+    def note(self) -> Optional[str]:
+        return self._combatant.notes
+
+    @property
+    def is_private(self) -> bool:
+        return self._combatant.is_private
+
+    @property
+    def combatant_type(self):
+        return self._combatant.type
+
+    @property
+    def group(self) -> Optional[str]:
+        if hasattr(self._combatant, "group"):
+            return self._combatant.group
+        return None
+
+    def hp_str(self, private: bool = False) -> str:
+        return self._combatant.hp_str(private)
+
+    @cached_property
+    def effects(self) -> List[AutomationEffect]:
+        return [AutomationEffect(effect) for effect in self._combatant.get_effects()]
+
+    def get_effect_by_name(self, name: str, strict: Optional[bool] = None) -> Optional[AutomationEffect]:
+        """
+        Gets an effect on the combatant by its name.
+
+        :param str name: The name of the effect to get.
+        :param strict: Whether effect name must be a full case insensitive match.
+            If this is ``None`` or ``False`` (default), attempts a strict match with fallback to partial match.
+            If this is ``True``, it will only return a strict match.
+        :return: The effect or None.
+        :rtype: :class:`AutomationEffect` or None
+        """
+        name = str(name)
+        effects = self._combatant.get_effects()
+
+        # exact match first
+        exact = next((e for e in effects if name.lower() == e.name.lower()), None)
+        if exact:
+            return AutomationEffect(exact)
+
+        # partial match only if not strict
+        if strict is not True:
+            partial = next((e for e in effects if name.lower() in e.name.lower()), None)
+            if partial:
+                return AutomationEffect(partial)
+
+        return None
+
+    def is_concentrating(self) -> bool:
+        return self._combatant.is_concentrating()
+
+
+class AutomationGroup:
+    """Read-only representation of an initiative group."""
+
+    def __init__(self, group: CombatantGroup):
+        self._group = group
+
+    @property
+    def id(self) -> str:
+        return self._group.id
+
+    @property
+    def name(self) -> str:
+        return self._group.name
+
+    @property
+    def init(self) -> int:
+        return self._group.init
+
+    @property
+    def size(self) -> int:
+        return len(self._group.get_combatants())
+
+    @cached_property
+    def combatants(self) -> List[AutomationCombatant]:
+        return [AutomationCombatant(c) for c in self._group.get_combatants()]
+
+
+def wrap_automation_entity(target):
+    """
+    Wraps a StatBlock/combatant/group into the automation-friendly variant.
+    Returns AliasStatBlock for simple targets.
+    """
+    if isinstance(target, init.InitiativeEffect):
+        return AutomationEffect(target)
+    if isinstance(target, CombatantGroup):
+        return AutomationGroup(target)
+    if isinstance(target, init.Combatant):
+        return AutomationCombatant(target)
+    return maybe_alias_statblock(target)

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -7,10 +7,12 @@ import aliasing.evaluators
 import cogs5e.initiative.combatant as init
 from cogs5e.models import character as character_api, embeds
 from utils.enums import AdvantageType, CritDamageType
+from .entities import AutomationCombatant, AutomationEffect, AutomationGroup, wrap_automation_entity
 from .errors import AutomationEvaluationException, AutomationException, InvalidIntExpression
-from .utils import maybe_alias_statblock, parse_save_bonuses
+from .utils import parse_save_bonuses
 
 __all__ = ("AutomationContext", "AutomationTarget")
+
 
 if TYPE_CHECKING:
     import disnake
@@ -57,10 +59,11 @@ class AutomationContext:
         self.evaluator = aliasing.evaluators.AutomationEvaluator.with_caster(caster)
         self.metavars = {
             # caster, targets as default (#1335)
-            "caster": aliasing.api.statblock.AliasStatBlock(caster),
-            "targets": [maybe_alias_statblock(t) for t in targets],
+            "caster": wrap_automation_entity(caster),
+            "targets": [wrap_automation_entity(t) for t in targets],
             "choice": self.args.last("choice", original_choice).lower(),
         }
+        self._populate_combat_metavars()
 
         # spellcasting utils
         self.spell = spell
@@ -78,7 +81,7 @@ class AutomationContext:
         # InitiativeEffect utils
         self.ieffect = ieffect
         if ieffect is not None:
-            self.metavars["ieffect"] = aliasing.api.combat.SimpleEffect(ieffect)
+            self.metavars["ieffect"] = AutomationEffect(ieffect)
         self.from_button = from_button
         self.allow_caster_ieffects = allow_caster_ieffects
         self.allow_target_ieffects = allow_target_ieffects
@@ -109,6 +112,28 @@ class AutomationContext:
         self.combatant: Optional[init.Combatant] = None
         if isinstance(caster, init.Combatant):
             self.combatant: init.Combatant = caster  # type annotation to narrow type here
+
+    def _populate_combat_metavars(self):
+        """Injects combat-related metavars so automation can inspect turn/round state."""
+        self.metavars["combatRound"] = self.combat.round_num if self.combat else None
+        self.metavars["turnCombatant"] = None
+        self.metavars["turnCombatants"] = []
+
+        if not self.combat:
+            return
+
+        current = getattr(self.combat, "current_combatant", None)
+        if current is None:
+            return
+        turn_entity = wrap_automation_entity(current)
+        self.metavars["turnCombatant"] = turn_entity
+
+        if isinstance(turn_entity, AutomationGroup):
+            self.metavars["turnCombatants"] = turn_entity.combatants
+        elif isinstance(turn_entity, AutomationCombatant):
+            self.metavars["turnCombatants"] = [turn_entity]
+        elif turn_entity:
+            self.metavars["turnCombatants"] = [turn_entity]
 
     # ===== embed builder =====
     def queue(self, text):

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -34,10 +34,18 @@ Runtime Variables
 
 All Automation runs provide the following variables:
 
-- ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The character, combatant, or monster who is running the
-  automation.
-- ``targets`` (list of :class:`~aliasing.api.statblock.AliasStatBlock`, :class:`str`, or None) A list of combatants
-  targeted by this automation (i.e. the ``-t`` argument).
+- ``caster`` (:class:`~cogs5e.models.automation.entities.AutomationCombatant`) The character, combatant, or monster who
+  is running the automation.
+- ``targets`` (list of :class:`~cogs5e.models.automation.entities.AutomationCombatant`, :class:`str`, or ``None``) A
+  list of combatants targeted by this automation (i.e. the ``-t`` argument). Entries that refer to creatures outside of
+  initiative will expose the basic :class:`~aliasing.api.statblock.AliasStatBlock` placeholder instead.
+- ``combatRound`` (:class:`int` or ``None``) The current initiative round if the automation is running in combat.
+- ``turnCombatant`` (:class:`~cogs5e.models.automation.entities.AutomationCombatant`,
+  :class:`~cogs5e.models.automation.entities.AutomationGroup`, or ``None``) The creature or group whose turn it is when
+  the automation resolves. Available only while an initiative is active.
+- ``turnCombatants`` (list of :class:`~cogs5e.models.automation.entities.AutomationCombatant`) A convenience list
+  containing the members of ``turnCombatant``. If the current turn belongs to a group, this contains all group
+  members; otherwise it is a single-element list.
 - ``spell_attack_bonus`` (:class:`int` or None) - The attack bonus for the spell, or the caster's default attack bonus.
 - ``spell_dc`` (:class:`int` or None) - The DC for the spell, or the caster's default DC.
 - ``spell`` (:class:`int` or None) - The casting mod for the spell, or the caster's default casting mod.
@@ -47,8 +55,222 @@ All Automation runs provide the following variables:
 Additionally, runs triggered by an initiative effect (such as automation provided in a :ref:`ButtonInteraction`) provide
 the following variables:
 
-- ``ieffect`` (:class:`~aliasing.api.combat.SimpleEffect`) The initiative effect responsible for providing the
-  automation.
+- ``ieffect`` (:class:`~cogs5e.models.automation.entities.AutomationEffect`) The initiative effect responsible for
+  providing the automation.
+
+Automation Runtime Helper Types
+-------------------------------
+
+Some variables (such as ``caster`` and ``targets``) expose helper objects that mirror the combat state without allowing
+automation to mutate it.
+
+.. autoclass:: cogs5e.models.automation.entities.AutomationCombatant(aliasing.api.statblock.AliasStatBlock)
+   :members:
+   :inherited-members:
+
+   Read-only representation of a creature participating in automation. Inherits all
+   :class:`~aliasing.api.statblock.AliasStatBlock` statblock data (name, AC, HP, saves, spellbook, etc.) and adds
+   combat-specific attributes useful in automation contexts.
+
+   .. attribute:: id
+
+        Unique identifier of the combatant within initiative.
+
+        :type: str
+
+   .. attribute:: controller_id
+
+        The Discord user ID that controls the combatant.
+
+        :type: int
+
+   .. attribute:: init
+
+        The combatant's rolled initiative.
+
+        :type: int
+
+   .. attribute:: initiative_bonus
+
+        The initiative modifier used when rolling initiative.
+
+        :type: int
+
+   .. attribute:: note
+
+        Any note text attached to the combatant.
+
+        :type: str or None
+
+   .. attribute:: is_private
+
+        Whether the combatant is hidden from other players.
+
+        :type: bool
+
+   .. attribute:: combatant_type
+
+        The underlying combatant type (e.g. ``"pc"`` or ``"monster"``).
+
+        :type: str
+
+   .. attribute:: group
+
+        The name of the initiative group the combatant belongs to, if any.
+
+        :type: str or None
+
+   .. attribute:: effects
+
+        The initiative effects currently active on the combatant.
+
+        :type: list of :class:`AutomationEffect`
+
+   .. method:: get_effect_by_name(name, strict=None)
+      :noindex:
+
+        Gets an effect on a combatant. If an exact name is not found, it will attempt partial matching unless `strict=True`
+
+        :rtype: :class:`AutomationEffect` or None
+
+   .. method:: hp_str(private=False)
+      :noindex:
+
+        Returns a human-readable HP string (``"12/20"`` style). If ``private`` is true, hides the exact HP for monsters
+        that are configured as private in initiative.
+
+        :rtype: str
+
+   .. method:: is_concentrating()
+      :noindex:
+
+        Whether the combatant currently has any concentration effect active.
+
+        :rtype: bool
+
+.. autoclass:: cogs5e.models.automation.entities.AutomationGroup
+   :members:
+
+   Read-only representation of an initiative group.
+
+   .. attribute:: id
+
+        Unique identifier of the group.
+
+        :type: str
+
+   .. attribute:: name
+
+        The group name.
+
+        :type: str
+
+   .. attribute:: init
+
+        The initiative roll for the group.
+
+        :type: int
+
+   .. attribute:: size
+
+        Number of combatants in the group.
+
+        :type: int
+
+   .. attribute:: combatants
+
+        Members of the group.
+
+        :type: list of :class:`AutomationCombatant`
+
+.. autoclass:: cogs5e.models.automation.entities.AutomationEffect
+   :members:
+
+   Read-only representation of an initiative effect.
+
+   .. attribute:: id
+
+        Unique identifier of the effect.
+
+        :type: str
+
+   .. attribute:: name
+
+        Name of the effect.
+
+        :type: str
+
+   .. attribute:: duration
+
+        Total duration in rounds, or ``None``.
+
+        :type: int or None
+
+   .. attribute:: remaining
+
+        Remaining duration in rounds, or ``None``.
+
+        :type: int or None
+
+   .. attribute:: description
+
+        Effect description text.
+
+        :type: str
+
+   .. attribute:: concentration
+
+        Whether the effect requires concentration.
+
+        :type: bool
+
+   .. attribute:: ends_on_turn_end
+
+        Whether the effect expires at the end of the bearer’s turn.
+
+        :type: bool
+
+   .. attribute:: effect
+
+        Serialized automation payload applied by the effect.
+
+        :type: dict
+
+   .. attribute:: attacks
+
+        Serialized attack payloads attached to the effect.
+
+        :type: list of dict
+
+   .. attribute:: buttons
+
+        Serialized button payloads attached to the effect.
+
+        :type: list of dict
+
+   .. attribute:: combatant_id
+
+        ID of the combatant the effect is on.
+
+        :type: str or None
+
+   .. attribute:: combatant_name
+
+        Name of the combatant the effect is on.
+
+        :type: str or None
+
+   .. attribute:: parent
+
+        Parent effect if this was created by another effect.
+
+        :type: :class:`AutomationEffect` or None
+
+   .. attribute:: children
+
+        Child effects created from this effect.
+
+        :type: list of :class:`AutomationEffect`
 
 Target
 ------

--- a/tests/e2e/automation_effects_test.py
+++ b/tests/e2e/automation_effects_test.py
@@ -12,7 +12,8 @@ from cogs5e.models import automation
 from cogs5e.models.automation.utils import parse_save_bonuses
 from cogs5e.models.sheet.statblock import StatBlock
 from gamedata.compendium import compendium
-from tests.utils import active_character, active_combat, end_init, requires_data, start_init
+from tests.utils import ContextBotProxy, active_character, active_combat, end_init, requires_data, start_init
+from utils.argparser import ParsedArguments
 
 log = logging.getLogger(__name__)
 pytestmark = pytest.mark.asyncio
@@ -595,6 +596,88 @@ async def test_usecounter_build_str(counter, amount):
     result = usecounter.build_str(DEFAULT_CASTER, DEFAULT_EVALUATOR)
     log.info(f"UseCounter str: ({counter=!r}, {amount=!r}) -> {result}")
     assert result
+
+
+class TestAutomationMetavars:
+    @pytest.mark.usefixtures("character", "init_fixture")
+    async def test_combat_metavars_executor(self, avrae, dhttp):
+        effects = [{
+            "type": "target",
+            "target": "self",
+            "effects": [{
+                "type": "text",
+                "text": "{combatRound}|{turnCombatants[0].name}",
+            }],
+        }]
+        auto = automation.Automation.from_data(effects)
+        caster = StatBlock("Caster")
+        args = ParsedArguments.empty_args()
+        ctx = ContextBotProxy(avrae)
+
+        await start_init(avrae, dhttp)
+        avrae.message("!init join")
+        await dhttp.drain()
+
+        combat = await active_combat(avrae)
+        combat.round_num = 1
+
+        embed = disnake.Embed()
+        await auto.run(ctx=ctx, embed=embed, caster=caster, targets=[], args=args, combat=combat)
+        assert embed.fields[-1].value.startswith("1|")
+
+        combat.round_num = 2
+        embed = disnake.Embed()
+        await auto.run(ctx=ctx, embed=embed, caster=caster, targets=[], args=args, combat=combat)
+        assert embed.fields[-1].value.startswith("2|")
+
+        await end_init(avrae, dhttp)
+
+    @pytest.mark.usefixtures("character", "init_fixture")
+    async def test_set_hp_side_effects(self, avrae, dhttp):
+        attack = textwrap.dedent(
+            """
+            {
+              "name": "Set HP Automation Test",
+              "_v": 2,
+              "automation": [
+                {
+                  "type": "target",
+                  "target": "self",
+                  "effects": [
+                    {
+                      "type": "text",
+                      "text": "{target.set_hp(max(target.hp - 10, 0))}"
+                    }
+                  ]
+                }
+              ]
+            }
+            """
+        ).strip()
+
+        await start_init(avrae, dhttp)
+        avrae.message("!init join")
+        await dhttp.drain()
+
+        avrae.message(f"!a import {attack}")
+        await dhttp.receive_message(r"Imported 1 attacks.*\n.*", regex=True)
+
+        char = await active_character(avrae)
+        original_hp = char.hp
+
+        avrae.message('!a "Set HP Automation Test"')
+        await dhttp.drain()
+
+        char = await active_character(avrae)
+        combat = await active_combat(avrae)
+        combatant = combat.get_combatant(char.name, strict=True)
+
+        expected_hp = max(original_hp - 10, 0)
+        assert combatant.hp == expected_hp
+        assert char.hp == expected_hp
+
+        combatant.set_hp(original_hp)
+        await end_init(avrae, dhttp)
 
 
 # ==== Check ====

--- a/tests/unit/automation_entities_test.py
+++ b/tests/unit/automation_entities_test.py
@@ -1,0 +1,43 @@
+from cogs5e.initiative.combatant import Combatant
+from cogs5e.initiative.effects import InitiativeEffect
+from cogs5e.models.automation.entities import AutomationCombatant, AutomationEffect
+from tests.utils import ContextBotProxy
+
+
+def make_combatant(bot, name: str) -> Combatant:
+    return Combatant(
+        ctx=ContextBotProxy(bot),
+        combat=None,
+        id=name.lower(),
+        name=name,
+        controller_id=1,
+        private=False,
+        init=10,
+    )
+
+
+def add_effect(combatant: Combatant, name: str) -> InitiativeEffect:
+    effect = InitiativeEffect.new(combat=None, combatant=combatant, name=name)
+    combatant.add_effect(effect)
+    return effect
+
+
+def test_get_effect_by_name_matches_strict_and_partial(avrae):
+    combatant = make_combatant(avrae, "Fighter")
+    add_effect(combatant, "Bless")
+    add_effect(combatant, "Bane")
+
+    auto = AutomationCombatant(combatant)
+
+    effect = auto.get_effect_by_name("bless")
+    assert isinstance(effect, AutomationEffect)
+    assert effect.name == "Bless"
+
+    exact_on_partial_flag = auto.get_effect_by_name("Bless", strict=False)
+    assert exact_on_partial_flag and exact_on_partial_flag.name == "Bless"
+
+    partial = auto.get_effect_by_name("ban", strict=False)
+    assert partial and partial.name == "Bane"
+
+    assert auto.get_effect_by_name("nope", strict=True) is None
+    assert not isinstance(effect, InitiativeEffect)

--- a/tests/unit/automation_runtime_test.py
+++ b/tests/unit/automation_runtime_test.py
@@ -1,0 +1,76 @@
+import disnake
+
+from cogs5e.initiative.combatant import Combatant
+from cogs5e.initiative.group import CombatantGroup
+from cogs5e.models.automation.entities import AutomationCombatant, AutomationGroup
+from cogs5e.models.automation.runtime import AutomationContext
+from cogs5e.models.sheet.statblock import StatBlock
+from tests.utils import ContextBotProxy
+from utils.argparser import ParsedArguments
+
+
+class DummyCombat:
+    def __init__(self, round_num=1, current=None):
+        self.round_num = round_num
+        self._current = current
+
+    @property
+    def current_combatant(self):
+        return self._current
+
+
+def build_context(bot, combat, *, targets=None, caster=None):
+    return AutomationContext(
+        ctx=ContextBotProxy(bot),
+        embed=disnake.Embed(),
+        caster=caster or StatBlock("Caster"),
+        targets=targets or [],
+        args=ParsedArguments.empty_args(),
+        combat=combat,
+    )
+
+
+def make_combatant(bot, name: str, *, init_value: int = 10):
+    return Combatant(
+        ctx=ContextBotProxy(bot),
+        combat=None,
+        id=name.lower(),
+        name=name,
+        controller_id=1,
+        private=False,
+        init=init_value,
+    )
+
+
+def test_automation_context_turn_metavars_wrap_combatant(avrae):
+    current = make_combatant(avrae, "Rogue", init_value=14)
+    combat = DummyCombat(round_num=4, current=current)
+
+    autoctx = build_context(avrae, combat)
+
+    assert autoctx.metavars["combatRound"] == 4
+    assert isinstance(autoctx.metavars["turnCombatant"], AutomationCombatant)
+    assert autoctx.metavars["turnCombatant"].init == 14
+    assert [c.name for c in autoctx.metavars["turnCombatants"]] == ["Rogue"]
+
+
+def test_automation_context_turn_metavars_for_group(avrae):
+    members = [make_combatant(avrae, "Goblin A"), make_combatant(avrae, "Goblin B")]
+    group = CombatantGroup(
+        ctx=ContextBotProxy(avrae), combat=None, id="grp", combatants=members, name="Goblin Mob", init=12
+    )
+    combat = DummyCombat(round_num=2, current=group)
+
+    autoctx = build_context(avrae, combat)
+
+    assert isinstance(autoctx.metavars["turnCombatant"], AutomationGroup)
+    assert [c.name for c in autoctx.metavars["turnCombatants"]] == ["Goblin A", "Goblin B"]
+
+
+def test_target_metavars_wrap_combatants(avrae):
+    target = make_combatant(avrae, "Bandit")
+    combat = DummyCombat(round_num=1, current=None)
+
+    autoctx = build_context(avrae, combat, targets=[target])
+
+    assert isinstance(autoctx.metavars["targets"][0], AutomationCombatant)


### PR DESCRIPTION
### Summary
Adds `AutomationCombatant`, `AutomationGroup`, and `AutomationEffect`. Caster/target are wrapped to these new classes as well when applicable.
Previously, these were not accessible in automation. Simple objects from Aliasing would not work due to state changes. These are read-only classes for accessing information in Automation only.

### Changelog Entry
Various ways of accessing combatant information have been added to Automation. Check the docs!

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
