### PR TITLE
feat: expose tick_on_combatant_id on SimpleEffect

### DIFF
--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -620,6 +620,7 @@ class SimpleEffect:
         self.conc = self._effect.concentration
         self.desc = self._effect.desc
         self.ticks_on_end = self._effect.end_on_turn_end
+        self.tick_on_combatant_id = self._effect.tick_on_combatant_id
         self.combatant_name = self._effect.combatant.name
         self._parent = None
         self._children = None

--- a/docs/aliasing/api.rst
+++ b/docs/aliasing/api.rst
@@ -926,6 +926,12 @@ SimpleEffect
 
         :type: bool
 
+    .. attribute:: tick_on_combatant_id
+
+        The ID of the combatant whose turn the effect duration ticks on (defaults to the combatant the effect is on).
+
+        :type: str or None
+
     .. attribute:: attacks
 
         A list of the attacks granted by the effect.

--- a/tests/unit/aliasing/combat_test.py
+++ b/tests/unit/aliasing/combat_test.py
@@ -1,0 +1,19 @@
+from types import SimpleNamespace
+
+from aliasing.api.combat import SimpleEffect
+from cogs5e.initiative.effects.effect import InitiativeEffect
+
+
+def test_simpleeffect_exposes_tick_on_combatant_id():
+    combatant = SimpleNamespace(name="Target")
+    effect = InitiativeEffect(
+        combat=None,
+        combatant=combatant,  # type: ignore
+        id="effect-1",
+        name="Test Effect",
+        tick_on_combatant_id="caster-123",
+    )
+
+    simple_effect = SimpleEffect(effect)
+
+    assert simple_effect.tick_on_combatant_id == "caster-123"


### PR DESCRIPTION
### Summary

Resolves AFR-1094

Adds `tick_on_combatant_id` to `SimpleEffect` in Aliases

### Changelog Entry

`tick_on_combatant_id` is now properly exposed for `SimpleEffect`s

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [X] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
