### PR TITLE
Automation Upgrades

### DIFF
--- a/aliasing/api/automation.py
+++ b/aliasing/api/automation.py
@@ -1,0 +1,411 @@
+from functools import cached_property
+
+from aliasing.api.statblock import (
+    AliasAttackList,
+    AliasBaseStats,
+    AliasLevels,
+    AliasResistances,
+    AliasSaves,
+    AliasSkills,
+    AliasSpellbookSpell,
+)
+from cogs5e.models.sheet.statblock import StatBlock
+
+
+def wrap_target(value):
+    """Wrap an automation target, preserving placeholder statblock behavior for string/None targets."""
+    if isinstance(value, (str, type(None))):
+        return AutomationStatBlock(StatBlock(name=value or "Target"))
+    return wrap_statblock(value)
+
+
+def wrap_statblock(statblock):
+    """Return the correct automation wrapper for the given actor-like object."""
+
+    # Deferred to avoid a circular dependency with Character and Combatant.
+    from cogs5e.initiative.combatant import Combatant, PlayerCombatant
+    from cogs5e.initiative.group import CombatantGroup
+    from cogs5e.models.character import Character
+
+    if isinstance(statblock, CombatantGroup):
+        return AutomationGroup(statblock)
+    if isinstance(statblock, PlayerCombatant):
+        return AutomationCharacter(statblock.character, combatant=statblock)
+    if isinstance(statblock, Character):
+        return AutomationCharacter(statblock)
+    if isinstance(statblock, Combatant):
+        return AutomationCombatant(statblock)
+    if isinstance(statblock, StatBlock):
+        return AutomationStatBlock(statblock)
+    raise TypeError(f"Unsupported automation statblock type: {type(statblock).__name__}")
+
+
+class AutomationStatBlock:
+    def __init__(self, statblock: StatBlock):
+        self._statblock = statblock
+        self._stats = None
+        self._levels = None
+        self._attacks = None
+        self._skills = None
+        self._saves = None
+        self._resistances = None
+        self._spellbook = None
+
+    @property
+    def name(self):
+        return self._statblock.name
+
+    @property
+    def stats(self):
+        if self._stats is None:
+            self._stats = AliasBaseStats(self._statblock.stats)
+        return self._stats
+
+    @property
+    def levels(self):
+        if self._levels is None:
+            self._levels = AliasLevels(self._statblock.levels)
+        return self._levels
+
+    @property
+    def attacks(self):
+        if self._attacks is None:
+            self._attacks = AliasAttackList(self._statblock.attacks, self._statblock)
+        return self._attacks
+
+    @property
+    def skills(self):
+        if self._skills is None:
+            self._skills = AliasSkills(self._statblock.skills)
+        return self._skills
+
+    @property
+    def saves(self):
+        if self._saves is None:
+            self._saves = AliasSaves(self._statblock.saves)
+        return self._saves
+
+    @property
+    def resistances(self):
+        if self._resistances is None:
+            self._resistances = AliasResistances(self._statblock.resistances)
+        return self._resistances
+
+    @property
+    def ac(self):
+        return self._statblock.ac
+
+    @property
+    def max_hp(self):
+        return self._statblock.max_hp
+
+    @property
+    def hp(self):
+        return self._statblock.hp
+
+    @property
+    def temp_hp(self):
+        return self._statblock.temp_hp
+
+    @property
+    def spellbook(self):
+        if self._spellbook is None:
+            self._spellbook = AutomationSpellbook(self._statblock.spellbook)
+        return self._spellbook
+
+    @property
+    def creature_type(self):
+        return self._statblock.creature_type
+
+    def hp_str(self):
+        return self._statblock.hp_str()
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} name={self.name!r}>"
+
+
+class AutomationCombatant(AutomationStatBlock):
+    def __init__(self, statblock):
+        super().__init__(statblock)
+        self._combatant = statblock
+
+    @property
+    def id(self):
+        return self._combatant.id
+
+    @property
+    def note(self):
+        return self._combatant.notes
+
+    @property
+    def controller(self):
+        return self._combatant.controller_id
+
+    @property
+    def group(self):
+        group = self._combatant.get_group()
+        return group.name if group else None
+
+    @property
+    def is_hidden(self):
+        return bool(self._combatant.is_private)
+
+    @property
+    def monster_name(self):
+        return getattr(self._combatant, "monster_name", None)
+
+    @property
+    def monster_id(self):
+        return getattr(self._combatant, "monster_id", None)
+
+    @cached_property
+    def effects(self):
+        return [AutomationEffect(effect) for effect in self._combatant.get_effects()]
+
+    def get_effect(self, name: str, strict: bool = False):
+        effect = self._combatant.get_effect(str(name), strict)
+        if effect:
+            return AutomationEffect(effect)
+        return None
+
+
+class AutomationCharacter(AutomationCombatant):
+    def __init__(self, character, combatant=None):
+        AutomationStatBlock.__init__(self, combatant or character)
+        self._character = character
+        self._combatant = combatant
+        self._in_combat = combatant is not None
+
+    @property
+    def owner(self):
+        return self._character.owner
+
+    @property
+    def upstream(self):
+        return self._character.upstream
+
+    @property
+    def sheet_type(self):
+        return self._character.sheet_type
+
+    @property
+    def race(self):
+        return self._character.race
+
+    @property
+    def background(self):
+        return self._character.background
+
+    @property
+    def csettings(self):
+        return self._character.options.dict()
+
+    @property
+    def description(self):
+        return self._character.description
+
+    @property
+    def image(self):
+        return self._character.image
+
+    @property
+    def id(self):
+        if not self._in_combat:
+            return None
+        return super().id
+
+    @property
+    def note(self):
+        if not self._in_combat:
+            return None
+        return super().note
+
+    @property
+    def controller(self):
+        if not self._in_combat:
+            return None
+        return super().controller
+
+    @property
+    def group(self):
+        if not self._in_combat:
+            return None
+        return super().group
+
+    @property
+    def is_hidden(self):
+        if not self._in_combat:
+            return False
+        return super().is_hidden
+
+    @cached_property
+    def effects(self):
+        if not self._in_combat:
+            return []
+        return super().effects
+
+    def get_effect(self, name: str, strict: bool = False):
+        if not self._in_combat:
+            return None
+        return super().get_effect(name, strict)
+
+
+class AutomationSpellbook:
+    def __init__(self, spellbook):
+        self._spellbook = spellbook
+        self._spells = None
+
+    @property
+    def dc(self):
+        return self._spellbook.dc
+
+    @property
+    def sab(self):
+        return self._spellbook.sab
+
+    @property
+    def caster_level(self):
+        return self._spellbook.caster_level
+
+    @property
+    def spell_mod(self):
+        return self._spellbook.spell_mod
+
+    @property
+    def spells(self):
+        if self._spells is None:
+            self._spells = [AliasSpellbookSpell(spell) for spell in self._spellbook.spells]
+        return self._spells
+
+    @property
+    def pact_slot_level(self):
+        return self._spellbook.pact_slot_level
+
+    @property
+    def num_pact_slots(self):
+        return self._spellbook.num_pact_slots
+
+    @property
+    def max_pact_slots(self):
+        return self._spellbook.max_pact_slots
+
+    def find(self, spell_name: str):
+        if self._spells is None:
+            self._spells = [AliasSpellbookSpell(spell) for spell in self._spellbook.spells]
+        return [spell for spell in self._spells if spell_name.lower() == spell.name.lower()]
+
+    def slots_str(self, level):
+        return self._spellbook.slots_str(int(level))
+
+    def get_max_slots(self, level):
+        return self._spellbook.get_max_slots(int(level))
+
+    def get_slots(self, level):
+        return self._spellbook.get_slots(int(level))
+
+    def remaining_casts_of(self, spell, level):
+        the_spell = _SpellProxy(str(spell), int(level))
+        return self._spellbook.remaining_casts_of(the_spell, int(level))
+
+    def can_cast(self, spell, level):
+        the_spell = _SpellProxy(str(spell), int(level))
+        return self._spellbook.can_cast(the_spell, int(level))
+
+    def __contains__(self, item):
+        return str(item) in self._spellbook
+
+
+class AutomationGroup:
+    def __init__(self, group):
+        self._group = group
+        self.combatants = [wrap_statblock(combatant) for combatant in self._group.get_combatants()]
+        self.init = self._group.init
+
+    @property
+    def name(self):
+        return self._group.name
+
+    @property
+    def id(self):
+        return self._group.id
+
+    def get_combatant(self, name, strict=None):
+        name = str(name)
+        combatant = None
+        if strict is not False:
+            combatant = next((c for c in self.combatants if name.lower() == c.name.lower()), None)
+        if not combatant and not strict:
+            combatant = next((c for c in self.combatants if name.lower() in c.name.lower()), None)
+        return combatant
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} combatants={self.combatants!r}>"
+
+
+class AutomationCombat:
+    def __init__(self, combat):
+        self._combat = combat
+        self.combatants = [wrap_statblock(combatant) for combatant in combat.get_combatants()]
+        self.groups = [wrap_statblock(group) for group in combat.get_groups()]
+        self.round_num = self._combat.round_num
+        self.turn_num = self._combat.turn_num
+        current = self._combat.current_combatant
+        self.current = wrap_statblock(current) if current else None
+        self.name = self._combat.options.name
+
+    def get_combatant(self, name, strict=None):
+        combatant = self._combat.get_combatant(str(name), strict)
+        return wrap_statblock(combatant) if combatant else None
+
+    def get_group(self, name, strict=None):
+        group = self._combat.get_group(str(name), strict)
+        return wrap_statblock(group) if group else None
+
+    def get_metadata(self, key: str, default=None) -> str:
+        return self._combat.metadata.get(str(key), default)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}>"
+
+
+class AutomationEffect:
+    def __init__(self, effect):
+        self._effect = effect
+        self.name = self._effect.name
+        self.duration = self._effect.duration
+        self.remaining = self._effect.remaining
+        self.effect = self._effect.effects.to_dict()
+        self.attacks = [interaction.to_dict() for interaction in self._effect.attacks]
+        self.buttons = [interaction.to_dict() for interaction in self._effect.buttons]
+        self.conc = self._effect.concentration
+        self.desc = self._effect.desc
+        self.ticks_on_end = self._effect.end_on_turn_end
+        self.combatant_name = self._effect.combatant.name if self._effect.combatant is not None else None
+        self._parent = None
+        self._children = None
+
+    @property
+    def parent(self):
+        if self._parent is None:
+            the_parent = self._effect.parent
+            if the_parent is not None:
+                self._parent = AutomationEffect(self._effect.get_parent_effect())
+        return self._parent
+
+    @property
+    def children(self):
+        if self._children is None:
+            self._children = [AutomationEffect(effect) for effect in self._effect.get_children_effects()]
+        return self._children
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} name={self.name!r} duration={self.duration!r} remaining={self.remaining!r}>"
+
+    def __eq__(self, other):
+        return isinstance(other, AutomationEffect) and self._effect is other._effect
+
+
+class _SpellProxy:
+    def __init__(self, name, level):
+        self.name = name
+        self.level = level

