### PR TITLE
Fix regressions with init descriptions

### DIFF
--- a/cogs5e/initiative/combatant.py
+++ b/cogs5e/initiative/combatant.py
@@ -484,13 +484,14 @@ class Combatant(BaseCombatant, StatBlock):
 
     def _get_long_effects(self, private=False, **kwargs) -> str:
         # Remove parenthetical and description from kwargs to avoid conflicts
-        kwargs.pop("parenthetical", None)
-        kwargs.pop("description", None)
+        kw_parenthetical = kwargs.pop("parenthetical", None)
+        kw_description = kwargs.pop("description", None)
 
-        return "\n".join(
-            f"* {e.get_str(description=private or not e.hidden, parenthetical=private or not e.hidden, **kwargs)}"
-            for e in self.get_effects()
-        )
+        return "\n".join(f"""* {e.get_str(
+            description=False if kw_description is False else (private or not e.hidden),
+            parenthetical=False if kw_parenthetical is False else (private or not e.hidden),
+            **kwargs,
+        )}""" for e in self.get_effects())
 
     def _get_effects_and_notes(self) -> str:
         out = []

--- a/cogs5e/models/automation/effects/ieffect.py
+++ b/cogs5e/models/automation/effects/ieffect.py
@@ -355,7 +355,7 @@ class IEffect(Effect):
             effect_result = combatant.add_effect(effect)
             is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
             autoctx.queue(
-                f"**Effect{effect_target}**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}"
+                f"**Effect{effect_target}**: {effect.get_str(description=False, parenthetical=not is_hidden)}"
             )
             if conc_conflict := effect_result["conc_conflict"]:
                 autoctx.queue(f"**Concentration{effect_target}**: dropped {', '.join([e.name for e in conc_conflict])}")
@@ -378,7 +378,7 @@ class IEffect(Effect):
             )
             is_hidden = autoctx.args.last("h", type_=bool) or effect.hidden
             autoctx.queue(
-                f"**Effect{effect_target}**: {effect.get_str(description=not is_hidden, parenthetical=not is_hidden)}"
+                f"**Effect{effect_target}**: {effect.get_str(description=False, parenthetical=not is_hidden)}"
             )
 
         return IEffectResult(effect=effect, conc_conflict=conc_conflict)


### PR DESCRIPTION
### Summary
Fixes a regression introduced with #2213 where !i status messages would not send their truncate descriptions when they are too long.
Fixes a second regression where init effect description would display in !a when they shouldn't (introduced by #2213)

### Changelog Entry
Here goes a short one line about the PR to display in the Changelog ( optional )

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [X] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
