### PR TITLE
feat(selection): enable btn selection by default

### DIFF
--- a/tests/unit/selection_systems_test.py
+++ b/tests/unit/selection_systems_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, AsyncMock, patch
 
 from gamedata.lookuputils import _handle_legacy_preference, search_entities
 from gamedata.shared import Sourced
+from utils.selection.constants import ENABLE_BUTTON_SELECTION_DEFAULT
 from utils.settings.guild import LegacyPreference, ServerSettings
 
 
@@ -165,6 +166,11 @@ class TestHandleLegacyPreference:
         with patch("gamedata.lookuputils.can_access", return_value=True):
             result = await _handle_legacy_preference(mock_ctx, [legacy_monster, modern_monster], available_ids)
             assert result == legacy_monster
+
+
+def test_button_selection_is_enabled_by_default():
+    assert ENABLE_BUTTON_SELECTION_DEFAULT is True
+    assert ServerSettings(guild_id=12345).enable_button_selection is True
 
 
 class TestMonsterPMSelectorLegacyPreference:

--- a/utils/selection/constants.py
+++ b/utils/selection/constants.py
@@ -6,7 +6,7 @@ consistency and maintainability.
 """
 
 # System Default
-ENABLE_BUTTON_SELECTION_DEFAULT = False
+ENABLE_BUTTON_SELECTION_DEFAULT = True
 
 # Timeout Values
 SELECTION_TIMEOUT = 60


### PR DESCRIPTION
### Summary
Enable button-based selection as the default for lookup results.

### Changelog Entry
Button-based lookup selection is now enabled by default.

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [x] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