--- a/aliasing/api/combat.py
+++ b/aliasing/api/combat.py
@@ -3,12 +3,13 @@ from typing import Optional, TYPE_CHECKING
 from d20 import roll
 
 import cogs5e.initiative as init
-from aliasing.api.functions import SimpleRollResult
+from aliasing.api.roll import SimpleRollResult
 from aliasing.api.statblock import AliasStatBlock
 from cogs5e.models.errors import InvalidSaveType
-from cogs5e.models.automation.utils import parse_save_bonuses
 from cogs5e.models.sheet.statblock import StatBlock
 from utils.argparser import ParsedArguments
+from cogs5e.models.automation.saveutils import parse_save_bonuses
+
 from . import validators
 
 if TYPE_CHECKING:

--- a/aliasing/api/functions.py
+++ b/aliasing/api/functions.py
@@ -10,52 +10,15 @@ import disnake.ext.commands
 import disnake.utils
 import draconic
 
-from cogs5e.utils.gameutils import parse_coin_args
 from utils import config
-from utils.dice import RerollableStringifier
 from .context import AliasAuthor, AliasChannel, AliasGuild
+from .roll import SimpleRollResult
 from ..errors import AliasException
 from ..utils import ExecutionScope
+from cogs5e.utils.gameutils import parse_coin_args
 from draconic.types import approx_len_of
 
 MAX_ITER_LENGTH = 10000
-
-
-# vroll(), roll()
-class SimpleRollResult:
-    def __init__(self, result):
-        """
-        :type result: d20.RollResult
-        """
-        self.dice = d20.MarkdownStringifier().stringify(result.expr.roll)
-        self.total = result.total
-        self.full = str(result)
-        self.result = result
-        self.raw = result.expr
-        self._roll = result
-
-    def __str__(self):
-        """
-        Equivalent to ``result.full``.
-        """
-        return self.full
-
-    def consolidated(self):
-        """
-        Gets the most simplified version of the roll string. Consolidates totals and damage types together.
-
-        Note that this modifies the result expression in place!
-
-        >>> result = vroll("3d6[fire]+1d4[cold]")
-        >>> str(result)
-        '3d6 (3, 3, 2) [fire] + 1d4 (2) [cold] = `10`'
-        >>> result.consolidated()
-        '8 [fire] + 2 [cold]'
-
-        :rtype: str
-        """
-        d20.utils.simplify_expr(self._roll.expr, ambig_inherit="left")
-        return RerollableStringifier().stringify(self._roll.expr.roll)
 
 
 def vroll(dice, multiply=1, add=0):
@@ -264,6 +227,7 @@ def parse_coins(args: str, include_total: bool = True) -> dict:
     :return: A dict of the coin changes, e.g. ``{"pp":0, "gp":1, "ep":0, "sp":-2, "cp":3, "total": 0.83}``
     :rtype: dict
     """
+
     coin_args = parse_coin_args(args)
     parsed = {
         "pp": coin_args.pp,
@@ -272,7 +236,6 @@ def parse_coins(args: str, include_total: bool = True) -> dict:
         "sp": coin_args.sp,
         "cp": coin_args.cp,
     }
-
     if include_total:
         parsed.update({"total": coin_args.total})
     return parsed

--- a/aliasing/api/roll.py
+++ b/aliasing/api/roll.py
@@ -1,0 +1,39 @@
+import d20
+
+from utils.dice import RerollableStringifier
+
+
+class SimpleRollResult:
+    def __init__(self, result):
+        """
+        :type result: d20.RollResult
+        """
+        self.dice = d20.MarkdownStringifier().stringify(result.expr.roll)
+        self.total = result.total
+        self.full = str(result)
+        self.result = result
+        self.raw = result.expr
+        self._roll = result
+
+    def __str__(self):
+        """
+        Equivalent to ``result.full``.
+        """
+        return self.full
+
+    def consolidated(self):
+        """
+        Gets the most simplified version of the roll string. Consolidates totals and damage types together.
+
+        Note that this modifies the result expression in place!
+
+        >>> result = vroll("3d6[fire]+1d4[cold]")
+        >>> str(result)
+        '3d6 (3, 3, 2) [fire] + 1d4 (2) [cold] = `10`'
+        >>> result.consolidated()
+        '8 [fire] + 2 [cold]'
+
+        :rtype: str
+        """
+        d20.utils.simplify_expr(self._roll.expr, ambig_inherit="left")
+        return RerollableStringifier().stringify(self._roll.expr.roll)

--- a/aliasing/evaluators.py
+++ b/aliasing/evaluators.py
@@ -15,8 +15,8 @@ import d20
 import draconic
 import json.scanner
 import yaml
-from yaml import composer, parser, scanner
 
+import aliasing.api.automation as automation_api
 import aliasing.api.character as character_api
 import aliasing.api.combat as combat_api
 from aliasing import helpers
@@ -516,22 +516,27 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
                 data.update(value)
 
         DraconicConstructor.add_constructor(
-            "tag:yaml.org,2002:null", yaml.constructor.SafeConstructor.construct_yaml_null
+            "tag:yaml.org,2002:null",
+            yaml.constructor.SafeConstructor.construct_yaml_null,
         )
         DraconicConstructor.add_constructor(
-            "tag:yaml.org,2002:bool", yaml.constructor.SafeConstructor.construct_yaml_bool
+            "tag:yaml.org,2002:bool",
+            yaml.constructor.SafeConstructor.construct_yaml_bool,
         )
         DraconicConstructor.add_constructor(
             "tag:yaml.org,2002:int", yaml.constructor.SafeConstructor.construct_yaml_int
         )
         DraconicConstructor.add_constructor(
-            "tag:yaml.org,2002:float", yaml.constructor.SafeConstructor.construct_yaml_float
+            "tag:yaml.org,2002:float",
+            yaml.constructor.SafeConstructor.construct_yaml_float,
         )
         DraconicConstructor.add_constructor(
-            "tag:yaml.org,2002:omap", yaml.constructor.SafeConstructor.construct_yaml_omap
+            "tag:yaml.org,2002:omap",
+            yaml.constructor.SafeConstructor.construct_yaml_omap,
         )
         DraconicConstructor.add_constructor(
-            "tag:yaml.org,2002:pairs", yaml.constructor.SafeConstructor.construct_yaml_pairs
+            "tag:yaml.org,2002:pairs",
+            yaml.constructor.SafeConstructor.construct_yaml_pairs,
         )
         DraconicConstructor.add_constructor("tag:yaml.org,2002:set", DraconicConstructor.construct_yaml_set)
         DraconicConstructor.add_constructor("tag:yaml.org,2002:str", DraconicConstructor.construct_yaml_str)
@@ -569,7 +574,12 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         Serializes an object to a YAML string. See `yaml.safe_dump <https://pyyaml.org/wiki/PyYAMLDocumentation>`_.
         """
         return yaml.dump(
-            obj, Dumper=self._yaml_dumper, default_flow_style=False, line_break=True, indent=indent, sort_keys=False
+            obj,
+            Dumper=self._yaml_dumper,
+            default_flow_style=False,
+            line_break=True,
+            indent=indent,
+            sort_keys=False,
         )
 
     # ==== json ====
