### PR TITLE
Fix- Remove effect descriptions from ever showing in !a.

### DIFF
--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -137,7 +137,7 @@ class LegacyIEffect(Effect):
             # add
             effect_result = autoctx.target.target.add_effect(effect)
             is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
-            autoctx.queue(f"**Effect**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}")
+            autoctx.queue(f"**Effect**: {effect.get_str(description=False, parenthetical=not is_hidden)}")
             if conc_conflict := effect_result["conc_conflict"]:
                 autoctx.queue(f"**Concentration**: dropped {', '.join([e.name for e in conc_conflict])}")
 
@@ -157,7 +157,7 @@ class LegacyIEffect(Effect):
                 hidden=self.hidden,
             )
             is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
-            autoctx.queue(f"**Effect**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}")
+            autoctx.queue(f"**Effect**: {effect.get_str(description=False, parenthetical=not is_hidden)}")
 
         return IEffectResult(effect=effect, conc_conflict=conc_conflict)
 


### PR DESCRIPTION
As previous behaviour, effect description should not show in !a but this was accidentally added with the change to make effects hidable.

### Summary
As previous behaviour, effect description should not show in !a but this was accidentally added with the change to make effects hidable, making !a sometimes have very long text descriptions of effects when this is never wanted.

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
