### PR TITLE
[AVR-1906] Fix: AuthException surfaces as unhandled error after roll when DDB account is unlinked 

### DIFF
--- a/dbot.py
+++ b/dbot.py
@@ -35,6 +35,7 @@ from aliasing.errors import CollectableRequiresLicenses, EvaluationError
 from aliasing.helpers import handle_alias_exception, handle_alias_required_licenses, handle_aliases
 from cogs5e.models.errors import AvraeException, RequiresLicense
 from ddb import BeyondClient, BeyondClientBase
+from ddb.errors import AuthException
 from ddb.gamelog import GameLogClient
 from gamedata.compendium import compendium
 from gamedata.lookuputils import handle_required_license
@@ -344,6 +345,9 @@ async def command_errors(ctx, error):
             return await handle_alias_required_licenses(ctx, original)
 
         elif isinstance(original, AvraeException):
+            return await ctx.send(str(original))
+
+        elif isinstance(original, AuthException):
             return await ctx.send(str(original))
 
         elif isinstance(original, d20.RollError):

--- a/ddb/client.py
+++ b/ddb/client.py
@@ -241,8 +241,8 @@ class BeyondClient(BeyondClientBase):
                     raise AuthException("Could not deserialize D&D Beyond response.")
                 token_val = data.get("token")
                 if resp.status == 200 and token_val is None:
-                    log.debug(f"Auth Service returned 200 with no token - user not linked: {data}")
-                    raise AuthException("D&D Beyond authentication failed. Please ensure your account is linked.")
+                    log.debug(f"Auth Service (v1) returned 200 with no token - user not linked: {data}")
+                    return None, None
         except aiohttp.ServerTimeoutError:
             raise AuthException("Timed out connecting to D&D Beyond. Please try again in a few minutes.")
         return data["token"], data.get("ttl")


### PR DESCRIPTION

### Summary
Fixes a noisy error shown to users after a successful roll when their Discord account is not linked to DDB but their character is in a campaign-linked channel.

The v1 auth endpoint returns `200 + null token` for unlinked users (unlike v2 which returns `401`). This caused `_fetch_token` to raise `AuthException`, which was unhandled in `dbot.py` and appended "Uh oh, that wasn't supposed to happen!" to an otherwise user-friendly error message.

### Changelog Entry
fix: gracefully handle unlinked DDB accounts in Game Log preflight

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