@@ -779,7 +789,10 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         pass
 
     async def transformed_str_async(
-        self, string, execution_scope: ExecutionScope = ExecutionScope.UNKNOWN, invoking_object: _CodeInvokerT = None
+        self,
+        string,
+        execution_scope: ExecutionScope = ExecutionScope.UNKNOWN,
+        invoking_object: _CodeInvokerT = None,
     ):
         """Async convenience method around :meth:`ScriptingEvaluator.transformed_str`."""
         return await asyncio.get_event_loop().run_in_executor(
@@ -787,7 +800,10 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         )
 
     def transformed_str(
-        self, string, execution_scope: ExecutionScope = ExecutionScope.UNKNOWN, invoking_object: _CodeInvokerT = None
+        self,
+        string,
+        execution_scope: ExecutionScope = ExecutionScope.UNKNOWN,
+        invoking_object: _CodeInvokerT = None,
     ):
         """
         Parses a scripting string (evaluating text in {{}}). The caller should pass the execution scope and invoking
@@ -835,18 +851,72 @@ class ScriptingEvaluator(draconic.DraconicInterpreter):
         return output
 
 
-class AutomationEvaluator(MathEvaluator):
+class AutomationEvaluator(draconic.DraconicInterpreter):
+    """Draconic evaluator for automation with a narrow, read-only helper surface."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.builtins.update(
+            combat=self.combat,
+        )
+
+        self._roller = d20.Roller(context=PersistentRollContext(max_rolls=1_000, max_total_rolls=10_000))
+        self.builtins.update(vroll=self._limited_vroll, roll=self._limited_roll)
+
+        self._automation_caster = None
+        self._automation_combat = None
+        self._automation_cache = {}
+
     @classmethod
-    def with_caster(cls, caster):
+    def with_caster(cls, caster, spell_override=None):
         names = caster.get_scope_locals()
-        builtins = {**names, **DEFAULT_BUILTINS}
-        return cls(builtins=builtins)
+        if spell_override is not None:
+            names["spell"] = spell_override
+
+        inst = cls(builtins={**names, **DEFAULT_BUILTINS})
+        inst.set_automation_runtime(caster, getattr(caster, "combat", None))
+
+        try:
+            inst.builtins["caster"] = automation_api.wrap_statblock(caster)
+        except TypeError:
+            pass
+
+        return inst
+
+    @classmethod
+    def with_character(cls, character, spell_override=None):
+        return cls.with_caster(character, spell_override=spell_override)
+
+    def set_automation_runtime(self, caster, combat=None):
+        self._automation_caster = caster
+        self._automation_combat = combat
+        self._automation_cache.clear()
+        return self
+
+    def combat(self):
+        if self._automation_combat is None:
+            return None
+        if "combat" not in self._automation_cache:
+            self._automation_cache["combat"] = automation_api.AutomationCombat(self._automation_combat)
+        return self._automation_cache["combat"]
+
+    # ==== roll limiters ====
+    def _limited_vroll(self, dice, multiply=1, add=0):
+        return _vroll(str(dice), multiply, add, roller=self._roller)
+
+    def _limited_roll(self, dice):
+        return _roll(str(dice), roller=self._roller)
+
+    def _preflight(self):
+        """We don't want limits to reset."""
+        pass
 
     def transformed_str(self, string, extra_names=None):
         """Parses a spell-formatted string (evaluating {{}} and replacing {} with rollstrings)."""
-        original_names = None
+        original_builtins = None
         if extra_names:
-            original_names = self.builtins.copy()
+            original_builtins = self.builtins.copy()
             self.builtins.update(extra_names)
 
         def evalrepl(match):
@@ -856,7 +926,7 @@ class AutomationEvaluator(MathEvaluator):
                 elif match.group("roll"):  # {}
                     try:
                         evalresult = self.eval(match.group("roll").strip())
-                    except:
+                    except Exception:
                         evalresult = match.group(0)
                 else:
                     evalresult = None
@@ -865,10 +935,10 @@ class AutomationEvaluator(MathEvaluator):
 
             return str(evalresult) if evalresult is not None else ""
 
-        output = re.sub(SCRIPTING_RE, evalrepl, string)  # evaluate
+        output = re.sub(SCRIPTING_RE, evalrepl, string)
 
-        if original_names:
-            self.builtins = original_names
+        if original_builtins is not None:
+            self.builtins = original_builtins
 
         return output
 

--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -4,7 +4,6 @@ from typing import Callable, List, Optional, TYPE_CHECKING, TypeVar
 import disnake
 
 import aliasing.evaluators
-import aliasing.api.statblock
 import cogs5e.models.character
 from cogs5e.models.sheet.attack import AttackList
 from cogs5e.models.sheet.base import BaseStats, Levels, Saves, Skill, Skills
