### PR TITLE
[AVR-1893] Fix: Use v1 auth tokens for DDB backend service calls

### DIFF
--- a/cogs5e/gamelog/character.py
+++ b/cogs5e/gamelog/character.py
@@ -29,7 +29,7 @@ class CharacterHandler(GameLogCallbackHandler):
             return
 
         character_id = data.character_id
-        ddb_user = await self.bot.ddb.get_ddb_user(gctx, gctx.discord_user_id)
+        ddb_user = await self.bot.ddb.get_ddb_user(gctx, gctx.discord_user_id, auth_v1=True)
         resp = await self.bot.ddb.scds.get_characters(ddb_user, [character_id])
         if not resp.found_characters:
             return

--- a/cogs5e/gamelog/cog.py
+++ b/cogs5e/gamelog/cog.py
@@ -184,7 +184,7 @@ class GameLog(commands.Cog):
         if campaign_link.channel_id != ctx.channel.id:
             return None, None
         # and the user must have their ddb acct connected
-        ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id)
+        ddb_user = await self.bot.ddb.get_ddb_user(ctx, ctx.author.id, auth_v1=True)
         if ddb_user is None:
             return campaign_id, None
         # and they must be allowed to use game log send by feature flag

--- a/cogs5e/models/ddbsync.py
+++ b/cogs5e/models/ddbsync.py
@@ -17,7 +17,7 @@ class DDBSheetSync(LiveIntegration):
             raise ValueError("Attempted to call DDB sheet sync method with no valid context")
         if self._ddb_user is not _sentinel:
             return self._ddb_user
-        ddb_user = await self._ctx.bot.ddb.get_ddb_user(self._ctx)
+        ddb_user = await self._ctx.bot.ddb.get_ddb_user(self._ctx, auth_v1=True)
         self._ddb_user = ddb_user
         return ddb_user
 
@@ -102,7 +102,7 @@ class DDBSheetSync(LiveIntegration):
             pass
 
     async def commit(self, ctx):
-        ddb_user = await ctx.bot.ddb.get_ddb_user(ctx)
+        ddb_user = await ctx.bot.ddb.get_ddb_user(ctx, auth_v1=True)
         self._ddb_user = ddb_user
         if ddb_user is None:
             return


### PR DESCRIPTION
### Summary
Fixes authentication failures when syncing character data with D&D Beyond services.

#### Problem

PR #2251 changed the default auth endpoint from v1 to v2. While some call sites were updated to explicitly use `auth_v1=True`, several were missed:

- Character sync (HP, counters, spell slots, etc.) → Character Service returned **403 "Anonymous"**
- GameLog roll posting → GameLog REST returned **403 Forbidden**
- Inbound character sync from DDB → SCDS returned **502 Internal Server Error**

####
All changes add `auth_v1=True` to `get_ddb_user()` calls that interact with DDB backend services.

### Changelog Entry
Fixed error: authentication failures when syncing character data on the bot with D&D Beyond services.
### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
