### PR TITLE
fix: roll kind default value added

### DIFF
--- a/ddb/dice/tree.py
+++ b/ddb/dice/tree.py
@@ -111,7 +111,7 @@ class RollRequestRoll:
     def from_dict(cls, d):
         dice_notation = DiceNotation.from_dict(d["diceNotation"])
         roll_type = RollType(d["rollType"])
-        roll_kind = RollKind(d["rollKind"])
+        roll_kind = RollKind(d.get("rollKind", RollKind.NONE.value))
         if (result := d.get("result")) is not None:
             result = RollResult.from_dict(result)
         return cls(dice_notation, roll_type, roll_kind, result)


### PR DESCRIPTION
### Summary
Default value added to rollkind, so that upstream can omit passing it without breaking the bot

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