@@ -475,7 +474,6 @@ class Combatant(BaseCombatant, StatBlock):
         :returns str - the string with annotations evaluated
         """
         evaluator = aliasing.evaluators.AutomationEvaluator.with_caster(self)
-        evaluator.builtins["caster"] = aliasing.api.statblock.AliasStatBlock(self)
 
         try:
             return evaluator.transformed_str(varstr)

--- a/cogs5e/models/automation/__init__.py
+++ b/cogs5e/models/automation/__init__.py
@@ -2,7 +2,7 @@ from typing import Optional, TYPE_CHECKING, Union
 
 import disnake.utils
 
-import aliasing.api.statblock
+import aliasing.api.automation
 import aliasing.evaluators
 from utils.enums import CritDamageType
 from utils.functions import get_guild_member
@@ -137,7 +137,7 @@ class Automation:
         if not self.effects:
             return "No effects."
         evaluator = aliasing.evaluators.DisplayOnlyAutomationEvaluator.with_caster(caster)
-        evaluator.builtins["caster"] = aliasing.api.statblock.AliasStatBlock(caster)
+        evaluator.builtins["caster"] = aliasing.api.automation.wrap_statblock(caster)
         inner = Effect.build_child_str(self.effects, caster, evaluator)
         if not inner:
             inner = ", ".join(e.type for e in self.effects)

--- a/cogs5e/models/automation/effects/castspell.py
+++ b/cogs5e/models/automation/effects/castspell.py
@@ -1,4 +1,4 @@
-import aliasing.api.combat
+import aliasing.api.automation
 import gamedata
 import gamedata.lookuputils
 from cogs5e.models.errors import RequiresLicense, InvalidArgument
@@ -81,7 +81,7 @@ class CastSpell(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.automation.AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an IEffectMetaVar "
                         f"(got `{type(parent_ref).__name__}`)."

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import disnake
 
-import aliasing.api.combat
+import aliasing.api.automation
 from cogs5e import initiative as init
 from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.resistance import Resistance
@@ -123,7 +123,7 @@ class LegacyIEffect(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.automation.AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an IEffectMetaVar "
                         f"(got `{type(parent_ref).__name__}`)."
@@ -328,19 +328,19 @@ class IEffect(Effect):
             # parenting
             explicit_parent = None
             if self.parent is not None and (parent_ref := autoctx.metavars.get(self.parent, None)) is not None:
-                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.combat.SimpleEffect)):
+                if not isinstance(parent_ref, (IEffectMetaVar, aliasing.api.automation.AutomationEffect)):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an initiative effect "
-                        f"(expected IEffectMetaVar or SimpleEffect, got `{type(parent_ref).__name__}`)."
+                        f"(expected IEffectMetaVar or AutomationEffect, got `{type(parent_ref).__name__}`)."
                     )
                 # noinspection PyProtectedMember
                 explicit_parent = parent_ref._effect
             # explicit support for parenting to the parent of this ieffect's parent
             elif self.parent == "ieffect.parent" and (parent_ref := autoctx.metavars.get("ieffect", None)) is not None:
-                if not isinstance(parent_ref, aliasing.api.combat.SimpleEffect):
+                if not isinstance(parent_ref, aliasing.api.automation.AutomationEffect):
                     raise InvalidArgument(
                         f"Could not set IEffect parent: The variable `{self.parent}` is not an initiative effect "
-                        f"(expected SimpleEffect, got `{type(parent_ref).__name__}`)."
+                        f"(expected AutomationEffect, got `{type(parent_ref).__name__}`)."
                     )
 
                 # parent_ref.parent is None in data tests

--- a/cogs5e/models/automation/effects/save.py
+++ b/cogs5e/models/automation/effects/save.py
@@ -6,7 +6,8 @@ from utils.functions import maybe_mod, reconcile_adv, verbose_stat
 from . import Effect
 from ..errors import AutomationException, NoSpellDC, TargetException
 from ..results import SaveResult
-from ..utils import stringify_intexpr, parse_save_bonuses
+from ..utils import stringify_intexpr
+from ..saveutils import parse_save_bonuses
 
 
 class Save(Effect):

--- a/cogs5e/models/automation/effects/target.py
+++ b/cogs5e/models/automation/effects/target.py
@@ -60,7 +60,9 @@ class Target(Effect):
 
         # restore the previous target
         autoctx.target = previous_target
-        autoctx.metavars["target"] = utils.maybe_alias_statblock(previous_target)  # #1335
+        autoctx.metavars["target"] = utils.maybe_automation_statblock(
+            previous_target.target if previous_target else None
+        )
 
         return results.TargetResult(iteration_results)
 
@@ -143,7 +145,7 @@ class Target(Effect):
     def run_effects(self, autoctx, target, target_index=0, original_target_index=None) -> list[results.TargetIteration]:
         # set up autoctx and metavars
         autoctx.target = AutomationTarget(autoctx, target)
-        autoctx.metavars["target"] = utils.maybe_alias_statblock(target)  # #1335
+        autoctx.metavars["target"] = utils.maybe_automation_statblock(target)  # #1335
         autoctx.metavars["targetIndex"] = target_index  # #1711
         autoctx.metavars["targetNumber"] = target_index + 1
 

--- a/cogs5e/models/automation/runtime.py
+++ b/cogs5e/models/automation/runtime.py
@@ -1,16 +1,18 @@
 from functools import cached_property
+import logging
 from typing import List, Optional, TYPE_CHECKING, Union
 
-import aliasing.api.combat
-import aliasing.api.statblock
+import aliasing.api.automation
 import aliasing.evaluators
 import cogs5e.initiative.combatant as init
 from cogs5e.models import character as character_api, embeds
 from utils.enums import AdvantageType, CritDamageType
 from .errors import AutomationEvaluationException, AutomationException, InvalidIntExpression
-from .utils import maybe_alias_statblock, parse_save_bonuses
+from .utils import maybe_automation_statblock
+from .saveutils import parse_save_bonuses
 
 __all__ = ("AutomationContext", "AutomationTarget")
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     import disnake
@@ -55,10 +57,11 @@ class AutomationContext:
         # runtime internals
         self.caster_needs_commit = False
         self.evaluator = aliasing.evaluators.AutomationEvaluator.with_caster(caster)
+        self.evaluator.set_automation_runtime(caster, combat)
         self.metavars = {
             # caster, targets as default (#1335)
-            "caster": aliasing.api.statblock.AliasStatBlock(caster),
-            "targets": [maybe_alias_statblock(t) for t in targets],
+            "caster": aliasing.api.automation.wrap_statblock(caster),
+            "targets": [maybe_automation_statblock(t) for t in targets],
             "choice": self.args.last("choice", original_choice).lower(),
         }
 
@@ -78,7 +81,7 @@ class AutomationContext:
         # InitiativeEffect utils
         self.ieffect = ieffect
         if ieffect is not None:
-            self.metavars["ieffect"] = aliasing.api.combat.SimpleEffect(ieffect)
+            self.metavars["ieffect"] = aliasing.api.automation.AutomationEffect(ieffect)
         self.from_button = from_button
         self.allow_caster_ieffects = allow_caster_ieffects
         self.allow_target_ieffects = allow_target_ieffects

--- a/cogs5e/models/automation/saveutils.py
+++ b/cogs5e/models/automation/saveutils.py
@@ -1,0 +1,28 @@
+from utils.constants import SAVE_BONUS_PATTERN, normalize_save_bonus_token
+
+
+def parse_save_bonuses(save_type: str, save_bonuses: list[str]) -> list[str]:
+    """
+    Parse a save bonus string.
+    """
+    out = []
+    for save_bonus_combo in save_bonuses:
+        current_out = []
+        for match_text in SAVE_BONUS_PATTERN.split(save_bonus_combo):
+            if not match_text:
+                continue
+            save_bonus = normalize_save_bonus_token(match_text)
+            if not save_bonus:
+                continue
+            if "|" not in save_bonus:
+                out.append(save_bonus)
+                continue
+            save_bonus_dice, bonus_save_type = save_bonus.split("|", 1)
+            bonus_save_type = bonus_save_type[:3]
+
+            if bonus_save_type == save_type:
+                current_out.append(save_bonus_dice)
+        if current_out:
+            out.append("+".join(current_out))
+
+    return out

--- a/cogs5e/models/automation/utils.py
+++ b/cogs5e/models/automation/utils.py
@@ -5,19 +5,15 @@ import d20
 import draconic
 from d20.utils import TreeType
 
-import aliasing.api.statblock
+import aliasing.api.automation
 from cogs5e.models.sheet.statblock import StatBlock
-from utils.constants import SAVE_BONUS_PATTERN, normalize_save_bonus_token
 
 
-def maybe_alias_statblock(target):
-    """Returns the AliasStatBlock for the target if applicable."""
+def maybe_automation_statblock(target):
+    """Returns an automation wrapper for the target if applicable."""
     if not isinstance(target, (StatBlock, str, type(None))):
         raise ValueError("target must be a statblock, str, or None")
-    if isinstance(target, StatBlock):
-        return aliasing.api.statblock.AliasStatBlock(target)
-
-    return aliasing.api.statblock.AliasStatBlock(StatBlock(name=target or "Target"))
+    return aliasing.api.automation.wrap_target(target)
 
 
 def upcast_scaled_dice(effect, autoctx, dice_ast):
@@ -181,30 +177,3 @@ def filter_dmg_bonuses(damage_str: str, bonuses: list[str]) -> list[str]:
     """Filter bonuses by type: 'heal' for healing rolls, else for damage rolls."""
     is_healing = damage_str.lstrip().startswith("-")
     return [b for b in bonuses if is_healing == ("heal" in b.lower())]
-
-
-def parse_save_bonuses(save_type: str, save_bonuses: list[str]) -> list[str]:
-    """
-    Parse a save bonus string.
-    """
-    out = []
-    for save_bonus_combo in save_bonuses:
-        current_out = []
-        for match_text in SAVE_BONUS_PATTERN.split(save_bonus_combo):
-            if not match_text:
-                continue
-            save_bonus = normalize_save_bonus_token(match_text)
-            if not save_bonus:
-                continue
-            if "|" not in save_bonus:
-                out.append(save_bonus)
-                continue
-            save_bonus_dice, bonus_save_type = save_bonus.split("|", 1)
-            bonus_save_type = bonus_save_type[:3]
-
-            if bonus_save_type == save_type:
-                current_out.append(save_bonus_dice)
-        if current_out:
-            out.append("+".join(current_out))
-
-    return out

--- a/cogs5e/models/character.py
+++ b/cogs5e/models/character.py
@@ -5,7 +5,6 @@ import cachetools
 from disnake.ext.commands import NoPrivateMessage
 
 import aliasing.evaluators
-import aliasing.api.statblock
 from cogs5e.models.ddbsync import DDBSheetSync
 from cogs5e.models.dicecloud.integration import DicecloudIntegration
 from cogs5e.models.embeds import EmbedWithCharacter
@@ -345,7 +344,6 @@ class Character(StatBlock):
         :returns str - the string with annotations evaluated
         """
         evaluator = aliasing.evaluators.AutomationEvaluator.with_character(self)
