### PR TITLE
fix: prevent passive_effects dmg bonus from reducing healing

### DIFF
--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -83,7 +83,7 @@ class Damage(Effect):
         d_args = []
         if not (self.contains_roll_meta(autoctx) or self.fixedValue):
             d_args = args.get("d", [], ephem=True)
-            # #224: filter bonuses by sign: positive for damage, negative for healing
+            # #224: filter bonuses by type: 'heal' for healing, else for damage
             effect_bonuses = autoctx.caster_active_effects(mapper=lambda e: e.effects.damage_bonus, default=[])
             d_args.extend(utils.filter_dmg_bonuses(damage, effect_bonuses))
 

--- a/cogs5e/models/automation/effects/damage.py
+++ b/cogs5e/models/automation/effects/damage.py
@@ -78,15 +78,15 @@ class Damage(Effect):
         if autoctx.target.is_simple and self.is_meta(autoctx):
             return
 
-        d_args = []
-        # check if we actually need to care about the -d tag
-        if not (self.contains_roll_meta(autoctx) or self.fixedValue):
-            d_args = args.get("d", [], ephem=True)
-            # add on combatant damage effects (#224)
-            d_args.extend(autoctx.caster_active_effects(mapper=lambda effect: effect.effects.damage_bonus, default=[]))
-
         # set up damage AST
         damage = autoctx.parse_annostr(damage)
+        d_args = []
+        if not (self.contains_roll_meta(autoctx) or self.fixedValue):
+            d_args = args.get("d", [], ephem=True)
+            # #224: filter bonuses by sign: positive for damage, negative for healing
+            effect_bonuses = autoctx.caster_active_effects(mapper=lambda e: e.effects.damage_bonus, default=[])
+            d_args.extend(utils.filter_dmg_bonuses(damage, effect_bonuses))
+
         dice_ast = copy.copy(d20.parse(damage))
         dice_ast = utils.upcast_scaled_dice(self, autoctx, dice_ast)
 

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -54,7 +54,7 @@ class Roll(Effect):
 
         if not (self.fixedValue or self.hidden):
             d = autoctx.args.join("d", "+", ephem=True)
-            # #224: filter bonuses by sign: positive for damage, negative for healing
+            # #224: filter bonuses by type: 'heal' for healing, else for damage
             all_bonuses = autoctx.caster_active_effects(mapper=lambda e: e.effects.damage_bonus, default=[])
             effect_bonuses = utils.filter_dmg_bonuses(dice_str, all_bonuses)
             if effect_bonuses:

--- a/cogs5e/models/automation/effects/roll.py
+++ b/cogs5e/models/automation/effects/roll.py
@@ -48,21 +48,18 @@ class Roll(Effect):
     def run(self, autoctx):
         super().run(autoctx)
 
-        dice_ast = copy.copy(d20.parse(autoctx.parse_annostr(self.dice)))
+        dice_str = autoctx.parse_annostr(self.dice)
+        dice_ast = copy.copy(d20.parse(dice_str))
         dice_ast = utils.upcast_scaled_dice(self, autoctx, dice_ast)
 
         if not (self.fixedValue or self.hidden):
             d = autoctx.args.join("d", "+", ephem=True)
