### PR TITLE
fix(ddb): disable cookie jar to stop AWS WAF SQLi_COOKIE 403s

### DIFF
--- a/ddb/client.py
+++ b/ddb/client.py
@@ -51,7 +51,11 @@ class BeyondClient(BeyondClientBase):
     """
 
     def __init__(self, loop):
-        self.http = aiohttp.ClientSession(loop=loop)
+        # DummyCookieJar disables cookie storage/replay. DDB services authenticate via bearer
+        # token / request body, never cookies, so we don't need one. Replaying Set-Cookie values
+        # (notably the ALB stickiness cookie AWSALB, a random base64 blob) was intermittently
+        # tripping AWS WAF's AWSManagedRulesSQLiRuleSet (SQLi_COOKIE) and returning 403 Forbidden.
+        self.http = aiohttp.ClientSession(loop=loop, cookie_jar=aiohttp.DummyCookieJar())
 
         self.character = character.CharacterServiceClient(self.http)
         self.waterdeep = waterdeep.WaterdeepClient(self.http)

--- a/ddb/gamelog/client.py
+++ b/ddb/gamelog/client.py
@@ -27,7 +27,9 @@ class GameLogClient(BaseClient):
         """
         :param bot: Avrae instance
         """
-        super().__init__(aiohttp.ClientSession(loop=bot.loop))
+        # DummyCookieJar: don't store/replay Set-Cookie (e.g. ALB's AWSALB). Replayed cookies
+        # trip AWS WAF's SQLi_COOKIE rule (403). DDB auth is bearer/body, so no jar needed.
+        super().__init__(aiohttp.ClientSession(loop=bot.loop, cookie_jar=aiohttp.DummyCookieJar()))
         self.bot = bot
         self.ddb = bot.ddb  # type: ddb.BeyondClient
         self.rdb = bot.rdb


### PR DESCRIPTION
### Summary
DDB lookups (`!ddb`, `lookup`, `spell`, `cast`, `madd`, ...) were failing in production with `D&D Beyond returned an error: 403 Forbidden`, raised from `ddb/client.py` `_fetch_token` — the auth-token exchange that every entitlement call funnels through.

**Root cause:** the shared `aiohttp.ClientSession` used its default cookie jar, so it stored `Set-Cookie` values from DDB responses (notably the ALB stickiness cookie `AWSALB`, a random base64 blob) and **replayed** them on later requests. AWS WAF's `AWSManagedRulesSQLiRuleSet` is unpinned (`Version: null`), so AWS auto-updated its default signatures; the new signatures began matching that base64 cookie value under the **`SQLi_COOKIE`** sub-rule and blocking the request with a 403 HTML page **before it reached the auth service**. Random per-session cookie values explain the intermittent "was fixed, now breaking again" reports.

**Evidence (AWS WAF logs, `aws-waf-logs-dnd-beyond-api`):** 200/200 sampled blocks on `/v1|/v2/discord-token` terminated on `AWSManagedRulesSQLiRuleSet` → `SQLi_COOKIE`; the flagged cookies were `AWSALB` / `AWSALBCORS`. Bot commit deployed was unchanged across the incident (not a code regression). Onset 2026-07-24 04:45 UTC.

**Fix:** build the DDB HTTP sessions with `aiohttp.DummyCookieJar()` so cookies are never stored or replayed. DDB services authenticate via bearer token / request body, never cookies, so no jar is needed. Verified in-repo: `ddb/baseclient.py` sends `Authorization: Bearer`, `_fetch_token` sends the JWT in the JSON body — nothing depends on cookies. Applied to the main `BeyondClient` session (covers auth, character, waterdeep, scds) and the game-log client session (same latent risk).

This is the bot-side, AWS-signature-proof fix. A parallel WAF-side mitigation (override `SQLi_COOKIE` to Count / scope-down on the auth path, then pin the managed-rule version) is being pursued separately by the infra owners and is not part of this PR.

### Changelog Entry
Fixed DDB lookups returning "403 Forbidden" caused by cookie replay tripping an AWS WAF SQLi rule.

### Checklist
#### PR Type
- [ ] This PR is a code change that implements a feature request.
- [x] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