-        evaluator.builtins["caster"] = aliasing.api.statblock.AliasStatBlock(self)
 
         try:
             return evaluator.transformed_str(varstr)

--- a/cogs5e/utils/checkutils.py
+++ b/cogs5e/utils/checkutils.py
@@ -8,7 +8,7 @@ from cogs5e.initiative.utils import ieffect_handler
 from cogs5e.models import embeds
 from cogs5e.models.errors import InvalidArgument
 from cogs5e.models.sheet.base import Skill
-from cogs5e.models.automation.utils import parse_save_bonuses
+from cogs5e.models.automation.saveutils import parse_save_bonuses
 from utils.constants import SKILL_MAP, STAT_ABBREVIATIONS, STAT_NAMES
 from utils.functions import a_or_an, camel_to_title, maybe_http_url, verbose_stat
 

--- a/ddb/client.py
+++ b/ddb/client.py
@@ -34,7 +34,7 @@ class BeyondClientBase:  # for development - assumes no entitlements
     async def get_accessible_entities(self, ctx, user_id, entity_type):
         return None
 
-    async def get_ddb_user(self, ctx, user_id=None):
+    async def get_ddb_user(self, ctx, user_id=None, auth_v1: bool = False):
         return None
 
     async def close(self):

--- a/docs/automation_ref.rst
+++ b/docs/automation_ref.rst
@@ -34,10 +34,11 @@ Runtime Variables
 
 All Automation runs provide the following variables:
 
-- ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The character, combatant, or monster who is running the
-  automation.
-- ``targets`` (list of :class:`~aliasing.api.statblock.AliasStatBlock`, :class:`str`, or None) A list of combatants
-  targeted by this automation (i.e. the ``-t`` argument).
+- ``caster`` (:class:`~aliasing.api.automation.AutomationCharacter`,
+  :class:`~aliasing.api.automation.AutomationCombatant`, or
+  :class:`~aliasing.api.automation.AutomationStatBlock`) The character, combatant, or monster who is running the automation.
+- ``targets`` A list of targets for this automation (i.e. the ``-t`` argument), If a target is only a name or missing, 
+  it is exposed as an :class:`~aliasing.api.automation.AutomationStatBlock` with the name set to that target or ``"Target"``.
 - ``spell_attack_bonus`` (:class:`int` or None) - The attack bonus for the spell, or the caster's default attack bonus.
 - ``spell_dc`` (:class:`int` or None) - The DC for the spell, or the caster's default DC.
 - ``spell`` (:class:`int` or None) - The casting mod for the spell, or the caster's default casting mod.
@@ -47,8 +48,484 @@ All Automation runs provide the following variables:
 Additionally, runs triggered by an initiative effect (such as automation provided in a :ref:`ButtonInteraction`) provide
 the following variables:
 
-- ``ieffect`` (:class:`~aliasing.api.combat.SimpleEffect`) The initiative effect responsible for providing the
+- ``ieffect`` (:class:`~aliasing.api.automation.AutomationEffect`) The initiative effect responsible for providing the
   automation.
