### PR TITLE
fix(dcv2): give spell_actions a default

### DIFF
--- a/cogs5e/sheets/dicecloudv2.py
+++ b/cogs5e/sheets/dicecloudv2.py
@@ -584,6 +584,7 @@ class DicecloudV2Parser(SheetLoaderABC):
                 continue
 
             import_action = "avrae:no_action" not in spell["tags"] + spell.get("libraryTags", [])
+            spell_actions = []
             if import_action:
                 spell_actions = self.persist_actions_for_name(spell["name"])
                 actions += spell_actions


### PR DESCRIPTION
### Summary
Makes ignoring actions from a spell in Dicecloud V2 work without giving an error.

### Changelog Entry
Ignoring actions from a spell in Dicecloud V2 now works properly.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
