### PR TITLE
feat: add `reply_to_id` to `AliasCtx` and `-reply` option to `embed`

### DIFF
--- a/aliasing/api/context.py
+++ b/aliasing/api/context.py
@@ -19,6 +19,7 @@ class AliasContext:
         self._prefix = ctx.prefix
         self._alias = ctx.invoked_with
         self._message_id = ctx.message.id
+        self._reply_to_id = ctx.message.reference.message_id if ctx.message.reference else None
 
     @property
     def guild(self):
@@ -82,10 +83,23 @@ class AliasContext:
         """
         return self._message_id
 
+    @property
+    def reply_to_id(self):
+        """
+        The ID of the message being replied to, if the alias was invoked as a reply.
+        Returns None if the alias invocation was not a reply.
+
+        >>> !test {{ctx.reply_to_id}}
+        982495360129847306
+
+        :rtype: int or None
+        """
+        return self._reply_to_id
+
     def __repr__(self):
         return (
             f"<{self.__class__.__name__} guild={self.guild!r} channel={self.channel!r} author={self.author!r} "
-            f"prefix={self.prefix!r} alias={self.alias!r} message={self.message_id!r}>"
+            f"prefix={self.prefix!r} alias={self.alias!r} message={self.message_id!r} reply_to={self.reply_to_id!r}>"
         )
 
 

--- a/cogs5e/pbpUtils.py
+++ b/cogs5e/pbpUtils.py
@@ -6,6 +6,7 @@ Created on Jan 13, 2017
 
 from math import sqrt
 
+import disnake
 from disnake.ext import commands
 
 from cogs5e.models import embeds
@@ -48,6 +49,8 @@ class PBPUtils(commands.Cog):
         -color [hex color]
             Leave blank for random color.
         -t <timeout (0..600)>
+        -reply <message_id>
+            Makes the bot's message a reply to the specified message.
         """
         await try_delete(ctx.message)
 
@@ -72,10 +75,19 @@ class PBPUtils(commands.Cog):
             except:
                 pass
 
+        reference = None
+        try:
+            reply_id = args.last("reply", type_=int)
+            if reply_id:
+                reference = disnake.MessageReference(
+                    message_id=reply_id, channel_id=ctx.channel.id, fail_if_not_exists=False
+                )
+        except (ValueError, TypeError):
+            pass
         if timeout:
-            await ctx.send(embed=embed, delete_after=timeout)
+            await ctx.send(embed=embed, delete_after=timeout, reference=reference, mention_author=False)
         else:
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, reference=reference, mention_author=False)
 
     @commands.command()
     async def br(self, ctx):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -148,6 +148,7 @@ class ContextBotProxy:
 class MessageProxy:
     def __init__(self):
         self.id = int(MESSAGE_ID)
+        self.reference = None
 
 
 # ==== assertion helpers ====


### PR DESCRIPTION
### Summary
This include a new field `AliasCtx.reply_to_id` which is the message ID of the message this alias invocation is replying to, if any.

Additionally, it adds the `-reply` to the `embed` command, the value being the message ID of another message in the channel, which can be used for the generated embed to be sent as a response to said message.

This allows creating an alias like:
```
!alias smart_reply embed -title "Response" -desc "Acknowledged!" {{f"-reply {ctx.reply_to_id}" if ctx.reply_to_id else ""}}
```

<img width="1427" height="660" alt="image" src="https://github.com/user-attachments/assets/c1e183b1-854a-441d-894d-ef13b54b21aa" />

In the image above the second message was not sent as a reply, so it doesnt link to any message

### Changelog Entry
add `reply_to_id` to `AliasCtx` and `-reply` option to `embed`

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.