+
+Automation Models
+--------------------
+
+.. py:currentmodule:: aliasing.api.automation
+
+.. function:: combat()
+
+    Returns the current combat as an :class:`~aliasing.api.automation.AutomationCombat` object, or ``None`` if the
+    automation is not running in combat.
+
+    :rtype: :class:`~aliasing.api.automation.AutomationCombat` or ``None``
+
+.. class:: AutomationStatBlock
+
+    A base class similar to AliasStatBlock.
+
+    .. attribute:: name
+
+        The creature's name.
+
+        :type: str
+
+    .. attribute:: stats
+
+        The creature's base stats.
+
+        :type: :class:`~aliasing.api.statblock.AliasBaseStats`
+
+    .. attribute:: levels
+
+        The creature's class levels.
+
+        :type: :class:`~aliasing.api.statblock.AliasLevels`
+
+    .. attribute:: attacks
+
+        The creature's attacks.
+
+        :type: :class:`~aliasing.api.statblock.AliasAttackList`
+
+    .. attribute:: skills
+
+        The creature's skills.
+
+        :type: :class:`~aliasing.api.statblock.AliasSkills`
+
+    .. attribute:: saves
+
+        The creature's saving throws.
+
+        :type: :class:`~aliasing.api.statblock.AliasSaves`
+
+    .. attribute:: resistances
+
+        The creature's damage resistances.
+
+        :type: :class:`~aliasing.api.statblock.AliasResistances`
+
+    .. attribute:: ac
+
+        The creature's armor class.
+
+        :type: int or ``None``
+
+    .. attribute:: max_hp
+
+        The creature's maximum hit points.
+
+        :type: int or ``None``
+
+    .. attribute:: hp
+
+        The creature's current hit points.
+
+        :type: int or ``None``
+
+    .. attribute:: temp_hp
+
+        The creature's temporary hit points.
+
+        :type: int
+
+    .. attribute:: spellbook
+
+        The creature's spellbook.
+
+        :type: :class:`~aliasing.api.automation.AutomationSpellbook`
+
+    .. attribute:: creature_type
+
+        The creature type, or ``None`` if unavailable.
+
+        :type: str or ``None``
+
+    .. method:: hp_str()
+
+        Returns a string describing the creature's current, max, and temp HP.
+
+        :rtype: str
+
+.. class:: AutomationCombatant
+
+    Subclass of AutomationStatBlock, represents a creature in Combat.
+
+    .. attribute:: id
+
+        The combatant ID.
+
+        :type: str
+
+    .. attribute:: note
+
+        The combatant's note field.
+
+        :type: str or ``None``
+
+    .. attribute:: controller
+
+        The controller's Discord user ID.
+
+        :type: int or ``None``
+
+    .. attribute:: group
+
+        The combat group name, or ``None`` if the combatant is not grouped.
+
+        :type: str or ``None``
+
+    .. attribute:: is_hidden
+
+        Whether the combatant is hidden/private in initiative.
+
+        :type: bool
+
+    .. attribute:: monster_name
+
+        The source monster name for monster combatants, or ``None``.
+
+        :type: str or ``None``
+
+    .. attribute:: monster_id
+
+        The source monster ID for monster combatants, or ``None``.
+
+        :type: int or ``None``
+
+    .. attribute:: effects
+
+        A list of initiative effects on the combatant.
+
+        :type: list of :class:`~aliasing.api.automation.AutomationEffect`
+
+    .. method:: get_effect(name, strict=False)
+
+        Returns the matching initiative effect, or ``None`` if no effect matches.
+
+        :rtype: :class:`~aliasing.api.automation.AutomationEffect` or ``None``
+
+.. class:: AutomationCharacter
+
+    Subclass of AutomationCombatant, representing a character in Combat.
+
+    .. attribute:: owner
+
+        The owning Discord user ID.
+
+        :type: str
+
+    .. attribute:: upstream
+
+        The upstream character sheet ID.
+
+        :type: str
+
+    .. attribute:: sheet_type
+
+        The source sheet type.
+
+        :type: str
+
+    .. attribute:: race
+
+        The character's race.
+
+        :type: str
+
+    .. attribute:: background
+
+        The character's background.
+
+        :type: str
+
+    .. attribute:: csettings
+
+        The character's CSettings as a dict.
+
+        :type: dict
+
+    .. attribute:: description
+
+        The full character description.
+
+        :type: str
+
+    .. attribute:: image
+
+        The character image URL.
+
+        :type: str
+
+    When not in initiative, fields such as ``id``, ``note``, ``controller``, 
+    and ``group`` are ``None``; ``is_hidden`` is ``False``; and ``effects`` is an empty list.
+
+.. class:: AutomationSpellbook
+
+    A read-only spellbook wrapper exposed by :attr:`~aliasing.api.automation.AutomationStatBlock.spellbook`.
+
+    .. attribute:: dc
+
+        The spell save DC.
+
+        :type: int or ``None``
+
+    .. attribute:: sab
+
+        The spell attack bonus.
+
+        :type: int or ``None``
+
+    .. attribute:: caster_level
+
+        The caster level.
+
+        :type: int
+
+    .. attribute:: spell_mod
+
+        The spellcasting modifier.
+
+        :type: int or ``None``
+
+    .. attribute:: spells
+
+        The known spells.
+
+        :type: list of :class:`~aliasing.api.statblock.AliasSpellbookSpell`
+
+    .. attribute:: pact_slot_level
+
+        The pact slot level, if any.
+
+        :type: int or ``None``
+
+    .. attribute:: num_pact_slots
+
+        The current number of pact slots.
+
+        :type: int
+
+    .. attribute:: max_pact_slots
+
+        The maximum number of pact slots.
+
+        :type: int or ``None``
+
+    .. method:: find(spell_name)
+
+        Returns spells whose names exactly match ``spell_name`` case-insensitively.
+
+        :rtype: list of :class:`~aliasing.api.statblock.AliasSpellbookSpell`
+
+    .. method:: slots_str(level)
+
+        Returns the formatted slot display for a spell level.
+
+        :rtype: str
+
+    .. method:: get_max_slots(level)
+
+        Returns the maximum slots for a spell level.
+
+        :rtype: int
+
+    .. method:: get_slots(level)
+
+        Returns the current slots for a spell level.
+
+        :rtype: int
+
+    .. method:: remaining_casts_of(spell, level)
+
+        Returns a string representing the remaining cast resources for a spell at the given level.
+
+        :rtype: str
+
+    .. method:: can_cast(spell, level)
+
+        Returns whether the spell can currently be cast at the given level.
+
+        :rtype: bool
+
+    ``spell_name in caster.spellbook`` can also be used to test whether a spell exists in the spellbook.
+
+.. class:: AutomationGroup
+
+    A group in initiative
+
+    .. attribute:: name
+
+        The group's name.
+
+        :type: str
+
+    .. attribute:: id
+
+        The group ID.
+
+        :type: str
+
+    .. attribute:: init
+
+        The group's initiative value.
+
+        :type: int
+
+    .. attribute:: combatants
+
+        The group's combatants.
+
+        :type: list of :class:`~aliasing.api.automation.AutomationCharacter` or :class:`~aliasing.api.automation.AutomationCombatant`
+
+    .. method:: get_combatant(name, strict=None)
+
+        Returns a matching combatant from the group, or ``None``.
+
+        :rtype: :class:`~aliasing.api.automation.AutomationCharacter`, :class:`~aliasing.api.automation.AutomationCombatant`, or ``None``
+
+.. class:: AutomationCombat
+
+    A representation of Combat.
+
+    .. attribute:: combatants
+
+        All combatants in combat.
+
+        :type: list of :class:`~aliasing.api.automation.AutomationCharacter` or :class:`~aliasing.api.automation.AutomationCombatant`
+
+    .. attribute:: groups
+
+        All combat groups.
+
+        :type: list of :class:`~aliasing.api.automation.AutomationGroup`
+
+    .. attribute:: round_num
+
+        The current round number.
+
+        :type: int
+
+    .. attribute:: turn_num
+
+        The current turn number.
+
+        :type: int
+
+    .. attribute:: current
+
+        The current combat turn holder.
+
+        :type: :class:`~aliasing.api.automation.AutomationGroup`, :class:`~aliasing.api.automation.AutomationCharacter`, :class:`~aliasing.api.automation.AutomationCombatant`, or ``None``
+
+    .. attribute:: name
+
+        The combat's configured name.
+
+        :type: str or ``None``
+
+    .. method:: get_combatant(name, strict=None)
+
+        Returns a matching combatant, or ``None``.
+
+        :rtype: :class:`~aliasing.api.automation.AutomationCharacter`, :class:`~aliasing.api.automation.AutomationCombatant`, or ``None``
+
+    .. method:: get_group(name, strict=None)
+
+        Returns a matching group, or ``None``.
+
+        :rtype: :class:`~aliasing.api.automation.AutomationGroup` or ``None``
+
+    .. method:: get_metadata(key, default=None)
+
+        Returns a combat metadata value.
+
+        :rtype: str
+
+.. class:: AutomationEffect
+
+    An effect in initiative.
+
+    .. attribute:: name
+
+        The effect name.
+
+        :type: str
+
+    .. attribute:: duration
+
+        The total duration.
+
+        :type: int or ``None``
+
+    .. attribute:: remaining
+
+        The remaining duration.
+
+        :type: int or ``None``
+
+    .. attribute:: effect
+
+        The effect's passive effect data as a dict.
+
+        :type: dict
+
+    .. attribute:: attacks
+
+        The effect's granted attacks as dicts.
+
+        :type: list of dict
+
+    .. attribute:: buttons
+
+        The effect's granted buttons as dicts.
+
+        :type: list of dict
+
+    .. attribute:: conc
+
+        Whether the effect requires concentration.
+
+        :type: bool
+
+    .. attribute:: desc
+
+        The effect description.
+
+        :type: str or ``None``
+
+    .. attribute:: ticks_on_end
+
+        Whether the effect ticks on turn end.
+
+        :type: bool
+
+    .. attribute:: combatant_name
+
+        The affected combatant's name, or ``None``.
+
+        :type: str or ``None``
+
+    .. attribute:: parent
+
+        The parent effect, or ``None``.
+
+        :type: :class:`~aliasing.api.automation.AutomationEffect` or ``None``
+
+    .. attribute:: children
+
+        The child effects.
+
+        :type: list of :class:`~aliasing.api.automation.AutomationEffect`
+
+Automation save results use :class:`~aliasing.api.functions.SimpleRollResult`, as documented in
+:doc:`aliasing/api`.
+
+.. py:currentmodule:: None
 
 Target
 ------
@@ -90,7 +567,9 @@ It designates what creatures to affect.
 
 **Variables**
 
-- ``target`` (:class:`~aliasing.api.statblock.AliasStatBlock`) The current target.
+- ``target`` (:class:`~aliasing.api.automation.AutomationCharacter`,
+  :class:`~aliasing.api.automation.AutomationCombatant`, or
+  :class:`~aliasing.api.automation.AutomationStatBlock`) The current target.
 - ``targetIteration`` (:class:`int`) If running multiple iterations (i.e. ``-rr``), the current iteration (1-indexed).
 - ``targetIterations`` (:class:`int`) The total number of iterations. Minimum 1, maximum 25.
 - ``targetIndex`` (:class:`int`) The index of the target in the list of targets processed by this effect