-
-            # add on combatant damage effects (#224)
-            effect_d = autoctx.caster_active_effects(
-                mapper=lambda effect: effect.effects.damage_bonus, reducer="+".join
-            )
-            if effect_d:
-                if d:
-                    d = f"{d}+{effect_d}"
-                else:
-                    d = effect_d
+            # #224: filter bonuses by sign: positive for damage, negative for healing
+            all_bonuses = autoctx.caster_active_effects(mapper=lambda e: e.effects.damage_bonus, default=[])
+            effect_bonuses = utils.filter_dmg_bonuses(dice_str, all_bonuses)
+            if effect_bonuses:
+                effect_d = "+".join(effect_bonuses)
+                d = f"{d}+{effect_d}" if d else effect_d
 
             if d:
                 d_ast = d20.parse(d)

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -177,6 +177,12 @@ def tree_map_prefix(func: Callable[[TreeType], tuple[TreeType, bool]], node: Tre
     return operated
 
 
+def filter_dmg_bonuses(damage_str: str, bonuses: list[str]) -> list[str]:
+    """Positive bonuses for damage, negative for healing."""
+    is_healing = damage_str.lstrip().startswith("-")
+    return [b for b in bonuses if is_healing == b.lstrip().startswith("-")]
+
+
 def parse_save_bonuses(save_type: str, save_bonuses: list[str]) -> list[str]:
     """
     Parse a save bonus string.

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -178,9 +178,9 @@ def tree_map_prefix(func: Callable[[TreeType], tuple[TreeType, bool]], node: Tre
 
 
 def filter_dmg_bonuses(damage_str: str, bonuses: list[str]) -> list[str]:
-    """Positive bonuses for damage, negative for healing."""
+    """Filter bonuses by type: 'heal' for healing rolls, else for damage rolls."""
     is_healing = damage_str.lstrip().startswith("-")
-    return [b for b in bonuses if is_healing == b.lstrip().startswith("-")]
+    return [b for b in bonuses if is_healing == ("heal" in b.lower())]
 
 
 def parse_save_bonuses(save_type: str, save_bonuses: list[str]) -> list[str]:

--- a/tests/unit/dmg_bonus_filter_test.py
+++ b/tests/unit/dmg_bonus_filter_test.py
@@ -1,0 +1,43 @@
+"""Unit tests for passive_effects damage_bonus filtering by sign."""
+
+from cogs5e.models.automation.utils import filter_dmg_bonuses
+
+
+def test_damage_gets_positive_bonus():
+    result = filter_dmg_bonuses("1d8 [fire]", ["2 [fire]"])
+    assert result == ["2 [fire]"]
+
+
+def test_damage_skips_negative_bonus():
+    result = filter_dmg_bonuses("1d8 [fire]", ["-2"])
+    assert result == []
+
+
+def test_healing_gets_negative_bonus():
+    result = filter_dmg_bonuses("-1d8 [healing]", ["-2"])
+    assert result == ["-2"]
+
+
+def test_healing_skips_positive_bonus():
+    result = filter_dmg_bonuses("-1d8 [healing]", ["2 [fire]"])
+    assert result == []
+
+
+def test_damage_filters_mixed():
+    result = filter_dmg_bonuses("1d8", ["2", "-3", "1d4", "-1d6"])
+    assert result == ["2", "1d4"]
+
+
+def test_healing_filters_mixed():
+    result = filter_dmg_bonuses("-1d8", ["2", "-3", "1d4", "-1d6"])
+    assert result == ["-3", "-1d6"]
+
+
+def test_empty_bonuses():
+    assert filter_dmg_bonuses("1d8", []) == []
+    assert filter_dmg_bonuses("-1d8", []) == []
+
+
+def test_whitespace_handling():
+    assert filter_dmg_bonuses("  -1d8", ["-2"]) == ["-2"]
+    assert filter_dmg_bonuses("-1d8", ["  -2"]) == ["  -2"]

--- a/tests/unit/dmg_bonus_filter_test.py
+++ b/tests/unit/dmg_bonus_filter_test.py
@@ -1,43 +1,48 @@
-"""Unit tests for passive_effects damage_bonus filtering by sign."""
+"""Unit tests for passive_effects damage_bonus filtering by type."""
 
 from cogs5e.models.automation.utils import filter_dmg_bonuses
 
 
-def test_damage_gets_positive_bonus():
-    result = filter_dmg_bonuses("1d8 [fire]", ["2 [fire]"])
-    assert result == ["2 [fire]"]
+# damage rolls get non-heal bonuses
+def test_damage_gets_non_heal_bonus():
+    assert filter_dmg_bonuses("1d8 [fire]", ["2 [fire]"]) == ["2 [fire]"]
+    assert filter_dmg_bonuses("1d8", ["-2"]) == ["-2"]  # damage penalty works
 
 
-def test_damage_skips_negative_bonus():
-    result = filter_dmg_bonuses("1d8 [fire]", ["-2"])
-    assert result == []
+def test_damage_skips_heal_bonus():
+    assert filter_dmg_bonuses("1d8 [fire]", ["2 [healing]"]) == []
+    assert filter_dmg_bonuses("1d8", ["-2 [heal]"]) == []
 
 
-def test_healing_gets_negative_bonus():
-    result = filter_dmg_bonuses("-1d8 [healing]", ["-2"])
-    assert result == ["-2"]
+# healing rolls get heal bonuses only
+def test_healing_gets_heal_bonus():
+    assert filter_dmg_bonuses("-1d8 [healing]", ["-2 [healing]"]) == ["-2 [healing]"]
+    assert filter_dmg_bonuses("-1d8", ["-2 [heal]"]) == ["-2 [heal]"]
+    assert filter_dmg_bonuses("-1d8", ["-3 [magical healing]"]) == ["-3 [magical healing]"]
 
 
-def test_healing_skips_positive_bonus():
-    result = filter_dmg_bonuses("-1d8 [healing]", ["2 [fire]"])
-    assert result == []
+def test_healing_skips_non_heal_bonus():
+    assert filter_dmg_bonuses("-1d8 [healing]", ["2 [fire]"]) == []
+    assert filter_dmg_bonuses("-1d8", ["-2"]) == []  # no heal type = skipped
 
 
+# mixed bonuses
 def test_damage_filters_mixed():
-    result = filter_dmg_bonuses("1d8", ["2", "-3", "1d4", "-1d6"])
-    assert result == ["2", "1d4"]
+    result = filter_dmg_bonuses("1d8", ["2 [fire]", "-3 [healing]", "1d4", "-1d6 [heal]"])
+    assert result == ["2 [fire]", "1d4"]
 
 
 def test_healing_filters_mixed():
-    result = filter_dmg_bonuses("-1d8", ["2", "-3", "1d4", "-1d6"])
-    assert result == ["-3", "-1d6"]
+    result = filter_dmg_bonuses("-1d8", ["2 [fire]", "-3 [healing]", "1d4", "-1d6 [heal]"])
+    assert result == ["-3 [healing]", "-1d6 [heal]"]
 
 
+# edge cases
 def test_empty_bonuses():
     assert filter_dmg_bonuses("1d8", []) == []
     assert filter_dmg_bonuses("-1d8", []) == []
 
 
 def test_whitespace_handling():
-    assert filter_dmg_bonuses("  -1d8", ["-2"]) == ["-2"]
-    assert filter_dmg_bonuses("-1d8", ["  -2"]) == ["  -2"]
+    assert filter_dmg_bonuses("  -1d8", ["-2 [healing]"]) == ["-2 [healing]"]
+    assert filter_dmg_bonuses("-1d8", ["  -2 [heal]"]) == ["  -2 [heal]"]


### PR DESCRIPTION
### Summary                                                                                                 
  - `passive_effects` damage bonuses now filter by type: bonuses with 'heal' in the string apply to healing rolls, 
  others apply to damage rolls                                                                                     
  - Fixes issue where `+2 [fire]` from an initiative effect would reduce `-1d8 [healing]` output                   
  - User-provided `-d` arguments are unaffected                                                                    
  - Damage penalties (e.g., `-2`) still work on damage rolls

### How to Test:
- Replace <char_name> with a test character to test this:
```
!multiline
!i begin
!i join
!action add "Fire Strike" -b 5 -d "1d8 [fire]"
!action add "Healing Touch" -d "-1d8 [healing]"
!i effect <char_name> "Damage Buff" -d "2 [fire]"
!a "Fire Strike" hit
!a "Healing Touch" hit
!i effect <char_name> "Healing Buff" -d "-3 [magical healing]"
!a "Fire Strike" hit
!a "Healing Touch" hit
!action delete "Fire Strike"
!action delete "Healing Touch"
```

### Behaviour Before:
<img width="416" height="683" alt="image" src="https://github.com/user-attachments/assets/b048e3fd-7372-425f-8229-88f310b02c9f" />

### Behaviour After:
<img width="374" height="674" alt="image" src="https://github.com/user-attachments/assets/22d38616-f07a-4b1e-8bab-5ebaeb47a71c" />

### Changelog Entry
Fixed damage bonuses from passive effects reducing healing output

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
