### PR TITLE
feat: persist choice/cast level in effects

### DIFF
--- a/aliasing/api/validators.py
+++ b/aliasing/api/validators.py
@@ -57,6 +57,10 @@ class AttackInteraction(BaseModel):
     override_default_dc: Optional[int]
     override_default_attack_bonus: Optional[int]
     override_default_casting_mod: Optional[int]
+    # include -choice and spell cast level
+    granting_spell_id: Optional[int] = None
+    granting_spell_cast_level: Optional[int] = None
+    original_choice: Optional[str] = ""
 
     def dict(self, *args, **kwargs):
         kwargs.setdefault("by_alias", True)
@@ -71,6 +75,9 @@ class ButtonInteraction(BaseModel):
     override_default_dc: Optional[int]
     override_default_attack_bonus: Optional[int]
     override_default_casting_mod: Optional[int]
+    granting_spell_id: Optional[int] = None
+    granting_spell_cast_level: Optional[int] = None
+    original_choice: Optional[str] = ""
 
 
 # ==== helpers ====

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -976,6 +976,9 @@ Some examples are provided below.
         override_default_dc: Optional[int]
         override_default_attack_bonus: Optional[int]
         override_default_casting_mod: Optional[int]
+        granting_spell_id: Optional[int]
+        granting_spell_cast_level: Optional[int]
+        original_choice: Optional[str]
 
     class ButtonInteraction:
         automation: Automation  # this can be any automation built on the Avrae Dashboard
@@ -985,6 +988,9 @@ Some examples are provided below.
         override_default_dc: Optional[int]
         override_default_attack_bonus: Optional[int]
         override_default_casting_mod: Optional[int]
+        granting_spell_id: Optional[int]
+        granting_spell_cast_level: Optional[int]
+        original_choice: Optional[str]
 
 **Example: Passive Effects**
 


### PR DESCRIPTION
### Summary
Allows for specifying some extra fields when adding effects that you previously could not in automation.
Allows for copying effects with original choice & spell level.
Reference: https://discord.com/channels/269275778867396608/795769081282297928/1386853378365325486

### Changelog Entry

Added `granting_spell_id`, `granting_spell_cast_level`, and `original_choice` as possible fields to `SimpleCombatant.add_effect`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