@@ -1544,7 +2023,9 @@ Hand-written custom attacks may be written in JSON or YAML and imported using th
         
         *optional* - The display text to display in the action list (such as ``!a list`` ).
 
-        ``caster`` (:class:`~aliasing.api.statblock.AliasStatBlock)` is available in this attribute.
+        ``caster`` (:class:`~aliasing.api.automation.AutomationCharacter`,
+        :class:`~aliasing.api.automation.AutomationCombatant`, or
+        :class:`~aliasing.api.automation.AutomationStatBlock`) is available in this attribute.
 
     .. attribute:: activation_type
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,11 @@ pass
 
 from cogs5e.models.character import Character  # noqa: E402
 from cogs5e.initiative import Combat  # noqa: E402
+from cogs5e.initiative.combat import CombatOptions  # noqa: E402
 from tests.discord_mock_data import *  # noqa: E4
 from tests.mocks import MockAsyncLaunchDarklyClient, MockDiscordHTTP  # noqa: E402
 from tests.monkey import add_reaction, message, on_command_error  # noqa: E402
+from tests.utils import ContextBotProxy  # noqa: E402
 
 SENTINEL = object()
 
@@ -96,6 +98,13 @@ async def avrae(dhttp, mock_ldclient):
 
 
 # ===== Character Fixture =====
+@pytest.fixture(scope="module")
+def ara():
+    filename = os.path.join(dir_path, "static", "char-ara.json")
+    with open(filename) as f:
+        return Character.from_dict(json.load(f))
+
+
 @pytest.fixture(scope="class", params=["ara", "drakro"])
 def character(request, avrae):
     """Sets up an active character in the user's context, to be used in tests. Cleans up after itself."""
@@ -116,6 +125,21 @@ def character(request, avrae):
 
 
 # ===== Init Fixture/Utils =====
+@pytest.fixture()
+def mock_combat(avrae):
+    """
+    Sets up a combat in the channel's context, to be used in tests. Cleans up after itself.
+    """
+    new_combat = Combat.new(
+        channel_id=str(TEST_CHANNEL_ID),
+        message_id=int(MESSAGE_ID),
+        dm_id=int(DEFAULT_USER_ID),
+        options=CombatOptions(),
+        ctx=ContextBotProxy(avrae),
+    )
+    yield new_combat
+
+
 @pytest.fixture(scope="class")
 async def init_fixture(avrae):
     """Ensures we clean up before and after ourselves. Init tests should be grouped in a class."""

--- a/tests/e2e/aliasing_mixed_test.py
+++ b/tests/e2e/aliasing_mixed_test.py
@@ -327,16 +327,5 @@ class TestCombatAliases:
         avrae.message("!test {{combat()}}")
         await dhttp.receive_message()
 
-    async def test_combat_me(self, avrae, dhttp):
-        avrae.message("!test {{combat().me}}")
-        await dhttp.receive_message(r".+:\s*$")  # nothing after the colon, should return None
-        # character joins
-        character = await active_character(avrae)
-        avrae.message("!init join")
-        await dhttp.drain()
-
-        avrae.message("!test {{combat().me.name}}")
-        await dhttp.receive_message(f".+: {character.name}")  # should return the character's name
-
     async def test_combat_aliases_teardown(cls, avrae, dhttp):
         await end_init(avrae, dhttp)

--- a/tests/e2e/automation_effects_test.py
+++ b/tests/e2e/automation_effects_test.py
@@ -9,7 +9,7 @@ import pytest
 from aliasing.evaluators import AutomationEvaluator
 from cogs5e.initiative.utils import InteractionMessageType, combatant_interaction_components
 from cogs5e.models import automation
-from cogs5e.models.automation.utils import parse_save_bonuses
+from cogs5e.models.automation.saveutils import parse_save_bonuses
 from cogs5e.models.sheet.statblock import StatBlock
 from gamedata.compendium import compendium
 from tests.utils import active_character, active_combat, end_init, requires_data, start_init

--- a/tests/gamedata/conftest.py
+++ b/tests/gamedata/conftest.py
@@ -4,9 +4,6 @@ import os
 
 import pytest
 
-from tests.discord_mock_data import DEFAULT_USER_ID, MESSAGE_ID, TEST_CHANNEL_ID
-from tests.utils import ContextBotProxy
-
 SIMULATION_BASE_PATH = os.getenv("TEST_SIMULATION_BASE_PATH")
 
 
@@ -87,16 +84,6 @@ def bob():
     return StatBlock("Bob", spellbook=Spellbook(dc=10, sab=2, spell_mod=0))
 
 
-@pytest.fixture(scope="module")
-def ara():
-    from cogs5e.models.character import Character
-
-    filename = os.path.join(os.path.dirname(__file__), f"../static/char-ara.json")
-    with open(filename) as f:
-        char = Character.from_dict(json.load(f))
-    return char
-
-
 # ==== automation ====
 @pytest.fixture(autouse=True, scope="session")
 def monkey_patch_effect_run():
@@ -171,22 +158,3 @@ def monkey_patch_use_spell_slot():
     UseCounter.use_spell_slot = use_spell_slot
     yield
     UseCounter.use_spell_slot = real_use_spell_slot
-
-
-# ===== mock combat =====
-@pytest.fixture()
-def mock_combat(avrae):
-    """
-    Sets up a combat in the channel's context, to be used in tests. Cleans up after itself.
-    """
-    from cogs5e.initiative.combat import Combat, CombatOptions
-
-    # noinspection PyTypeChecker
-    new_combat = Combat.new(
-        channel_id=str(TEST_CHANNEL_ID),
-        message_id=int(MESSAGE_ID),
-        dm_id=int(DEFAULT_USER_ID),
-        options=CombatOptions(),
-        ctx=ContextBotProxy(avrae),
-    )
-    yield new_combat

--- a/tests/unit/automation_evaluator_test.py
+++ b/tests/unit/automation_evaluator_test.py
@@ -1,0 +1,232 @@
+from types import SimpleNamespace
+
+import disnake
+import pytest
+from aliasing.api import automation as automation_api
+from aliasing.evaluators import AutomationEvaluator
+from cogs5e import initiative as init
+from cogs5e.initiative.combatant import Combatant, MonsterCombatant, PlayerCombatant
+from cogs5e.initiative.utils import create_combatant_id
+from cogs5e.models.automation.effects.castspell import CastSpell
+from cogs5e.models.automation.runtime import AutomationContext
+from cogs5e.models.sheet.spellcasting import Spellbook
+from cogs5e.models.sheet.statblock import StatBlock
+from tests.discord_mock_data import DEFAULT_USER_ID
+from tests.utils import ContextBotProxy
+from utils.argparser import argparse
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _create_basic_combatant(combat, avrae, name="Basic Combatant"):
+    combatant = Combatant(
+        id=create_combatant_id(),
+        name=name,
+        controller_id=int(DEFAULT_USER_ID),
+        init=1,
+        private=False,
+        ctx=ContextBotProxy(avrae),
+        combat=combat,
+    )
+    combat.add_combatant(combatant)
+    return combatant
+
+
+def _create_monster_combatant(combat, avrae, name="Monster Combatant"):
+    combatant = MonsterCombatant(
+        id=create_combatant_id(),
+        name=name,
+        controller_id=int(DEFAULT_USER_ID),
+        init=0,
+        private=False,
+        ctx=ContextBotProxy(avrae),
+        combat=combat,
+        monster_name="Training Dummy",
+        monster_id=42,
+    )
+    combat.add_combatant(combatant)
+    return combatant
+
+
+def _create_player_combatant(combat, avrae, character):
+    combatant = PlayerCombatant.from_character(
+        character,
+        ctx=ContextBotProxy(avrae),
+        combat=combat,
+        controller_id=int(DEFAULT_USER_ID),
+        init=2,
+        private=False,
+    )
+    combat.add_combatant(combatant)
+    return combatant
+
+
+async def test_wrap_statblock_returns_expected_wrapper_types(mock_combat, avrae, ara):
+    basic = _create_basic_combatant(mock_combat, avrae)
+    monster = _create_monster_combatant(mock_combat, avrae)
+    player = _create_player_combatant(mock_combat, avrae, ara)
+    plain = StatBlock("Plain", spellbook=Spellbook())
+
+    assert isinstance(automation_api.wrap_statblock(plain), automation_api.AutomationStatBlock)
+    assert isinstance(automation_api.wrap_statblock(ara), automation_api.AutomationCharacter)
+    assert isinstance(automation_api.wrap_statblock(player), automation_api.AutomationCharacter)
+    assert isinstance(automation_api.wrap_statblock(basic), automation_api.AutomationCombatant)
+    assert isinstance(automation_api.wrap_statblock(monster), automation_api.AutomationCombatant)
+
+
+async def test_standalone_character_has_inert_combat_fields(ara):
+    wrapped = automation_api.wrap_statblock(ara)
+
+    assert isinstance(wrapped, automation_api.AutomationCharacter)
+    assert wrapped.id is None
+    assert wrapped.note is None
+    assert wrapped.controller is None
+    assert wrapped.group is None
+    assert wrapped.is_hidden is False
+    assert wrapped.effects == []
+    assert wrapped.get_effect("missing") is None
+    assert wrapped.monster_name is None
+    assert wrapped.monster_id is None
+
+
+async def test_automation_context_wraps_runtime_vars_and_preserves_simple_targets(mock_combat, avrae, ara):
+    basic = _create_basic_combatant(mock_combat, avrae)
+    effect = init.InitiativeEffect.new(combat=mock_combat, combatant=basic, name="Wrapped", effect_args="")
+    autoctx = AutomationContext(
+        ctx=ContextBotProxy(avrae),
+        embed=disnake.Embed(),
+        caster=ara,
+        targets=[basic, "Named Target", None],
+        args=argparse(""),
+        combat=mock_combat,
+        ieffect=effect,
+    )
+
+    assert isinstance(autoctx.metavars["caster"], automation_api.AutomationCharacter)
+    assert isinstance(autoctx.metavars["targets"][0], automation_api.AutomationCombatant)
+    assert isinstance(autoctx.metavars["targets"][1], automation_api.AutomationStatBlock)
+    assert autoctx.metavars["targets"][1].name == "Named Target"
+    assert isinstance(autoctx.metavars["targets"][2], automation_api.AutomationStatBlock)
+    assert autoctx.metavars["targets"][2].name == "Target"
+    assert isinstance(autoctx.metavars["ieffect"], automation_api.AutomationEffect)
+
+
+async def test_wrap_target_creates_placeholder_statblocks():
+    named = automation_api.wrap_target("Named Target")
+    missing = automation_api.wrap_target(None)
+
+    assert isinstance(named, automation_api.AutomationStatBlock)
+    assert named.name == "Named Target"
+    assert isinstance(missing, automation_api.AutomationStatBlock)
+    assert missing.name == "Target"
+
+
+async def test_combat_helper_returns_wrapped_objects(mock_combat, avrae, ara):
+    basic = _create_basic_combatant(mock_combat, avrae)
+    player = _create_player_combatant(mock_combat, avrae, ara)
+    mock_combat._current_index = 0
+    autoctx = AutomationContext(
+        ctx=ContextBotProxy(avrae),
+        embed=disnake.Embed(),
+        caster=player,
+        targets=[basic],
+        args=argparse(""),
+        combat=mock_combat,
+    )
+
+    combat = autoctx.evaluator.eval("combat()")
+
+    assert isinstance(combat, automation_api.AutomationCombat)
+    looked_up = autoctx.evaluator.eval(f"combat().get_combatant({basic.name!r})")
+    assert isinstance(looked_up, automation_api.AutomationCombatant)
+    assert looked_up.name == basic.name
+
+
+async def test_wrappers_do_not_expose_mutators(mock_combat, avrae, ara):
+    basic = _create_basic_combatant(mock_combat, avrae)
+    player = _create_player_combatant(mock_combat, avrae, ara)
+    autoctx = AutomationContext(
+        ctx=ContextBotProxy(avrae),
+        embed=disnake.Embed(),
+        caster=player,
+        targets=[basic],
+        args=argparse(""),
+        combat=mock_combat,
+    )
+    wrapped_caster = autoctx.metavars["caster"]
+    wrapped_combat = autoctx.evaluator.eval("combat()")
+
+    assert not hasattr(wrapped_caster, "set_hp")
+    assert not hasattr(wrapped_caster, "modify_hp")
+    assert not hasattr(wrapped_caster.spellbook, "set_slots")
+    assert not hasattr(wrapped_combat, "set_metadata")
+    assert not hasattr(wrapped_combat, "set_round")
+
+
+async def test_runtime_vars_override_scope_locals(avrae, monkeypatch):
+    caster = StatBlock("Caster", spellbook=Spellbook(dc=13, sab=5, spell_mod=3))
+    original_get_scope_locals = caster.get_scope_locals
+    monkeypatch.setattr(
+        caster,
+        "get_scope_locals",
+        lambda: {
+            **original_get_scope_locals(),
+            "caster": "cvar caster",
+            "choice": "cvar choice",
+            "target": "cvar target",
+        },
+    )
+    autoctx = AutomationContext(
+        ctx=ContextBotProxy(avrae),
+        embed=disnake.Embed(),
+        caster=caster,
+        targets=[],
+        args=argparse("-choice Runtime"),
+        combat=None,
+        spell_override=7,
+    )
+    autoctx.metavars["target"] = "runtime target"
+
+    assert autoctx.parse_annostr("{{caster}}", is_full_expression=True) is autoctx.metavars["caster"]
+    assert autoctx.parse_annostr("{{choice}}", is_full_expression=True) == "runtime"
+    assert autoctx.parse_annostr("{{target}}", is_full_expression=True) == "runtime target"
+    assert autoctx.parse_annostr("{{spell}}", is_full_expression=True) == 7
+
+
+async def test_cast_spell_accepts_automation_effect_as_parent(mock_combat, avrae, ara, monkeypatch):
+    observed = {}
+
+    class EmptyEffect:
+        type = "empty"
+
+        def run(self, autoctx):
+            observed["spell"] = autoctx.parse_annostr("{{spell}}", is_full_expression=True)
+            return None
+
+    combatant = _create_basic_combatant(mock_combat, avrae)
+    parent_effect = init.InitiativeEffect.new(combat=mock_combat, combatant=combatant, name="Parent", effect_args="")
+    autoctx = AutomationContext(
+        ctx=ContextBotProxy(avrae),
+        embed=disnake.Embed(),
+        caster=ara,
+        targets=[],
+        args=argparse(""),
+        combat=mock_combat,
+        ieffect=parent_effect,
+    )
+    spell = SimpleNamespace(
+        level=1,
+        range="Self",
+        higherlevels=None,
+        automation=SimpleNamespace(effects=[EmptyEffect()]),
+    )
+    monkeypatch.setattr(
+        "cogs5e.models.automation.effects.castspell.gamedata.compendium.lookup_entity",
+        lambda *_: spell,
+    )
+
+    CastSpell(id=1, parent="ieffect", castingMod=8).run(autoctx)
+
+    assert autoctx.conc_effect is parent_effect
+    assert observed["spell"] == 8

--- a/tests/unit/save_bonus_parser_test.py
+++ b/tests/unit/save_bonus_parser_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from cogs5e.models.automation.utils import parse_save_bonuses
+from cogs5e.models.automation.saveutils import parse_save_bonuses
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary

- Changes the `AutomationEvaluator` to a Draconic interpreter (similar to the aliasing interpreter).
- Adds a subset of aliasing functions and data models available to Automation (focusing on read-only methods to prevent the "save our changes" issue.
  - AutomationStatblock, AutomationCharacter, etc
  - **Adds `target.get_effect`**
- Adds docs to show the new classes.

Resolves #1912 with `get_effect`
Resolves #2191 via for loop over combat combatants (`combat().current`)

### Changelog Entry

Adds extensive upgrades to the automation engine. Check the docs!

<img width="1452" height="644" alt="image" src="https://github.com/user-attachments/assets/4eacd6a2-9b0e-465f-aaad-3d9c30d74e90" />


### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [X] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [X] I have updated the documentation to reflect the changes.
