### PR TITLE
fix: allow GVAR editors to be removed when not present in a server

### DIFF
--- a/cogsmisc/customization.py
+++ b/cogsmisc/customization.py
@@ -1146,7 +1146,7 @@ class Customization(commands.Cog):
         await ctx.send(f"Global variable `{name}` edited.")
 
     @globalvar.command(name="editor")
-    async def gvar_editor(self, ctx, name, user: disnake.Member = None):
+    async def gvar_editor(self, ctx, name, user: disnake.Member | disnake.User = None):
         """Toggles the editor status of a user."""
         gvar = await self.bot.mdb.gvars.find_one({"key": name})
         if gvar is None:


### PR DESCRIPTION
### Summary

Update editor type hint to allow [auto converter](https://docs.disnake.dev/en/stable/ext/commands/api/converters.html) to parse non-Guild users.

Motivation: [historical issues](https://discord.com/channels/269275778867396608/441356703263490070/1521679202653573171)

Local Testing:
<img width="894" height="268" alt="image" src="https://github.com/user-attachments/assets/201320ed-6c10-41a0-aa42-859325e0d452" />

### Changelog Entry

fix: You can now add/remove editors to GVARs who are not present on the same server as you.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
