### PR TITLE
AVR-1070 fix group sorting in init for mixed init skills

### DIFF
--- a/cogs5e/initiative/group.py
+++ b/cogs5e/initiative/group.py
@@ -74,11 +74,8 @@ class CombatantGroup(Combatant):
 
     @property
     def init_skill(self):
-        # groups: if all combatants are the same type, return the first one's skill, otherwise +0
-        if (
-            all(c.type == CombatantType.MONSTER for c in self._combatants)
-            and len(set(c.monster_name for c in self._combatants)) == 1
-        ):
+        # groups: return the initiative of the first combatant in the group if there is one, otherwise +0
+        if self._combatants:
             return self._combatants[0].init_skill
         return Skill(0)
 
@@ -115,6 +112,8 @@ class CombatantGroup(Combatant):
         self._combatants.append(combatant)
         combatant.group = self.id
         combatant.init = self.init
+        # Adding the first combatant changes the group's init_skill tie-breaker.
+        self.combat.sort_combatants()
 
     def remove_combatant(self, combatant):
         self._combatants.remove(combatant)


### PR DESCRIPTION
### Summary
Resolves AVR-1070
Changes to cogs5e/initiative/group.py to apply the init_skill of the first member in the group and ensure resort when a group is first created

### Changelog Entry
Fix to sort order of init when a group is on the same init step as another combatant

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
