### PR TITLE
[AVR-1897] Fix: Default DieTerm operand to 1 if missing or empty in DDB dice payloads

### DIFF
--- a/ddb/dice/tree.py
+++ b/ddb/dice/tree.py
@@ -26,6 +26,7 @@ import d20
 from .constants import DiceOperation, RollKind, RollType
 
 SUPPORTED_DIE_SIZES = (4, 6, 8, 10, 12, 20, 100)
+DEFAULT_OPERAND = 1
 
 
 class RollRequest:
@@ -298,7 +299,10 @@ class DieTerm:
     def from_dict(cls, d):
         dice = [Die.from_dict(die) for die in d["dice"]]
         operation = DiceOperation(d["operation"])
-        return cls(d["count"], d["dieType"], dice, operation, d.get("operand"))
+        operand = d.get("operand")
+        if operand in (None, ""):
+            operand = DEFAULT_OPERAND
+        return cls(d["count"], d["dieType"], dice, operation, operand)
 
     def to_dict(self):
         dice = [die.to_dict() for die in self.dice]


### PR DESCRIPTION
### Summary
This PR addresses an issue where D&D Beyond (DDB) dice roll payloads may omit the operand field or provide it as an empty string, causing downstream errors in Avrae when constructing dice expressions. The fix ensures that when deserializing a DieTerm from a DDB payload, the operand is defaulted to 1 if it is missing or empty

### Changelog Entry
Fix: Default DieTerm operand to 1 if missing or empty in DDB dice payloads

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
